### PR TITLE
Add cut-cell stability and GKS analysis tooling

### DIFF
--- a/docs/brady2d_cpp_bridge_reference.md
+++ b/docs/brady2d_cpp_bridge_reference.md
@@ -1,0 +1,164 @@
+# Brady-Livescu 2D C++ Bridge Reference
+
+Reference for the Python → C++ closed-loop bridge added in plan 42. The bridge
+lets plan 41's analytical stability stack (layers L1–L7) validate survivors by
+running the compiled `shoccs` binary on the Brady-Livescu §4.3 two-dimensional
+varying-coefficient scalar wave test as a final layer (L8), without rebuilding
+C++ per sweep point.
+
+## Architecture
+
+```
+Python sweep
+  → brady2d_stability_score(max_layer=8)
+    → layer8_cpp_simulation(scheme, kernel, params)
+      → run_cpp_brady2d()
+        → make_brady2d_lua()        renders Lua config from template
+        → subprocess.run(shoccs …)  in a per-call tempfile.TemporaryDirectory
+        → parses logs/system.csv    returns BridgeResult
+  ← StabilityReport with layer8 = {final_linf, stable, wall_time_s, bridge_result}
+```
+
+- **No rebuild per sweep point.** The boundary-closure parameter (`alpha`,
+  `sigma`, or `epsilon`) is passed through Lua at runtime; the stencil struct
+  reads it in its constructor. A single compiled `shoccs` binary serves every
+  point of a sweep.
+- **Concurrency-safe.** Each `run_cpp_brady2d` call uses its own
+  `tempfile.TemporaryDirectory` as `cwd`, so concurrent invocations write
+  `logs/system.csv` under disjoint roots and never race on
+  `REPO_ROOT/logs/`.
+- **Isolation boundary.** Python owns optimization and parameter-space
+  sweeping; C++ is a validator. Python never links the solver, C++ never
+  reads `known_values.json`.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `lua-configs/brady_livescu_4_3.lua` | Template with `--{{N}}--`, `--{{T_FINAL}}--`, `--{{SCHEME_TABLE}}--` markers (not standalone-runnable) |
+| `lua-configs/brady_livescu_4_3_n61.lua`, `…_long.lua` | Thin standalone variants (N=61, or N=31 at t=100) |
+| `scripts/stencil_gen/stencil_gen/cpp_bridge.py` | `make_brady2d_lua`, `run_cpp_brady2d`, `BridgeResult` |
+| `scripts/stencil_gen/stencil_gen/brady2d_stability.py` | `layer8_cpp_simulation`, `brady2d_stability_score(max_layer=8)` |
+| `scripts/stencil_gen/sweeps/brady2d_sweep.py` | `brady2d` subcommand for parameter sweeps (`--validate-with-cpp` re-runs top-K at L8) |
+
+## C++ stencil families added in plan 42
+
+Each family is a uniform (non-cut-cell) first-derivative 4th-order boundary
+closure keyed on a single scalar parameter. All three live under
+`src/stencils/` and are registered in `stencil::from_lua`.
+
+| Family | Lua `scheme.type` | Parameter (Lua key, C++ struct field) | Default |
+|--------|-------------------|---------------------------------------|---------|
+| `tension_E4u_1` | `"tension_E4u"` | `sigma` (`real sigma`) | 3.0 |
+| `gaussian_E4u_1` | `"gaussian_E4u"` | `epsilon` (`real epsilon`) | 0.9 |
+| `multiquadric_E4u_1` | `"multiquadric_E4u"` | `epsilon` (`real epsilon`) | 1.0 |
+
+Construction-time solve. Each constructor takes the scalar parameter,
+builds the 10×10 augmented RBF+polynomial system (6-point tension/Gaussian/
+multiquadric kernel plus the four monomials `1, x, x^2, x^3` for `q=3`),
+runs one hand-coded Gaussian elimination with partial pivoting per boundary
+row, and caches the 5×7 = 35-entry coefficient block in `cached_coeffs`.
+`nbs_floating` then copies from the cache and applies the `1/h` scaling plus
+the `right=true` negate+reverse flip at each call site. Layout:
+
+- Rows 0..3 × cols 0..5: solved RBF+poly weights at `h=1`.
+- Rows 0..3 × col 6: zero-padded.
+- Row 4: hardcoded classical E4 centered stencil
+  `{0, 0, 1/12, -2/3, 0, 2/3, -1/12}`.
+
+The Python reference is `phs._rbf_weights_numeric`; each family ships with a
+fixture under `scripts/stencil_gen/tests/fixtures/` and a Catch2 test
+(`t-tension_E4u_1`, `t-gaussian_E4u_1`, `t-multiquadric_E4u_1`) that asserts
+match within `1e-12`.
+
+## Runtime-parameterized codegen pattern
+
+`StencilGenSpec` (`scripts/stencil_gen/stencil_gen/codegen.py`) accepts scalar
+runtime parameters via the `scalar_params: list[str]` field — companion to
+the existing `param_arrays`.
+
+```python
+spec = StencilGenSpec(
+    name="TensionE4u1",
+    scalar_params=["sigma"],  # → `real sigma;` field + `TensionE4u1(real sigma_)` ctor
+    ...
+)
+```
+
+The `StencilCodePrinter` (`printer.py::build_symbol_map`) maps
+`Symbol("sigma") → "sigma"` with no subscript, so SymPy expressions containing
+`Symbol("sigma")` print as `sigma` (not `sigma[0]`). This lets the pattern
+already used by `E4_1` for `alpha` generalize to scalar parameters without
+retouching the printer per family.
+
+Plan 42's three spline families are hand-written rather than codegen-emitted,
+because emitting a correct Gaussian elimination from SymPy adds significant
+scope. Scalar-param codegen is in place for future families that can be
+expressed in closed form (see plan 42 42.4).
+
+## Why cut-cell variants are deferred
+
+Brady-Livescu §4.3 is posed on a uniform rectangular domain, so the boundary
+closure does not depend on `psi`. The construction-time solve therefore runs
+exactly once per simulation and the coefficients are cached.
+
+Cut-cell (non-uniform-`psi`) runtime parameterization needs either (a) a
+per-cut-cell runtime solve, or (b) a precomputed coefficient cache indexed by
+`psi`. Both are strictly larger scope than plan 42 and are tracked as plan
+42.10b.
+
+## Bridge usage
+
+### Programmatic
+
+```python
+from stencil_gen.cpp_bridge import run_cpp_brady2d
+
+res = run_cpp_brady2d(
+    scheme_type="tension_E4u",
+    params={"sigma": 3.0},
+    N=31,
+    t_final=10.0,
+)
+# res.final_linf, res.stable, res.wall_time_s, res.exit_code, res.stderr
+```
+
+### Full-pipeline with L8
+
+```python
+from stencil_gen.brady2d_stability import brady2d_stability_score
+
+rep = brady2d_stability_score(
+    scheme="E4",
+    kernel="tension",
+    params={"sigma": 3.0},
+    max_layer=8,
+    layer8_N=31,
+    layer8_t_final=10.0,
+)
+# rep.overall_verdict, rep.layer8["stable"], rep.layer8["final_linf"]
+```
+
+### Sweep with empirical validation
+
+```bash
+cd scripts/stencil_gen
+uv run python -m sweeps brady2d \
+    --scheme E4 --kernel tension \
+    --param-range 2 6 20 \
+    --max-layer 3 \
+    --validate-with-cpp
+```
+
+Top 3 passing points (ranked by `layer6.transient_growth_bound` when present,
+else `layer3.max_stab_eig`) are re-run at `max_layer=8`.
+
+## Failure thresholds
+
+| Layer | Metric | Constant | Value |
+|-------|--------|----------|-------|
+| L8 | `final_linf` at `t_final` | `L8_FINAL_LINF_TOL` | 1.0 |
+| L8 | `stable` | parse of `logs/system.csv` last row | `isfinite(final_linf) and final_linf < 10.0` |
+
+`BridgeResult.final_linf = NaN` and `stable = False` on nonzero exit, timeout,
+or missing/empty CSV; the diagnostic is in `stderr` and `exit_code`.

--- a/scripts/stencil_gen/docs/bl42_reference.md
+++ b/scripts/stencil_gen/docs/bl42_reference.md
@@ -1,0 +1,180 @@
+# Brady-Livescu §4.2 Reflecting-Hyperbolic Eigenvalue Layer (L3r / BL42)
+
+## Problem statement
+
+From Brady & Livescu 2019 §4.2 (pp. 91–92): a 1D coupled hyperbolic
+system with energy-conserving reflecting boundary conditions.
+
+```
+u_t = v_x
+v_t = u_x          on [0, 1],  t in [0, 500]
+
+u(0, t) = 0         (Dirichlet, reflecting)
+v(1, t) = 0         (Dirichlet, reflecting)
+
+u(x, 0) = -(3*pi/2) * sin(3*pi*x/2)
+v(x, 0) = 0
+```
+
+Exact solution (standing-wave superposition from d'Alembert decomposition):
+
+```
+u(x, t) = -(3*pi/2) * sin(3*pi*x/2) * cos(3*pi*t/2)
+v(x, t) = -(3*pi/2) * cos(3*pi*x/2) * sin(3*pi*t/2)
+```
+
+The initial condition excites a single eigenmode (k=2, ω = 3π/2).
+
+## Why it's the cleanest boundary-closure stability test
+
+Unlike the §4.3 varying-coefficient advection problem (L7), where
+`div(c) = 1/ψ > 0` introduces physical growth that must be calibrated
+out (`L7_TOL = 5e-3`), the §4.2 system has three properties that make
+it an ideal discriminator:
+
+1. **`div(c) = 0`** — the coefficient matrix is constant and symmetric.
+2. **Energy-conserving BCs** — reflecting Dirichlet conditions satisfy
+   `⟨Lu, u⟩ = 0` in the continuous L²; no dissipation.
+3. **Purely imaginary continuous spectrum** — eigenvalues are
+   `λ_k = ±i(2k−1)π/2` for positive integer k.
+
+Any discrete `Re(λ) > tol` is therefore an unambiguous signature of
+boundary-closure instability, with no calibration needed. The tolerance
+`BL42_TOL = 1e-10` is tight and justified.
+
+## Block operator construction
+
+Semi-discrete form with a 1D differentiation matrix `D` (shape N×N):
+
+```
+dq/dt = L q,   q = [u; v],   L = [[0, D/h], [D/h, 0]]
+```
+
+where `h = L_DOMAIN / (N - 1) = 1 / (N - 1)`.
+
+After removing the Dirichlet DOFs — row/col 0 (`u` at `x = 0`) and
+row/col `2N − 1` (`v` at `x = 1`) — the reduced operator `L_red` has
+shape `(2N − 2) × (2N − 2)`.
+
+## API reference
+
+### `build_bl42_operator(D) -> scipy.sparse.csr_matrix`
+
+In `stencil_gen/brady2d_stability.py`. Builds the reduced `(2N-2) × (2N-2)`
+block operator from a 1D differentiation matrix `D` of shape `(N, N)`.
+
+- Scales `D` by `1/h` where `h = 1 / (N - 1)`.
+- Constructs `L = [[0, D/h], [D/h, 0]]` via `scipy.sparse.bmat`.
+- Removes DOFs at indices 0 and 2N−1 (Dirichlet rows/columns).
+
+### `layer_bl42_reflecting_hyperbolic(scheme, kernel, params, n_values=(21, 41, 81)) -> dict`
+
+Layer function that evaluates BL42 eigenvalue stability at multiple grid
+sizes.
+
+Returns:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `spectral_abscissa_by_n` | `dict[int, float]` | `{N: max Re(λ)}` for each grid size |
+| `max_spectral_abscissa` | `float` | Maximum over all grid sizes |
+| `purely_imaginary` | `bool` | `True` iff `max_spectral_abscissa < BL42_TOL` |
+
+### `BL42_TOL = 1e-10`
+
+Failure threshold. The continuous spectrum is exactly imaginary, so any
+positive real part above machine noise indicates instability.
+
+### Reference problem module
+
+`stencil_gen/benchmarks/brady_livescu_4_2.py` provides:
+
+| Function | Description |
+|----------|-------------|
+| `initial_u(x)` | IC: `-(3π/2) sin(3πx/2)` |
+| `initial_v(x)` | IC: zeros |
+| `exact_solution(x, t)` | Standing-wave closed form `(u, v)` |
+| `continuous_eigenvalues(k_max=20)` | `±i(2k−1)π/2` for `k = 1..k_max` |
+| `L_DOMAIN = 1.0` | Domain length constant |
+
+## Cascade position
+
+L3r runs during the L3 tier — after L3 (1D advection eigenvalue) and
+before L4 (2D local group velocity). It is a parallel 1D eigenvalue
+check on a different model problem.
+
+```
+L1 (GV error) → L2 (Kreiss) → L3 (advection eig) → L3r (BL42 eig) → L4 → L5 → L6 → L7 → L8
+```
+
+On failure:
+- `failed_layer = 3` (grouped with L3 for gate purposes).
+- `failed_reason` contains `"BL42"` to disambiguate from L3 failures.
+- A `gate_layer=3` feasibility cliff requires both L3 **and** L3r to pass.
+
+L3r runs whenever `max_layer >= 3`. It is strictly cheaper than L7
+(≤ 2N ≈ 160 dimensions at N=80, vs. (N−1)² ≈ 6400 for L7).
+
+### `StabilityReport` field
+
+```python
+layer_bl42: dict | None = None
+```
+
+The `__str__` output line:
+```
+L3r BL42 reflecting: PASS  max_re=6.0025e-14  per_n=[21:1.23e-14, 41:6.00e-14, 81:5.50e-14]
+```
+
+### Failure threshold table
+
+| Layer | Metric | Threshold | Value | Rationale |
+|-------|--------|-----------|-------|-----------|
+| L3r | `max_spectral_abscissa` | `BL42_TOL` | 1e-10 | Continuous spectrum is exactly imaginary |
+
+## Optimizer integration
+
+BL42 fields are valid optimizer objectives via the standard dotted-path
+convention:
+
+```bash
+cd scripts/stencil_gen
+uv run python -m sweeps optimize \
+    --scheme E4 --kernel tension \
+    --objective layer_bl42.max_spectral_abscissa \
+    --bounds 0.5 20 --method Nelder-Mead --max-evals 40
+```
+
+The `_FIELD_LAYER_ALIAS` mapping `"layer_bl42": 3` ensures that
+`make_objective` infers `max_layer=3` for BL42 objectives.
+
+When using `gate_layer`, note that tension kernels fail L3r at
+`gate_layer=3`. Use `--gate-layer 2` to gate only on L1-L2 while still
+computing the BL42 spectral abscissa as the optimization target.
+
+## Calibration results
+
+From `sweeps/known_values.json` under `"brady2d_calibration"`:
+
+| Family | Verdict | `max_spectral_abscissa` | `purely_imaginary` |
+|--------|---------|------------------------|--------------------|
+| E4\_classical | **pass** | 6.00e-14 | true |
+| E2\_phs\_k2 | **pass** | 4.89e-15 | true |
+| E4\_phs\_k2 | fail (L3r) | 6.30e-01 | false |
+| E4\_tension\_3 | fail (L3r) | 9.54e-01 | false |
+| E4\_gaussian\_09 | fail (L3r) | 7.00e-01 | false |
+| E4\_multiquadric\_1 | fail (L3r) | 6.48e-01 | false |
+| E2\_tension\_6 | fail (L1) | — | — |
+| E2\_gaussian\_2 | fail (L1) | — | — |
+| E2\_multiquadric\_1 | fail (L1) | — | — |
+
+Only 2 of 9 families pass BL42, compared to 6 of 9 that pass the L3
+advection eigenvalue check. This confirms BL42's value as a stricter
+discriminator: schemes that are stable for constant-coefficient
+advection can still fail on the reflecting-BC hyperbolic system.
+
+## References
+
+- Brady, P.T. and Livescu, D. (2019). "High-order, stable, and
+  conservative boundary schemes for central and compact finite
+  differences." *Computers & Fluids*, 183, pp. 84–101. §4.2, pp. 91–92.

--- a/scripts/stencil_gen/docs/brady2d_stability_reference.md
+++ b/scripts/stencil_gen/docs/brady2d_stability_reference.md
@@ -1,0 +1,303 @@
+# Brady-Livescu 2D Analytical Stability Reference
+
+> Any field documented here (e.g. `layer1.boundary_gv_err`,
+> `layer_bl42.max_spectral_abscissa`, `layer6.transient_growth_bound`) is
+> a valid element of `--objective` in `python -m sweeps optimize` and of
+> `--objectives` in `python -m sweeps pareto` (multi-objective NSGA-II;
+> see [`pareto_reference.md`](pareto_reference.md)). Layer depth and gate
+> are auto-inferred from the field's layer prefix. The same fields
+> double as the per-fidelity targets of `python -m sweeps bo`
+> (multi-fidelity BoTorch ICM-GP; see
+> [`mfbo_reference.md`](mfbo_reference.md)) — a layer index `m` is
+> mapped to its dotted field via `--objective <field>` plus
+> `--cheap-fidelities <m1> <m2> ...`.
+
+## Problem statement
+
+The benchmark is the two-dimensional varying-coefficient scalar advection
+problem from Brady & Livescu 2019 &sect;4.3 (pp. 92&ndash;94):
+
+```
+u_t + grad(psi) . grad(u) = 0    on [0, sqrt(2)]^2,  t in [0, 1000]
+
+psi(x, y) = sqrt((x + 0.25)^2 + (y + 0.25)^2)
+c_x = d(psi)/dx = (x + 0.25) / psi
+c_y = d(psi)/dy = (y + 0.25) / psi
+
+u(x, y, 0)   = sin(2*pi*psi)
+u(0, y, t)   = sin(2*pi*(psi(0, y) - t))    (inflow, Dirichlet)
+u(x, 0, t)   = sin(2*pi*(psi(x, 0) - t))    (inflow, Dirichlet)
+
+Exact: u(x, y, t) = sin(2*pi*(psi - t))
+```
+
+The radial velocity field `(c_x, c_y)` is unit-magnitude everywhere. Inflow
+enters at `x = 0` and `y = 0`; outflow exits at `x = sqrt(2)` and
+`y = sqrt(2)`.
+
+## Layered pipeline
+
+Each layer is strictly cheaper and more informative than running the full
+C++ simulation. The pipeline short-circuits on the first failure, so
+expensive layers only run for candidates that pass the cheap checks.
+
+| Layer | Metric | What it catches | Approx. cost (E4, N=81) |
+|-------|--------|-----------------|-------------------------|
+| L1 | Interior + boundary group velocity error (1D) | Dispersion-quality mismatch at boundary | sub-ms |
+| L2 | Rigorous GKS Kreiss determinant test | Boundary-closure instability (necessary **and** sufficient for the 1D reduction) | ~100 ms |
+| L3 | 1D eigenvalue `max Re(lambda)` at multiple N | Semi-discrete asymptotic stability, constant coefficient | ~30 ms |
+| L3r | BL §4.2 reflecting-hyperbolic `max Re(lambda)` | Boundary-closure instability on energy-conserving system (`div(c) = 0`, purely imaginary continuous spectrum) | ~30 ms |
+| L4 | Per-point local GV error across the 2D grid | Local dispersion error from varying `(c_x, c_y)` | ~tens ms |
+| L5 | 2D anisotropy `max angle_error` over propagation angles | Grid anisotropy interacting with the radial flow | ~100 ms |
+| L6 | Non-normality on 1D operator: spectral + numerical abscissa, Henrici departure, Kreiss constant, transient-growth bound | Transient growth from non-normal 1D spatial operator | ~seconds |
+| L7 | Sparse 2D Arnoldi `max Re(lambda)` on the full varying-coefficient operator | True 2D semi-discrete asymptotic stability | few seconds per N |
+| L8 | (Plan 42) C++ simulation via Lua bridge | Actual long-time L-infinity bound | minutes |
+
+## Failure thresholds
+
+| Layer | Metric | Threshold constant | Value | Rationale |
+|-------|--------|--------------------|-------|-----------|
+| L1 | `boundary_gv_err` | `L1_TOL` | 0.05 (5%) | Boundary dispersion error > 5% indicates poor closure quality |
+| L2 | `KreissResult.is_stable` | `sigma_tol` | 1e-8 | GKS determinant condition; `sigma_min(M(s)) < tol` indicates instability |
+| L3 | `max_stab_eig` | `STABILITY_TOL` | 1e-10 | 1D eigenvalue in right half-plane → unstable semi-discrete scheme |
+| L3r | `max_spectral_abscissa` | `BL42_TOL` | 1e-10 | BL §4.2 continuous spectrum is exactly imaginary; see [`bl42_reference.md`](bl42_reference.md) |
+| L4 | `max_local_gv_error` | `L4_TOL` | 0.1 (10%) | Looser than L1 because varying-coefficient scaling amplifies baseline error |
+| L5 | `max_aligned_error` | `L5_TOL` | 0.05 (5%) | Grid anisotropy projected onto the local propagation direction |
+| L6 | `spectral_abscissa` | `STABILITY_TOL` | 1e-10 | 1D operator eigenvalue check |
+| L6 | `transient_growth_bound` | `L6_TRANSIENT_GROWTH_TOL` | 50.0 | Kreiss constant bound `e*K > 50` indicates dangerous transient growth |
+| L7 | `max_spectral_abscissa` | `L7_TOL` | 5e-3 | 2D varying-coefficient operator; stable schemes show max Re ~ O(1e-3), unstable ~ O(0.1) |
+| L7+ | `transient_growth_bound` | `L7_TRANSIENT_GROWTH_TOL` | 50.0 | Same as L6 but on the 2D operator |
+
+## API reference
+
+### `brady2d_stability_score`
+
+Main entry point in `stencil_gen/brady2d_stability.py`.
+
+```python
+def brady2d_stability_score(
+    scheme: str,           # "E2" or "E4"
+    kernel: str,           # "classical" | "tension" | "gaussian" | "multiquadric"
+    params: dict,          # {"alpha": [...]}, {"sigma": float}, or {"epsilon": float}
+    *,
+    max_layer: int = 7,    # highest layer to run (1-8; L8 invokes the C++ bridge)
+    short_circuit: bool = True,  # stop at first failure
+    layer8_N: int = 31,          # grid resolution forwarded to L8
+    layer8_t_final: float = 10.0,  # physical end time forwarded to L8
+) -> StabilityReport
+```
+
+### `StabilityReport`
+
+Dataclass returned by `brady2d_stability_score`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `layer1` .. `layer7` | `dict \| None` | Per-layer metrics (populated when that layer runs) |
+| `layer_bl42` | `dict \| None` | L3r BL §4.2 reflecting-hyperbolic eigenvalue result |
+| `layer8` | `dict \| None` | L8 C++ simulation result (populated when `max_layer >= 8`) |
+| `kreiss` | `KreissResult \| None` | Alias for `layer2` (the Kreiss determinant result) |
+| `non_normality` | `NonNormalityReport \| None` | Populated by L6 (1D) or L7 (2D) |
+| `overall_verdict` | `"pass" \| "fail" \| "unknown"` | Final verdict |
+| `failed_layer` | `int \| None` | First layer that failed |
+| `failed_reason` | `str` | Human-readable failure description |
+| `compute_time` | `float` | Total wall-clock seconds |
+
+The `__str__` method produces a compact per-layer summary table.
+
+### `kreiss_stability_check`
+
+Rigorous GKS determinant test in `stencil_gen/gks_kreiss.py`. Implements
+Trefethen 1983 (pp. 206-207).
+
+```python
+def kreiss_stability_check(
+    interior_weights: np.ndarray,
+    interior_offsets: np.ndarray,
+    boundary_rows: list[BoundaryRow],
+    *,
+    s_grid_params: dict | None = None,
+    sigma_tol: float = 1e-8,
+    refine: bool = True,
+    min_s_magnitude: float = 0.1,
+) -> KreissResult
+```
+
+`KreissResult` fields: `is_stable`, `witness_s`, `witness_sigma_min`,
+`imaginary_axis_perturbation_verdict`, `defective_kappa_detected`,
+`s_grid_shape`, `compute_time`, `sigma_min_field`, `s_grid`,
+`n_admissible_roots`.
+
+### `compute_non_normality`
+
+Non-normality diagnostics in `stencil_gen/non_normality.py`. Calibration
+bands from Trefethen & Embree 2005, ch. 14.
+
+```python
+def compute_non_normality(
+    L,                           # sparse or dense matrix
+    *,
+    small_dense_threshold: int = 900,
+    epsilon_values: tuple[float, ...] = (1e-4, 1e-3, 1e-2, 1e-1),
+    s_grid_params: dict | None = None,
+) -> NonNormalityReport
+```
+
+`NonNormalityReport` fields: `spectral_abscissa`, `numerical_abscissa`,
+`henrici_departure`, `eigenvector_condition`, `pseudospectral_abscissae`
+(dict mapping epsilon to abscissa), `kreiss_constant`,
+`transient_growth_bound` (`= e * kreiss_constant`), `n`, `compute_time`,
+`notes`.
+
+## Layer 8 — C++ simulation
+
+L8 closes the loop between the analytical stack (L1&ndash;L7) and the
+compiled C++ solver. It is the only layer that runs an actual
+time-stepping simulation, so it is gated behind `max_layer >= 8` and
+typically only invoked for candidates that have already passed the cheap
+analytical layers.
+
+### Architecture
+
+Python builds a Lua config string from the `lua-configs/brady_livescu_4_3.lua`
+template, writes it to a per-call `tempfile.TemporaryDirectory`, and invokes
+`build/src/app/shoccs` as a subprocess. The simulation writes
+`logs/system.csv` under the tempdir (so concurrent invocations do not race),
+Python parses the final `Linf` column, and a `BridgeResult` is returned.
+The mechanics are described in detail in
+`docs/brady2d_cpp_bridge_reference.md`.
+
+### Dispatch
+
+`layer8_cpp_simulation(scheme, kernel, params, *, N, t_final)` maps
+`(scheme, kernel)` to the Lua `scheme.type` string expected by `stencil::from_lua`:
+
+| `(scheme, kernel)` | Lua `scheme.type` | Passed param |
+|--------------------|-------------------|--------------|
+| `("E4", "classical")` | `"E4u"` | `alpha = {...}` (2-vector) |
+| `("E4", "tension")` | `"tension_E4u"` | `sigma` |
+| `("E4", "gaussian")` | `"gaussian_E4u"` | `epsilon` |
+| `("E4", "multiquadric")` | `"multiquadric_E4u"` | `epsilon` |
+
+E2 spline variants and cut-cell (`E4_1`, not `E4u_1`) variants are
+deferred &mdash; see `plans/42-cpp-bridge-runtime-parameterized-stencils.md`
+items 42.10a / 42.10b.
+
+### Failure thresholds
+
+| Metric | Threshold constant | Value | Rationale |
+|--------|--------------------|-------|-----------|
+| `stable` | `BridgeResult.stable` | `final_linf < 10.0` and finite | Simulation did not blow up or timeout |
+| `final_linf` | `L8_FINAL_LINF_TOL` | 1.0 | Schemes that survive L1&ndash;L7 but diverge under the full 2D varying-coefficient flow still trip this at `t_final = 10` |
+
+A layer-8 failure sets `failed_layer = 8` and `failed_reason` to one of
+`"stable=False"` or `"final_linf=<v> > L8_FINAL_LINF_TOL=1.0"`.
+
+### `BridgeResult`
+
+Returned inside `report.layer8["bridge_result"]`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `final_linf` | `float` | L&infin; at `t_final`; `nan` on failure |
+| `linf_trace` | `np.ndarray` | Per-step L&infin; history |
+| `t_trace` | `np.ndarray` | Per-step physical time |
+| `stable` | `bool` | `isfinite(final_linf) and final_linf < 10.0` |
+| `wall_time_s` | `float` | Subprocess wall time |
+| `exit_code` | `int` | `shoccs` exit status |
+| `stderr` | `str` | Captured stderr (diagnostic on failure) |
+
+### Cost and runtime knobs
+
+Default `N = 31, t_final = 10.0` runs in ~1&nbsp;second per call at E4.
+For fast integration testing, pass `layer8_N=21, layer8_t_final=1.0`
+&mdash; the full L1&ndash;L8 pipeline then completes in ~20&nbsp;seconds
+(most of it L7's 2D Arnoldi, not the C++ run itself).
+
+### Sweep integration
+
+`sweeps/brady2d_sweep.py` (subcommand `brady2d`) sweeps a parameter range
+at `max_layer <= 7`, ranks survivors, and then re-runs the top-3 at
+`max_layer = 8` when invoked with `--validate-with-cpp`:
+
+```bash
+cd scripts/stencil_gen
+uv run python -m sweeps brady2d --scheme E4 --kernel tension \
+    --param-range 2 6 20 --max-layer 6 --validate-with-cpp
+```
+
+Ranking uses `layer6.transient_growth_bound` ascending when L6 is
+present, falling back to `layer3.max_stab_eig` otherwise. The C++ build
+is compiled once up front; Lua configs are the only thing that changes
+per sweep point.
+
+## Optimization
+
+The layered pipeline also backs a scipy-based optimizer that turns the
+brute-force sweep into actual optimization (single-objective +
+feasibility cliff, random-restart multi-start, SHGO and DE for global
+coverage, and a staged cheap-inner + expensive-validator cascade). See
+[`optimization_reference.md`](optimization_reference.md) for the full
+API and CLI surface.
+
+Entry points:
+
+- `stencil_gen/optimizer.py` — `make_objective`, `run_scipy_local`,
+  `multi_start_optimize`, `run_scipy_shgo`, `run_scipy_de`,
+  `run_staged_optimize`, `OptimizeResult`, `DEFAULT_BOUNDS`.
+- `python -m sweeps optimize ...` — CLI driver that persists winners
+  under `known_values.json["brady2d_optima"]` and can round-trip an L8
+  verdict when invoked with `--validate-with-cpp`.
+- `stencil_gen/benchmarks/alpha_basin_survey.py` — multi-seed diversity
+  study for the 2D classical-alpha landscape (Brady-Livescu Table 4
+  analog).
+
+The optimizer reuses the `StabilityReport` schema documented above:
+objectives are dotted paths into the report
+(`layer1.boundary_gv_err`, `layer3.max_stab_eig`,
+`layer6.transient_growth_bound`, ...), and the feasibility cliff fires
+when `failed_layer <= gate_layer`.
+
+## CLI usage
+
+```bash
+# Score a single scheme at max_layer=6
+cd scripts/stencil_gen
+uv run python -m stencil_gen.brady2d --scheme E4 --kernel tension --sigma 3.0 --max-layer 6
+
+# Run calibration across all families
+uv run python -m stencil_gen.brady2d --run-calibration --max-layer 6
+
+# Run calibration and persist to known_values.json
+uv run python -m stencil_gen.brady2d --run-calibration --max-layer 7 --update-known-values
+```
+
+L8 has no dedicated CLI entry point. Drive it via the Python API
+(`brady2d_stability_score(..., max_layer=8, layer8_N=..., layer8_t_final=...)`)
+or through the sweep subcommand (`python -m sweeps brady2d
+--validate-with-cpp`).
+
+## Calibration results
+
+Results stored in `sweeps/known_values.json` under the `"brady2d_calibration"` key.
+Regression tests in `tests/test_phs.py::TestRegressionBrady2DCalibration` verify
+that re-running at `max_layer=3` reproduces the stored verdicts.
+
+At `max_layer=6` (2026-04-14, with L3r/BL42 enabled):
+- **Pass all layers (2/9):** E4_classical, E2_phs_k2
+- **Fail at L3r/BL42 (4/9):** E4_phs_k2, E4_tension_3, E4_gaussian_09, E4_multiquadric_1
+- **Fail at L1 (3/9):** E2_tension_6, E2_gaussian_2, E2_multiquadric_1
+
+The L3r (BL42) layer is a strict discriminator: schemes that pass L3
+(constant-coefficient advection eigenvalue) can still fail on the
+reflecting-BC hyperbolic system. See [`bl42_reference.md`](bl42_reference.md)
+for the full calibration table and API.
+
+## References
+
+- Brady & Livescu 2019: "High-order multiblock/multiresolution finite
+  difference methods for the compressible Navier-Stokes equations", &sect;4.3 pp. 92-94
+- Trefethen 1983: "Group velocity in finite difference schemes", pp. 204-210
+  (GKS determinant condition)
+- Trefethen & Embree 2005: *Spectra and Pseudospectra*, ch. 14 (Kreiss constant
+  calibration bands)

--- a/scripts/stencil_gen/docs/group_velocity_reference.md
+++ b/scripts/stencil_gen/docs/group_velocity_reference.md
@@ -1,0 +1,813 @@
+# Group Velocity Analysis Reference
+
+## 1. Module Overview
+
+**Module:** `stencil_gen.group_velocity`
+
+This module provides tools for computing modified wavenumber, phase velocity, and group velocity from finite difference stencil coefficients. It supports interior stencils, boundary closures, cut-cell stencils with non-uniform spacing, 2D tensor-product operators, varying-coefficient problems, and GKS-type stability diagnostics.
+
+### Mathematical Foundation
+
+For the scalar advection equation
+
+    u_t + u_x = 0
+
+semi-discretized on a uniform grid as `du/dt = -D*u`, the stencil `D` acting on a Fourier mode `exp(i*j*xi)` produces a **modified wavenumber** `kappa*(xi)`:
+
+    kappa*(xi) = sum_j  w_j  exp(i * (j - i_eval) * xi)
+
+where `w_j` are the stencil weights and `i_eval` is the evaluation point index.
+
+The **dispersion relation** is `omega = Im(kappa*(xi))`. From this:
+
+- **Phase velocity:** `c(xi) = Im(kappa*(xi)) / xi` -- the speed at which wave crests of wavenumber `xi` propagate.
+- **Group velocity:** `C(xi) = d(Im(kappa*(xi))) / d(xi)` -- the speed at which wave energy (packets) propagate.
+
+For the exact PDE, `kappa*(xi) = i*xi`, so `c(xi) = C(xi) = 1` everywhere.
+
+### Sign Conventions
+
+- The PDE is `u_t + u_x = 0`, so the physical propagation is in the **positive x-direction** with unit speed.
+- `C(xi) > 0` means the stencil propagates energy rightward (same direction as the PDE).
+- `C(xi) < 0` means the stencil produces **spurious backwards-propagating** energy at wavenumber `xi`.
+- The **cutoff wavenumber** is the first `xi` beyond which `C` stays permanently non-positive. High-frequency modes above the cutoff carry energy in the wrong direction.
+- For an interior scheme of order `2p` (half-bandwidth `p`), group velocity error grows as `O(xi^(2p))` for small `xi`. The error magnitude is amplified by a factor of `(2p+1)` relative to the phase velocity error due to differentiation of the dispersion relation (see Key Mathematical Notes below).
+
+---
+
+## 2. Public API
+
+### 2.1 Core Computations
+
+These are the low-level building blocks. They operate on raw stencil weights and wavenumber arrays.
+
+#### `modified_wavenumber(weights, i_eval, node_indices, xi_array)`
+
+Compute `kappa*(xi) = sum_j w_j exp(i*(j - i_eval)*xi)` for integer grid indices.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `weights` | array-like | Stencil coefficients `w_j` |
+| `i_eval` | `int` | Grid index where derivative is evaluated |
+| `node_indices` | array-like of int | Grid indices used by the stencil |
+| `xi_array` | `np.ndarray` | Wavenumber values in `[0, pi]` |
+
+**Returns:** `np.ndarray` (complex) -- modified wavenumber `kappa*(xi)`.
+
+---
+
+#### `modified_wavenumber_nonuniform(weights, offsets, xi_array)`
+
+Generalization for real-valued (non-integer) offsets, as arise in cut-cell grids.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `weights` | array-like | Stencil coefficients |
+| `offsets` | array-like of float | Normalized distances `(x_j - x_i)/h` from evaluation point (may be fractional) |
+| `xi_array` | `np.ndarray` | Wavenumber values in `[0, pi]` |
+
+**Returns:** `np.ndarray` (complex) -- `kappa*(xi) = sum_j w_j exp(i * offset_j * xi)`.
+
+---
+
+#### `group_velocity_exact(weights, i_eval, node_indices, xi_array)`
+
+Compute group velocity analytically (no numerical differentiation):
+
+    C(xi) = Re(sum_j w_j * (j - i_eval) * exp(i*(j - i_eval)*xi))
+
+| Parameter | Type | Description |
+|---|---|---|
+| `weights` | array-like | Stencil coefficients |
+| `i_eval` | `int` | Evaluation point grid index |
+| `node_indices` | array-like of int | Grid indices used |
+| `xi_array` | `np.ndarray` | Wavenumber values |
+
+**Returns:** `np.ndarray` (real) -- group velocity `C(xi)`.
+
+---
+
+#### `group_velocity_exact_nonuniform(weights, offsets, xi_array)`
+
+Analytical group velocity for non-uniform offsets:
+
+    C(xi) = Re(sum_j w_j * offset_j * exp(i * offset_j * xi))
+
+Parameters and return are analogous to `modified_wavenumber_nonuniform`.
+
+---
+
+#### `group_velocity_numerical(kappa_star, xi_array)`
+
+Compute `C(xi) = d(Im(kappa*))/d(xi)` via `np.gradient` (numerical differentiation). Less accurate than `group_velocity_exact` but works when you only have a precomputed `kappa*` array.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `kappa_star` | `np.ndarray` (complex) | Modified wavenumber array |
+| `xi_array` | `np.ndarray` | Wavenumber values |
+
+**Returns:** `np.ndarray` (real) -- group velocity.
+
+---
+
+#### `phase_velocity(kappa_star, xi_array)`
+
+Compute phase velocity `c(xi) = Im(kappa*(xi)) / xi`. At `xi = 0` the singularity is handled by using the value at the first non-zero `xi` point.
+
+**Returns:** `np.ndarray` (real) -- phase velocity.
+
+---
+
+#### `group_velocity_error(C, C_exact=1.0)`
+
+Compute relative group velocity error: `(C - C_exact) / C_exact`. Default `C_exact = 1.0` matches the advection equation `u_t + u_x = 0`.
+
+**Returns:** `np.ndarray` -- relative error.
+
+---
+
+### 2.2 Interior Analysis
+
+#### `interior_group_velocity(p, nu, xi_array)`
+
+Convenience function: derives the `2p`-order explicit interior stencil for derivative order `nu`, then returns a full `GroupVelocityProfile`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `p` | `int` | Interior half-bandwidth (E2: `p=1`, E4: `p=2`, E6: `p=3`, E8: `p=4`) |
+| `nu` | `int` | Derivative order (1 or 2) |
+| `xi_array` | `np.ndarray` | Wavenumber values in `[0, pi]` |
+
+**Returns:** `GroupVelocityProfile`
+
+Internally calls `stencil_gen.interior.derive_interior(0, p, nu)` and `full_gamma_array` to get stencil weights, then delegates to `_build_profile`.
+
+---
+
+### 2.3 Boundary Analysis
+
+#### `boundary_group_velocity(p, q, nextra, nu, sigma, kernel, xi_array)`
+
+Compute group velocity profiles for **all boundary rows** using RBF/tension boundary stencil weights.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `p` | `int` | Interior half-bandwidth |
+| `q` | `int` | Polynomial degree for boundary augmentation |
+| `nextra` | `int` | Extra boundary rows/columns |
+| `nu` | `int` | Derivative order |
+| `sigma` | `float` | RBF shape / tension parameter |
+| `kernel` | `str` | RBF kernel: `"tension"`, `"gaussian"`, or `"multiquadric"` |
+| `xi_array` | `np.ndarray` | Wavenumber values |
+
+**Returns:** `dict[int, GroupVelocityProfile]` -- keyed by boundary row index `0` to `r-1`.
+
+Internally uses `stencil_gen.phs.uniform_boundary_weights_rbf` and `stencil_gen.temo.compute_dimensions` to determine stencil layout.
+
+---
+
+#### `boundary_group_velocity_classical(boundary_rows, alpha_values, order, xi_array)`
+
+Compute group velocity profiles for **classical (non-RBF) boundary rows** from the symbolic `BoundaryRow` objects produced by `derive_boundary` or `solve_conservation`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `boundary_rows` | `list[BoundaryRow]` | Symbolic boundary rows with alpha parameters |
+| `alpha_values` | `dict` | Mapping from alpha symbols to numeric values (e.g., `{alpha_0: -0.77}`) |
+| `order` | `int` | Polynomial accuracy order of the boundary scheme |
+| `xi_array` | `np.ndarray` | Wavenumber values |
+
+**Returns:** `dict[int, GroupVelocityProfile]` -- keyed by boundary row index.
+
+This function evaluates symbolic coefficients via `xreplace` to obtain numeric weights.
+
+---
+
+### 2.4 Cut-Cell Analysis
+
+#### `cut_cell_group_velocity(cut_cell_result, psi_sym, psi_val, alpha_values, xi_array, order=None)`
+
+Compute group velocity profiles for all rows of a **cut-cell stencil** at a specific `psi` value.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `cut_cell_result` | `CutCellResult` | Symbolic cut-cell stencil from `derive_cut_cell_mathematica` or `derive_cut_cell_scheme` |
+| `psi_sym` | `Symbol` | SymPy symbol for psi used in the result |
+| `psi_val` | `float` | Numeric psi value in `[0, 1]` |
+| `alpha_values` | `dict` | Alpha symbol to value mapping |
+| `xi_array` | `np.ndarray` | Wavenumber values |
+| `order` | `int`, optional | Polynomial accuracy order; defaults to `dims.r - 1` |
+
+**Returns:** `dict[int, GroupVelocityProfile]` -- keyed by row index `0` to `R-1`.
+
+The non-uniform offsets are computed from the cut-cell geometry: the wall is at offset `-(psi_val + i)` from row `i`, and the regular grid points are at offsets `j - i`.
+
+---
+
+#### `psi_sweep_group_velocity(scheme_params, psi_values, alpha_values, xi_array, order=None)`
+
+Sweep psi across the cut-cell parameter range `[0, 1]`, deriving the stencil once and evaluating group velocity at each psi.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `scheme_params` | `SchemeParams` | Scheme parameters (`p`, `q`, `s`, `nextra`, `nu`, `zeros`) |
+| `psi_values` | `np.ndarray` | Array of psi values to sweep |
+| `alpha_values` | `dict` | Alpha symbol to value mapping (empty dict uses zeros) |
+| `xi_array` | `np.ndarray` | Wavenumber values |
+| `order` | `int`, optional | Polynomial accuracy order |
+
+**Returns:** `PsiSweepResult`
+
+This function also computes the interior group velocity and checks for **sign reversals** -- wavenumbers where a boundary row has `C > 0` while the interior has `C < 0`, indicating parasitic energy propagating backwards through the boundary closure.
+
+Stencil derivation uses the singularity-free Mathematica workflow (`derive_cut_cell_mathematica`) when `scheme_params.zeros` is non-empty, otherwise the standard pipeline (`derive_cut_cell_scheme`).
+
+---
+
+### 2.5 2D Analysis
+
+#### `group_velocity_2d(kappa_x_star, kappa_y_star, xi_array, eta_array, a=1.0, b=1.0)`
+
+Compute 2D group velocity for **tensor-product stencils** where the dispersion relation factors as:
+
+    omega = a * kappa_x*(xi) + b * kappa_y*(eta)
+
+The group velocity vector is `(C_x, C_y)` where each component depends only on its respective wavenumber.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `kappa_x_star` | `np.ndarray` (complex) | Modified wavenumber for x-direction, shape `(N_xi,)` |
+| `kappa_y_star` | `np.ndarray` (complex) | Modified wavenumber for y-direction, shape `(N_eta,)` |
+| `xi_array` | `np.ndarray` | x-direction wavenumber array |
+| `eta_array` | `np.ndarray` | y-direction wavenumber array |
+| `a` | `float` | Wave speed in x-direction (default 1.0) |
+| `b` | `float` | Wave speed in y-direction (default 1.0) |
+
+**Returns:** `GroupVelocity2DResult`
+
+All 2D arrays in the result have shape `(N_xi, N_eta)` using `indexing='ij'`.
+
+---
+
+#### `anisotropy_profile(p, nu, theta_array, xi_mag)`
+
+Compute group speed and angle error vs propagation angle for an interior scheme.
+
+For the advection equation `u_t + cos(theta)*u_x + sin(theta)*u_y = 0`, this evaluates the numerical group velocity at wavenumber magnitude `xi_mag` for each propagation angle `theta`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `p` | `int` | Interior half-bandwidth |
+| `nu` | `int` | Derivative order |
+| `theta_array` | `np.ndarray` | Propagation angles in radians |
+| `xi_mag` | `float` | Wavenumber magnitude in `[0, pi]` |
+
+**Returns:** `AnisotropyResult`
+
+The exact group velocity is `(cos(theta), sin(theta))` with unit speed. Grid anisotropy causes deviations -- for example, Trefethen (1982) shows that E2 has higher group speed at diagonal propagation (`theta = pi/4`) than axis-aligned propagation (`theta = 0`).
+
+---
+
+#### `boundary_group_velocity_2d(boundary_rows_x, interior_y, theta_array, xi_mag)`
+
+Compute 2D group velocity at a boundary where x-direction uses boundary stencils and y-direction uses interior stencils.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `boundary_rows_x` | `dict[int, GroupVelocityProfile]` | Boundary profiles for x-direction |
+| `interior_y` | `GroupVelocityProfile` | Interior profile for y-direction |
+| `theta_array` | `np.ndarray` | Propagation angles |
+| `xi_mag` | `float` | Wavenumber magnitude |
+
+**Returns:** `dict[int, AnisotropyResult]` -- keyed by boundary row index.
+
+This reveals whether the boundary distorts the group velocity angle, bending waves toward or away from the boundary.
+
+---
+
+### 2.6 Varying-Coefficient Analysis
+
+#### `local_group_velocity(weights_func, x, xi_array)`
+
+Compute **spatially varying** group velocity for problems like `u_t + a(x)*u_x = 0` where stencil coefficients depend on position.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `weights_func` | callable | `weights_func(x_val) -> (weights, offsets)` returning stencil weights and offsets at position `x_val` |
+| `x` | `np.ndarray` | Grid point coordinates, shape `(N_x,)` |
+| `xi_array` | `np.ndarray` | Wavenumber values, shape `(N_xi,)` |
+
+**Returns:** `np.ndarray`, shape `(N_x, N_xi)` -- local group velocity `C[i_x, i_xi]`.
+
+---
+
+#### `ray_trace_group_velocity(C_field, x_grid, xi_array, xi_0, x_0, t_final, dt)`
+
+Trace a ray through a spatially varying group velocity field by integrating the ray equations:
+
+    dx/dt  =  C(x, xi)      (group velocity)
+    dxi/dt = -dC/dx          (refraction)
+
+using classical RK4 with bilinear interpolation of the `C_field`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `C_field` | `np.ndarray` | Group velocity field from `local_group_velocity`, shape `(N_x, N_xi)` |
+| `x_grid` | `np.ndarray` | Grid coordinates, shape `(N_x,)` |
+| `xi_array` | `np.ndarray` | Wavenumber values, shape `(N_xi,)` |
+| `xi_0` | `float` | Initial wavenumber |
+| `x_0` | `float` | Initial position |
+| `t_final` | `float` | Final integration time |
+| `dt` | `float` | Time step |
+
+**Returns:** `RayTraceResult`
+
+Uses `scipy.interpolate.RegularGridInterpolator` for bilinear interpolation and `np.gradient` along axis 0 for `dC/dx`. The refraction equation (`dxi/dt = -dC/dx`) is from Trefethen (1982), Eq. 4.9b.
+
+---
+
+### 2.7 GKS Stability Diagnostic
+
+#### `gks_group_velocity_check(D, xi_array, neutral_tol=0.1, localization_tol=0.3)`
+
+Identify boundary-localized eigenmodes whose group velocity indicates **GKS-type instability**.
+
+For the semi-discrete problem `du/dt = -D*u` with Dirichlet inflow BC (row/column 0 removed), this function:
+
+1. Computes eigenvalues and eigenvectors of `-D_bc`.
+2. Identifies **nearly-neutral** modes (small `|Re(lambda)|`).
+3. Checks for **boundary localization** (energy concentrated in the first or last quarter of the domain).
+4. Estimates the dominant wavenumber via zero-padded FFT of the boundary portion.
+5. Evaluates the interior group velocity at that wavenumber.
+6. Flags the mode as **outgoing** if the group velocity directs energy from the boundary into the domain -- the hallmark of GKS instability.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `D` | `np.ndarray` | Full `N x N` differentiation matrix |
+| `xi_array` | `np.ndarray` | Wavenumber array for group velocity evaluation |
+| `neutral_tol` | `float` | Fraction of `max|Re(lambda)|` below which a mode is nearly-neutral (default 0.1) |
+| `localization_tol` | `float` | Minimum fraction of eigenvector energy in the boundary region to classify as boundary-localized (default 0.3) |
+
+**Returns:** `list[GKSModeInfo]` -- one entry per identified mode.
+
+The left boundary is "outgoing" when `C > 0` (rightward into domain); the right boundary is "outgoing" when `C < 0` (leftward into domain). Only positive-imaginary members of conjugate pairs are kept.
+
+**Heuristic vs. rigorous test:** `gks_group_velocity_check` is a *heuristic* diagnostic (necessary but not sufficient for instability). For the rigorous GKS determinant condition, use `kreiss_stability_check` from `stencil_gen.gks_kreiss`, which implements Trefethen 1983 pp. 206-207: it sweeps the right half-plane for `s` where `sigma_min(M(s)) < tol`, refines witnesses via Nelder-Mead, and classifies imaginary-axis modes as incoming or outgoing. See `docs/brady2d_stability_reference.md` for the full API.
+
+---
+
+#### `local_group_velocity_2d_varying(interior_stencil_x, interior_stencil_y, c_x_field, c_y_field, xi_array)`
+
+Compute **per-point local group velocity error** across a 2D varying-coefficient field. At each grid point `(i, j)`, the local dispersion error is `c_*[i,j] * gv_error(xi)` — the factor of `c_*` scales the baseline interior error by the local wave speed. This is the first-order WKB approximation for smooth coefficient fields.
+
+Used by Layer 4 (L4) of the Brady-Livescu 2D stability pipeline. See `docs/brady2d_stability_reference.md`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `interior_stencil_x` | tuple | `(weights, offsets)` for x-direction interior stencil |
+| `interior_stencil_y` | tuple | `(weights, offsets)` for y-direction interior stencil |
+| `c_x_field` | `np.ndarray` | x-component of varying coefficient field, shape `(Ny, Nx)` |
+| `c_y_field` | `np.ndarray` | y-component of varying coefficient field, shape `(Ny, Nx)` |
+| `xi_array` | `np.ndarray` | Wavenumber array |
+
+**Returns:** `dict` with keys `C_x_field`, `C_y_field`, `gv_error_x_field`, `gv_error_y_field` (all shape `(Ny, Nx, N_xi)`) and scalar reduction `max_local_gv_error_2d(result) -> float`.
+
+---
+
+#### `anisotropy_over_coefficient_field(scheme, c_x_field, c_y_field, theta_array, xi_mag)`
+
+Evaluate the directional alignment between the grid anisotropy profile and the local propagation direction across a 2D coefficient field. At each grid point, the radial propagation direction is `(c_x[i,j], c_y[i,j])/|c|` — the anisotropy error is projected onto this direction.
+
+Used by Layer 5 (L5) of the Brady-Livescu 2D stability pipeline. See `docs/brady2d_stability_reference.md`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `scheme` | `str` | Scheme name (e.g. "E2", "E4") for looking up order `p` |
+| `c_x_field` | `np.ndarray` | x-component of varying coefficient field |
+| `c_y_field` | `np.ndarray` | y-component of varying coefficient field |
+| `theta_array` | `np.ndarray` | Propagation angles |
+| `xi_mag` | `float` | Wavenumber magnitude |
+
+**Returns:** `dict` with `max_aligned_error`, `worst_point`, `worst_theta`.
+
+---
+
+## 3. Dataclasses
+
+### `GroupVelocityProfile`
+
+Complete group velocity analysis for a single stencil row.
+
+| Field | Type | Description |
+|---|---|---|
+| `xi` | `np.ndarray` | Wavenumber array |
+| `kappa_star` | `np.ndarray` (complex) | Modified wavenumber `kappa*(xi)` |
+| `phase_velocity` | `np.ndarray` | Phase velocity `c(xi) = Im(kappa*)/xi` |
+| `group_velocity` | `np.ndarray` | Group velocity `C(xi) = d(Im(kappa*))/d(xi)` |
+| `gv_error` | `np.ndarray` | Relative GV error `(C - 1) / 1` |
+| `order` | `int` | Polynomial accuracy order of the stencil |
+| `cutoff_xi` | `float` | First `xi` beyond which `C` stays permanently non-positive |
+
+The cutoff is determined by scanning from `xi = pi` backward to find the last `xi` where `C > 0`, then taking the next grid point. This handles non-monotonic boundary stencils where `C` may dip below zero briefly then recover.
+
+---
+
+### `PsiSweepResult`
+
+Results from sweeping psi across the cut-cell parameter range.
+
+| Field | Type | Description |
+|---|---|---|
+| `psi_values` | `np.ndarray` | Array of psi values swept |
+| `profiles` | `dict[float, dict[int, GroupVelocityProfile]]` | Nested dict: `{psi_val: {row_index: profile}}` |
+| `worst_row` | `int` | Row index with the largest GV error across all psi values |
+| `worst_psi` | `float` | Psi value with the largest GV error |
+| `min_C` | `float` | Most negative group velocity across all psi/row combinations |
+| `has_sign_reversal` | `bool` | True if any boundary row has `C > 0` where the interior has `C < 0` |
+
+---
+
+### `GroupVelocity2DResult`
+
+2D group velocity analysis for tensor-product stencils.
+
+| Field | Type | Description |
+|---|---|---|
+| `xi` | `np.ndarray` | 1D wavenumber array for x-direction |
+| `eta` | `np.ndarray` | 1D wavenumber array for y-direction |
+| `C_x` | `np.ndarray` | 2D group velocity x-component, shape `(N_xi, N_eta)` |
+| `C_y` | `np.ndarray` | 2D group velocity y-component, shape `(N_xi, N_eta)` |
+| `speed` | `np.ndarray` | 2D group speed `|C|` |
+| `angle` | `np.ndarray` | 2D group propagation angle `atan2(C_y, C_x)` |
+| `angle_error` | `np.ndarray` | Angle deviation from wave normal direction |
+
+---
+
+### `AnisotropyResult`
+
+Anisotropy profile for a given scheme at fixed wavenumber magnitude.
+
+| Field | Type | Description |
+|---|---|---|
+| `theta` | `np.ndarray` | Propagation angle array |
+| `C_x` | `np.ndarray` | Group velocity x-component |
+| `C_y` | `np.ndarray` | Group velocity y-component |
+| `speed` | `np.ndarray` | Group speed `|C|` (equals speed ratio since exact speed is 1) |
+| `angle` | `np.ndarray` | Group propagation angle `atan2(C_y, C_x)` |
+| `angle_error` | `np.ndarray` | Angle deviation from propagation direction `theta` |
+
+---
+
+### `GKSModeInfo`
+
+Diagnostic information for a boundary-localized eigenmode.
+
+| Field | Type | Description |
+|---|---|---|
+| `eigenvalue` | `complex` | Eigenvalue of `-D_bc` |
+| `boundary_wavenumber` | `float` | Dominant `xi` from FFT of boundary eigenvector portion |
+| `group_velocity` | `float` | Interior `C(xi)` at `boundary_wavenumber` |
+| `is_outgoing` | `bool` | True if the mode radiates energy from the boundary into the domain |
+
+---
+
+### `RayTraceResult`
+
+Trajectory of a ray traced through a group velocity field.
+
+| Field | Type | Description |
+|---|---|---|
+| `t` | `np.ndarray` | Time array, shape `(N_t,)` |
+| `x` | `np.ndarray` | Position trajectory, shape `(N_t,)` |
+| `xi` | `np.ndarray` | Wavenumber trajectory, shape `(N_t,)` |
+
+---
+
+## 4. Usage Examples
+
+### 4.1 Interior Group Velocity for an E4 Stencil
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from stencil_gen.group_velocity import interior_group_velocity
+
+xi = np.linspace(0.01, np.pi, 500)
+
+# E4 scheme: p=2 (half-bandwidth), nu=1 (first derivative)
+profile = interior_group_velocity(p=2, nu=1, xi_array=xi)
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+# Group velocity
+axes[0].plot(xi, profile.group_velocity, label="E4 interior")
+axes[0].axhline(1.0, color="k", ls="--", label="Exact")
+axes[0].axhline(0.0, color="r", ls=":", alpha=0.5)
+axes[0].axvline(profile.cutoff_xi, color="gray", ls=":", label=f"Cutoff = {profile.cutoff_xi:.2f}")
+axes[0].set_xlabel(r"$\xi$")
+axes[0].set_ylabel(r"$C(\xi)$")
+axes[0].set_title("Group velocity")
+axes[0].legend()
+
+# Relative error
+axes[1].semilogy(xi, np.abs(profile.gv_error))
+axes[1].set_xlabel(r"$\xi$")
+axes[1].set_ylabel(r"$|C - 1|$")
+axes[1].set_title("Relative group velocity error")
+
+plt.tight_layout()
+plt.savefig("e4_group_velocity.png", dpi=150)
+```
+
+### 4.2 Comparing Boundary vs Interior Group Velocity
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from stencil_gen.group_velocity import (
+    interior_group_velocity,
+    boundary_group_velocity,
+)
+
+xi = np.linspace(0.01, np.pi, 500)
+
+# Interior E4 profile
+interior = interior_group_velocity(p=2, nu=1, xi_array=xi)
+
+# Boundary profiles: E4 with tension kernel
+boundary = boundary_group_velocity(
+    p=2, q=3, nextra=0, nu=1,
+    sigma=10.0, kernel="tension",
+    xi_array=xi,
+)
+
+plt.figure(figsize=(10, 6))
+plt.plot(xi, interior.group_velocity, "k-", lw=2, label="Interior")
+
+for row_idx, prof in sorted(boundary.items()):
+    plt.plot(xi, prof.group_velocity, "--",
+             label=f"Boundary row {row_idx} (cutoff={prof.cutoff_xi:.2f})")
+
+plt.axhline(1.0, color="gray", ls=":", alpha=0.5)
+plt.axhline(0.0, color="r", ls=":", alpha=0.5)
+plt.xlabel(r"$\xi$")
+plt.ylabel(r"$C(\xi)$")
+plt.title("Boundary vs Interior Group Velocity (E4, tension)")
+plt.legend()
+plt.savefig("boundary_vs_interior_gv.png", dpi=150)
+```
+
+### 4.3 Psi Sweep for Cut-Cell Analysis
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from stencil_gen.temo import E2_1
+from stencil_gen.group_velocity import psi_sweep_group_velocity
+
+xi = np.linspace(0.01, np.pi, 300)
+psi_values = np.linspace(0.05, 0.95, 19)
+
+result = psi_sweep_group_velocity(
+    scheme_params=E2_1,
+    psi_values=psi_values,
+    alpha_values={},      # use zeros for free parameters
+    xi_array=xi,
+)
+
+print(f"Worst row:          {result.worst_row}")
+print(f"Worst psi:          {result.worst_psi:.3f}")
+print(f"Most negative C:    {result.min_C:.4f}")
+print(f"Sign reversal:      {result.has_sign_reversal}")
+
+# Plot row 0 across psi values
+fig, ax = plt.subplots(figsize=(10, 6))
+for pv in psi_values[::4]:  # plot every 4th psi
+    prof = result.profiles[float(pv)][0]
+    ax.plot(xi, prof.group_velocity, label=f"psi={pv:.2f}")
+
+ax.axhline(0, color="r", ls=":", alpha=0.5)
+ax.set_xlabel(r"$\xi$")
+ax.set_ylabel(r"$C(\xi)$")
+ax.set_title("Cut-cell group velocity (row 0) vs psi")
+ax.legend(fontsize=8, ncol=2)
+plt.savefig("psi_sweep_gv.png", dpi=150)
+```
+
+### 4.4 2D Anisotropy Check
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from stencil_gen.group_velocity import anisotropy_profile
+
+theta = np.linspace(0, 2 * np.pi, 360)
+
+# Compare E2 and E4 anisotropy at xi_mag = 1.0
+for p, label in [(1, "E2"), (2, "E4")]:
+    result = anisotropy_profile(p=p, nu=1, theta_array=theta, xi_mag=1.0)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+    # Polar plot of group speed
+    ax = axes[0]
+    ax = plt.subplot(121, projection="polar")
+    ax.plot(result.theta, result.speed, label=f"{label}")
+    ax.plot(result.theta, np.ones_like(theta), "k--", alpha=0.3, label="Exact")
+    ax.set_title(f"{label} group speed (xi_mag=1.0)")
+    ax.legend()
+
+    # Angle error
+    axes[1].plot(np.degrees(theta), np.degrees(result.angle_error))
+    axes[1].set_xlabel("Propagation angle (deg)")
+    axes[1].set_ylabel("Angle error (deg)")
+    axes[1].set_title(f"{label} angle error")
+
+    plt.tight_layout()
+    plt.savefig(f"{label.lower()}_anisotropy.png", dpi=150)
+```
+
+### 4.5 GKS Stability Diagnostic
+
+```python
+import numpy as np
+from stencil_gen.group_velocity import gks_group_velocity_check
+
+# Build a differentiation matrix for E2 on N points with some boundary closure.
+# (In practice, you would assemble this from your stencil pipeline.)
+N = 64
+h = 1.0 / N
+
+# Interior: central difference [-1/2, 0, 1/2] / h
+D = np.zeros((N, N))
+for i in range(1, N - 1):
+    D[i, i - 1] = -0.5 / h
+    D[i, i + 1] = 0.5 / h
+
+# Boundary closures (one-sided)
+D[0, 0] = -1.0 / h
+D[0, 1] = 1.0 / h
+D[N - 1, N - 2] = -1.0 / h
+D[N - 1, N - 1] = 1.0 / h
+
+xi = np.linspace(0.01, np.pi, 500)
+modes = gks_group_velocity_check(D, xi)
+
+if not modes:
+    print("No GKS-unstable modes found -- boundary closure is stable.")
+else:
+    for m in modes:
+        print(f"Eigenvalue: {m.eigenvalue:.4f}")
+        print(f"  Boundary wavenumber: {m.boundary_wavenumber:.3f}")
+        print(f"  Group velocity:      {m.group_velocity:.4f}")
+        print(f"  Outgoing (unstable): {m.is_outgoing}")
+```
+
+---
+
+## 5. Sweep Integration
+
+The sweep optimization pipeline (`scripts/stencil_gen/sweeps/`) consumes this
+module exclusively through the thin wrappers in `sweeps/gv_objectives.py`.
+Sweep scripts never call `interior_group_velocity` / `boundary_group_velocity`
+/ `psi_sweep_group_velocity` / `gks_group_velocity_check` directly — all access
+goes through one of the helpers below so the `feasible-then-minimize` contract
+and the bit-exact `(param, gv_error)` self-consistency contract (see
+`docs/sweeps_reference.md` §2.9) stay consistent across every sweep.
+
+### 5.1 Objective Helpers in `sweeps/gv_objectives.py`
+
+| Helper | Wraps | Returns | Used by |
+|---|---|---|---|
+| `interior_gv_error_max(p, nu, n_xi)` | `interior_group_velocity` | `float` — max `|gv_error|` over `xi` | — (reserved for future interior-only sweeps) |
+| `interior_cutoff_fraction(p, nu, n_xi)` | `interior_group_velocity` | `float` — `cutoff_xi / pi` (1.0 = ideal) | — (reserved) |
+| `boundary_gv_error_max(p, q, nextra, nu, sigma, kernel, n_xi)` | `boundary_group_velocity` | `float` — max `|gv_error|` across all RBF boundary rows | `tension_sweep`, `epsilon_sweep`, `footprint_sweep`, `gv_stability_pareto` |
+| `cutcell_gv_min_C(scheme_params, psi_values, alpha_values, n_xi)` | `psi_sweep_group_velocity` | `(float, bool)` — `(min_C, has_sign_reversal)` | — (reserved for the deferred 40.5f cut-cell GV sweep) |
+| `gv_score_from_matrix(D, n_xi)` | `group_velocity_exact_nonuniform` + `group_velocity_error` | `dict` with `max_gv_error` / `min_cutoff_xi` | `tension_penalty_sweep` (avoids rebuilding `D`) |
+| `print_gks_advisory(D, *, label, n_xi)` | `gks_group_velocity_check` | `int` — outgoing mode count (advisory only) | `tension_sweep`, `epsilon_sweep` (`--check-gks`) |
+
+**Contract:** these helpers are *secondary* objectives only. Stability
+(`stability_eigenvalue < STABILITY_TOL`) is always the hard feasibility gate;
+GV error is minimized only among the feasible set. This mirrors the
+feasible-then-minimize pattern already established in
+`tension_penalty_sweep.py`.
+
+**Default `n_xi`:** all helpers use `np.linspace(1e-6, pi, 200)` for the
+wavenumber grid. This is enough for the ~1e-6 quadrature noise floor that the
+bit-exact regression tests in `tests/test_sweep_gv_objectives.py` rely on; see
+`_default_xi` in `gv_objectives.py`.
+
+**Deterministic output:** `boundary_gv_error_max` is a pure numpy pipeline with
+no RNG or cached state, so two consecutive calls at identical arguments return
+bit-identical floats. This is load-bearing for the 40.8f / 40.8g bit-exact
+gates — any helper added to this module must preserve that property.
+
+### 5.2 GKS Check is Advisory Only
+
+`gks_group_velocity_check` is exposed to sweeps through
+`print_gks_advisory` and surfaced via the `--check-gks` flag on
+`tension_sweep` and `epsilon_sweep`. It is **necessary not sufficient** for
+boundary instability (see the test docstring at
+`tests/test_group_velocity.py:1015-1017`): a clean advisory does not prove
+the scheme is GKS-stable, but any outgoing-mode warning it emits is a real
+finding that should be investigated.
+
+Consequently the sweep integration treats the GKS check as a *diagnostic*,
+never as a feasibility gate:
+
+- It runs **after** the stability-optimum and the `stable_at` cross-grid
+  list have already been built, so it cannot mutate the optimum by
+  construction, not just by convention.
+- It does not alter `known_values.json`.
+- It does not change the exit code of the sweep.
+- Any outgoing modes print as one-line `WARNING:` advisories with
+  `xi`, `eigenvalue`, and `group_velocity` fields.
+
+If you want to use the GKS check as a hard gate in your own tooling, call
+`gks_group_velocity_check` directly from this module and apply your own
+policy — do not add a feasibility branch to the sweep helpers.
+
+For a **rigorous** GKS stability test (necessary *and* sufficient for the 1D
+reduction), use `kreiss_stability_check` from `stencil_gen.gks_kreiss` (see
+`docs/brady2d_stability_reference.md`). The Kreiss determinant test sweeps
+`s` in the right half-plane, refines witnesses, and classifies imaginary-axis
+perturbations per Trefethen 1983 pp. 206-207. It is used as Layer 2 (L2) of
+the Brady-Livescu 2D stability pipeline.
+
+### 5.3 `known_values.json` Cross-Reference
+
+The persisted `*.gv_error` fields, `tension_gv` / `{kernel}_gv` /
+`tension_penalty_gv` entries, and `footprint.E4_nextra{nx}_tension_gv`
+entries are all computed through these helpers (see
+`docs/sweeps_reference.md` §2.9 and §3 for the schema). The primary
+`{primary}.gv_error` fields (`tension`, `gaussian`, `multiquadric` via
+`boundary_gv_error_max`; `tension_penalty` via `gv_score_from_matrix`; and
+the footprint `E4_nextra{nx}_tension_{N}.gv_error` via
+`boundary_gv_error_max`) are contractually bit-exact self-consistent with
+their paired `sigma` / `epsilon` / `(sigma, gamma)` field: rebuilding `D`
+at the persisted parameter and re-running the paired helper returns the
+stored `gv_error` to the full 13 significant digits of float64. The
+regression tests in `tests/test_phs.py::TestRegressionGV` and
+`tests/test_sweep_gv_objectives.py::test_*_bit_exact_at_persisted_sigma`
+gate this contract.
+
+---
+
+## 6. Key Mathematical Notes
+
+### Modified Wavenumber and Dispersion Relation
+
+For a stencil with weights `w_j` at offsets `d_j` from the evaluation point, the modified wavenumber is:
+
+    kappa*(xi) = sum_j w_j exp(i * d_j * xi)
+
+For the exact first derivative `d/dx`, `kappa*(xi) = i*xi`, giving `Im(kappa*) = xi` (perfect dispersion). Any finite-difference stencil introduces truncation error in `kappa*`.
+
+### Sign Convention for the Advection Equation
+
+The module adopts the convention `u_t + u_x = 0` (rightward propagation at unit speed). The semi-discrete form is `du/dt = -D*u` where `D` approximates `d/dx`. The physical group velocity is `C = +1`. A computed `C(xi) < 0` means spurious backward propagation at wavenumber `xi`.
+
+### Relationship to Eigenvalue Stability
+
+The eigenvalues of `-D` (with boundary conditions applied) control time-stepping stability. The modified wavenumber `kappa*` of the interior stencil gives the imaginary parts of these eigenvalues on a periodic domain. Group velocity analysis complements eigenvalue analysis by explaining *where* energy goes -- an eigenvalue can be neutrally stable (purely imaginary) while its associated mode's group velocity directs energy toward a boundary that reflects it, leading to algebraic growth or GKS instability.
+
+### (2p+1)x Error Amplification
+
+For a `2p`-order interior stencil, the phase velocity error is `O(xi^(2p))` at small `xi`. Because the group velocity is the *derivative* of the dispersion relation:
+
+    C(xi) = d(Im(kappa*))/d(xi)
+
+the leading error term gains a factor of `(2p+1)` compared to the phase velocity error. Concretely, if `Im(kappa*) = xi + c * xi^(2p+1)`, then `C = 1 + c*(2p+1)*xi^(2p)`. This means group velocity error is `(2p+1)` times larger than the corresponding phase velocity error at any given `xi`.
+
+### Cutoff Wavenumber
+
+The **cutoff wavenumber** `cutoff_xi` is defined as the first `xi` beyond which the group velocity `C(xi)` stays permanently non-positive. Waves with `xi > cutoff_xi` propagate in the wrong direction. For E2 (`p=1`), the interior cutoff is `xi = pi/2` (where `cos(pi/2) = 0`). Higher-order schemes push the cutoff closer to `pi`.
+
+Boundary stencils typically have a lower cutoff than the interior, meaning they produce backward-propagating energy at a wider range of wavenumbers. This is a key mechanism for boundary instability.
+
+### GKS Instability Mechanism
+
+Gustafsson, Kreiss, and Sundstrom (1972) showed that IBVP stability requires checking whether boundary-reflected waves carry energy into the domain. Trefethen (1983) connected this to group velocity: a boundary mode is GKS-unstable if:
+
+1. The eigenvalue is nearly neutral (small damping).
+2. The mode is localized near the boundary.
+3. The interior stencil's group velocity at the mode's dominant wavenumber directs energy **from the boundary into the domain**.
+
+The `gks_group_velocity_check` function automates this three-step diagnostic
+as a heuristic. The rigorous formulation is the Kreiss determinant test in
+`stencil_gen.gks_kreiss`: for each `s` with `Re(s) >= 0`, it assembles the
+Kreiss matrix from admissible roots (`|kappa| < 1`) and checks whether
+`sigma_min(M(s))` vanishes, confirming a genuine GKS violation.
+
+### Non-Uniform Offsets (Cut Cells)
+
+Cut-cell stencils have a wall point at fractional distance `psi` from the nearest grid point. The offsets become non-integer: the wall contributes offset `-(psi + i)` for boundary row `i`, while regular grid points contribute integer offsets `j - i`. The `_nonuniform` variants of modified wavenumber and group velocity handle these fractional offsets correctly.
+
+---
+
+## References
+
+- Trefethen, L.N. "Group velocity in finite difference schemes." *SIAM Review*, 24(2):113-136, 1982.
+- Trefethen, L.N. "Stability and group velocity." *Numerische Mathematik*, 41:1-29, 1983 (GKS connection).
+- Gustafsson, B., Kreiss, H.-O., and Sundstrom, A. "Stability theory of difference approximations for mixed initial boundary value problems." *Mathematics of Computation*, 26(119):649-686, 1972.
+- Brady, P.T. and Livescu, D. "High-order, stable, and conservative boundary schemes for central and compact finite differences." *Computers & Fluids*, 183:84-101, 2019.

--- a/scripts/stencil_gen/docs/pareto_reference.md
+++ b/scripts/stencil_gen/docs/pareto_reference.md
@@ -1,0 +1,385 @@
+# Multi-Objective Pareto Optimization Reference
+
+Companion to `optimization_reference.md`.  Where that document describes the
+*scalar* optimizer layer (`make_objective`, `run_scipy_local`,
+`run_staged_optimize`, …), this one describes the *multi-objective* layer
+added in plan 45 — NSGA-II driven Pareto fronts over two or more
+Brady-Livescu 2D stability metrics.
+
+## 1. Problem
+
+The scalar optimizers collapse every trade-off onto a single scalar, so
+genuinely conflicting metrics disappear.  Plan 44 made the conflict concrete:
+
+| Metric | Measures | Tension E4 σ=3 | Classical E4 (BL α) |
+|---|---|---|---|
+| `layer1.boundary_gv_err` | dispersion quality at the boundary | ~3.6e-2 (excellent) | ~1e-1 |
+| `layer_bl42.max_spectral_abscissa` | BL42 reflecting-BC stability | ~0.95 (fails) | ~3e-14 (passes) |
+| `layer6.transient_growth_bound` | non-normal transient growth | ~3.3 | basin-dependent |
+
+No single scalar captures "best closure."  The user's physics (acoustics
+vs. advection-dominated vs. transient-growth-sensitive) decides.  The
+multi-objective formulation
+
+```
+minimize  F(x) = [f_1(x), f_2(x), ..., f_m(x)]
+subject to  x ∈ [lb, ub]
+```
+
+is solved in the sense of *Pareto dominance*: `x` dominates `y` iff
+`F_i(x) ≤ F_i(y)` for all `i` and strictly `<` for at least one.  The
+*Pareto front* is the set of non-dominated points — no better on one axis
+without being worse on another.  NSGA-II (Deb et al. 2002) evolves a
+population toward this front via fast non-dominated sort plus
+crowding-distance survival; at convergence the population *is* the front.
+
+## 2. Why pymoo
+
+- Mature, stable 0.6 API with NSGA-II, NSGA-III, hypervolume indicator, and
+  reference-direction helpers.
+- `ElementwiseProblem` composes cleanly with the existing `make_objective`
+  pattern — one vector-valued objective wrapping the per-layer extractor.
+- Pure-Python numerics; no PyTorch/TensorFlow dependency (deferred to a
+  later Bayesian-optimization plan).
+
+## 3. API
+
+All exports live in `stencil_gen/pareto.py`.
+
+### 3.1 `ParetoPoint`
+
+```python
+@dataclass(frozen=True)
+class ParetoPoint:
+    x: np.ndarray          # (n_var,), float64 — optimizer vector
+    params: dict           # params_from_vector(kernel, x) — kernel-native
+    objectives: np.ndarray # (n_obj,), float64 — aligned with objective_fields
+    report: dict           # _report_to_dict(StabilityReport) at x (may be {})
+```
+
+One non-dominated member of a Pareto front.  `x` and `params` are redundant
+representations: carry whichever is convenient.  `objectives` is aligned
+with `ParetoResult.objective_fields`.  `report` captures the full
+short-circuit `StabilityReport` at `x` (including `layer_bl42` as of plan
+45.6a.1.1); downstream analysis tooling walks this dict without re-running
+the cascade.
+
+### 3.2 `ParetoResult`
+
+```python
+@dataclass(frozen=True)
+class ParetoResult:
+    front: tuple[ParetoPoint, ...]
+    objective_fields: tuple[str, ...]
+    scheme: str
+    kernel: str
+    bounds: tuple[tuple[float, float], ...]
+    method: str            # "NSGA-II"
+    pop_size: int
+    n_gen: int
+    n_evals: int
+    seed: int
+    compute_time: float
+    hv_trace: tuple[float, ...]  # hypervolume per generation
+    ref_point: tuple[float, ...] # used for HV; shape (n_obj,)
+    extras: dict                 # driver-specific diagnostics
+```
+
+`front` holds only finite, non-sentinel members; sentinel rows produced by
+the gate (see `_PARETO_SENTINEL` below) are filtered out and counted in
+`extras["n_sentinel_filtered"]`.  `hv_trace` has length `n_gen` and is
+non-decreasing under NSGA-II's elitism.  `ref_point` dominates every front
+member by construction (auto-picked at 1.1 × the max of a small random
+feasible probe, clipped to `[1.0, _PARETO_SENTINEL)`).  `extras` also
+carries `hv_n_nds` (per-generation non-dominated count) and, when
+`--validate-with-cpp` is used, `cpp_validation`.
+
+### 3.3 `make_multi_objective`
+
+```python
+def make_multi_objective(
+    scheme: str,
+    kernel: str,
+    report_fields: Sequence[str],
+    *,
+    gate_layer: int | None = None,
+    max_layer: int | None = None,
+) -> Callable[[np.ndarray], np.ndarray]
+```
+
+Vector-valued analogue of `make_objective`.  Runs `brady2d_stability_score`
+in short-circuit mode up to `max_layer` and extracts each dotted path via
+`extract_field`.  Returns a length-`len(report_fields)` vector per call.
+
+On any gate trip, parameter-vector shape mismatch, or exception from
+`brady2d_stability_score`, the closure returns
+`np.full(n_obj, _PARETO_SENTINEL)` with `_PARETO_SENTINEL = 1e12` — finite,
+because pymoo's hypervolume indicator and `ftol` termination both reject
+`+inf`.  Downstream NSGA-II filtering drops sentinel rows from the reported
+front.
+
+Requires `len(report_fields) >= 2`; raises `ValueError` otherwise.  Defaults
+`max_layer = max(_infer_max_layer(f) for f in report_fields)` and
+`gate_layer = max(max_layer - 1, 0)`, consistent with the 45.0b auto-infer
+shared by the scalar `make_objective`.
+
+### 3.4 `run_nsga2`
+
+```python
+def run_nsga2(
+    scheme: str,
+    kernel: str,
+    report_fields: Sequence[str],
+    bounds: Sequence[tuple[float, float]],
+    *,
+    pop_size: int = 40,
+    n_gen: int = 50,
+    seed: int = 1,
+    ref_point: Sequence[float] | None = None,
+    gate_layer: int | None = None,
+    max_layer: int | None = None,
+    verbose: bool = False,
+    objective: Callable[[np.ndarray], np.ndarray] | None = None,
+) -> ParetoResult
+```
+
+Builds a private `ElementwiseProblem` whose `_evaluate` calls the closure
+produced by `make_multi_objective` (unless `objective=` overrides it — a
+test hook so unit tests can plug synthetic analytic problems in without
+importing the Brady2D pipeline), constructs `NSGA2(pop_size=pop_size)` with
+pymoo defaults (SBX crossover, polynomial mutation), and runs
+`minimize(problem, algorithm, ("n_gen", n_gen), seed=seed, callback=...)`.
+After minimization, `res.F` is split into finite and sentinel rows; only
+finite rows populate `ParetoResult.front`, paired with a
+`_report_to_dict(brady2d_stability_score(...))` rebuild for each surviving
+`x`.
+
+Raises `ValueError` on `len(report_fields) < 2`, empty `bounds`, or a
+`ref_point` with mismatched shape.
+
+### 3.5 `_HVCallback`
+
+Private callback attached to the NSGA-II algorithm.  On each generation it
+pulls the current non-dominated set (`algorithm.opt`, not the full
+population history — see pymoo's docs on `Algorithm.opt`), filters rows
+whose objectives are non-finite or `≥ ref_point`, and records the
+hypervolume under the configured reference point.  The resulting
+`hv_trace` and `hv_n_nds` sequences end up in `ParetoResult.hv_trace` and
+`ParetoResult.extras["hv_n_nds"]`.
+
+## 4. CLI
+
+```bash
+cd scripts/stencil_gen
+uv run python -m sweeps pareto --help
+```
+
+The `pareto` subcommand (`sweeps/pareto.py`) mirrors `sweeps optimize`:
+
+| Flag | Description |
+|---|---|
+| `--scheme {E2,E4}` | Required. |
+| `--kernel {classical,tension,gaussian,multiquadric}` | Required. |
+| `--objectives FIELD [FIELD ...]` | Two or more dotted paths into `StabilityReport`. |
+| `--bounds LO HI [LO HI ...]` | Flat list of bound pairs; falls back to `DEFAULT_BOUNDS[(scheme,kernel)]`. |
+| `--pop-size N` | NSGA-II population. Default 40. |
+| `--n-gen N` | NSGA-II generations. Default 50. |
+| `--seed N` | Algorithm seed. Default 1. |
+| `--ref-point V [V ...]` | Override the hypervolume reference point (else auto-picked). |
+| `--gate-layer N` | Override the feasibility gate depth (else `max_layer - 1`). |
+| `--max-layer N` | Override pipeline depth (else `max(infer_max_layer(f))`). |
+| `--persist` | Write JSON to `sweeps/pareto_fronts/<scheme>_<kernel>_<mangled>.json`. |
+| `--validate-with-cpp` | Re-run up to 10 front members at L8 via the shoccs binary. |
+| `--verbose` | Forward to pymoo's `minimize(verbose=True)`. |
+
+The driver prints a summary (front size, final hypervolume, top-5 members
+ordered by each objective) after the run, validates (if requested), then
+persists (if requested).  Validation runs *before* persistence so the JSON
+captures `extras["cpp_validation"]` when both flags are set (plan 45.5a.1).
+
+### 4.1 Example — classical-α E4, 2D Pareto front
+
+```bash
+SYMPY_CACHE_SIZE=50000 uv run python -m sweeps pareto \
+    --scheme E4 --kernel classical \
+    --objectives layer1.boundary_gv_err layer_bl42.max_spectral_abscissa \
+    --bounds -2 2 0.05 2 \
+    --pop-size 40 --n-gen 30 --seed 1 --persist
+```
+
+This is the 45.6a.1 calibration run.  Produces a ~19-member front at
+`sweeps/pareto_fronts/E4_classical_layer1_boundary_gv_err__layer_bl42_max_spectral_abscissa.json`
+straddling the 1e-10 BL42 threshold: at one end a
+`(gv_err ≈ 0.047, BL42 ≈ 7e-15)` stability-focused closure near
+`α ≈ (-1.54, 0.31)`; at the other end a `(gv_err ≈ 2.9e-3, BL42 ≈ 0.42)`
+dispersion-focused closure near `α ≈ (-0.26, 0.05)`.  Wall time ~6 min on
+the dev container.
+
+### 4.2 Example — tension E4, 1D Pareto front
+
+```bash
+SYMPY_CACHE_SIZE=50000 uv run python -m sweeps pareto \
+    --scheme E4 --kernel tension \
+    --objectives layer1.boundary_gv_err layer_bl42.max_spectral_abscissa \
+    --bounds 0.5 20 \
+    --pop-size 20 --n-gen 20 --seed 1 --persist
+```
+
+The 45.6a.2 calibration run.  Both objectives are monotone non-decreasing
+in σ over `[0.5, 20]`, so the Pareto front collapses to a single point at
+the lower bound (σ = 0.5, `gv_err ≈ 2.2e-2`, `BL42 ≈ 0.65`).  This is the
+correct mathematical answer, not an optimizer failure — tension exposes the
+same qualitative story as classical (cleaner `gv_err`, worse BL42) but on a
+1D parameter space the trade-off lives on a monotone curve and Pareto
+dominance picks a single winner.
+
+### 4.3 Example — classical-α E4, 3-objective run
+
+```bash
+SYMPY_CACHE_SIZE=50000 uv run python -m sweeps pareto \
+    --scheme E4 --kernel classical \
+    --objectives layer1.boundary_gv_err \
+                 layer_bl42.max_spectral_abscissa \
+                 layer6.transient_growth_bound \
+    --bounds -2 2 0.05 2 \
+    --pop-size 60 --n-gen 40 --seed 1 \
+    --validate-with-cpp --persist
+```
+
+Exploratory 3D front.  `max_layer` auto-infers to 6 and `gate_layer` to 5,
+so L1/L2/L3/L3r/L4/L5 must all pass before the point contributes a finite
+triple.  Front size scales superlinearly with `n_obj`; pop_size=60 is the
+recommended minimum for three objectives.
+
+## 5. Persistence
+
+Each `--persist`ed run writes a single JSON file under
+`sweeps/pareto_fronts/`.  The filename is
+`{scheme}_{kernel}_{mangled_objectives}.json`, where the mangler replaces
+`.` with `_` inside each field and joins fields with `__`:
+
+```
+layer1.boundary_gv_err, layer_bl42.max_spectral_abscissa
+  → layer1_boundary_gv_err__layer_bl42_max_spectral_abscissa
+```
+
+Top-level JSON keys are emitted in a fixed order (see
+`sweeps/_pareto_io.py::_result_to_ordered`):
+
+```
+scheme, kernel, method, objective_fields, bounds,
+pop_size, n_gen, n_evals, seed, compute_time,
+ref_point, hv_trace, front, extras
+```
+
+Each `front[i]` carries `(x, params, objectives, report)`.  The `report`
+dict is the same shape produced by `_report_to_dict` in
+`stencil_gen/optimizer.py`; since plan 45.6a.1.1 it includes `layer_bl42`
+alongside the existing `layer1`–`layer8` entries, so a persisted BL42
+objective carries the full per-layer diagnostic context.
+
+`sweeps/_pareto_io.py` exposes:
+
+- `save_pareto_front(result, directory=PARETO_FRONTS_DIR) -> Path`
+- `load_pareto_front(path) -> dict`
+- `iter_pareto_fronts(directory=PARETO_FRONTS_DIR) -> Iterator[Path]`
+
+The load helper returns a raw dict rather than a reconstructed
+`ParetoResult`; the regression test in
+`tests/test_phs.py::TestRegressionBrady2DPareto` reads that dict, rebuilds
+`make_multi_objective(scheme, kernel, objective_fields)`, evaluates at
+each stored `x`, and asserts recomputed objectives match stored values
+within 1% relative tolerance (which holds bit-exact under the deterministic
+ARPACK regime of plan 45.6b.1).
+
+## 6. Reference-point selection
+
+Hypervolume is undefined unless the reference point dominates every front
+member.  `run_nsga2` auto-picks `ref_point` by:
+
+1. Drawing 20 uniform-random samples inside `bounds` with a seeded
+   `numpy.random.Generator`.
+2. Dropping sentinel rows (`y[i] >= _PARETO_SENTINEL` for any `i`).
+3. Taking `1.1 * max(finite_rows, axis=0)`.
+4. Clipping the result to `[1.0, _PARETO_SENTINEL)` so pymoo's HV stays
+   well-defined even for extremely small objective values (e.g.
+   `layer_bl42.max_spectral_abscissa ~ 1e-15`).
+
+If the probe phase finds no feasible sample, `ref_point` falls back to the
+all-ones vector.  The resulting hypervolume will be zero, but `ParetoResult`
+is still total — callers key off `len(front) > 0`, not HV.
+
+Override with `--ref-point` or `run_nsga2(..., ref_point=...)` when you
+want the indicator pinned to a known, problem-specific cap — e.g. when
+comparing two runs that must share a normalization.
+
+## 7. Cascade integration — `gate_layer` / `max_layer` auto-infer
+
+Both `make_objective` (scalar, plan 45.0b) and `make_multi_objective`
+(vector, plan 45.1b) share the same `gate_layer` convention:
+
+- `max_layer` defaults to `max(_infer_max_layer(f) for f in fields)`.
+- `gate_layer` defaults to `max(max_layer - 1, 0)`.
+
+So an objective living "in" layer N gates at layer N-1.  For the vector
+case this means a mixed objective list like
+`[layer1.boundary_gv_err, layer_bl42.max_spectral_abscissa]` runs the
+cascade to layer 3 (bl42 lives there), gating at layer 2 — precisely the
+depth needed to populate both objectives while still rejecting
+infeasible-at-layer-2 points early.
+
+The `_PARETO_SENTINEL` replaces `+inf` on any gate trip: hypervolume and
+NSGA-II's `ftol` termination both break on `inf`, but finite `1e12` keeps
+the indicator well-defined and lets the evolutionary dynamics migrate
+away from infeasible basins.
+
+## 8. Relationship to `gv-stability-pareto`
+
+Two CLI subcommands exist with "pareto" in the name — they are
+complementary, not alternatives:
+
+- `python -m sweeps pareto` (plan 45; this document): *optimizer*.
+  NSGA-II evolves a population toward the Pareto front of a user-picked
+  pair/triple of `StabilityReport` fields.  Output is a per-run JSON with
+  `(x, params, objectives, report)` tuples.
+- `python -m sweeps gv-stability-pareto` (plan 43 era): *read-only 1D scan
+  with dominance filter*.  Evaluates a single kernel's 1D parameter sweep,
+  applies a post-hoc non-domination filter over a fixed pair of
+  scientifically interesting metrics, and prints a table.  No RNG, no
+  population dynamics.
+
+The 1D scan is preserved as a research and documentation aid; when you
+need an *optimizer* (2D+ parameter space, or genuinely global exploration),
+reach for the NSGA-II driver.
+
+## 9. Known limitations
+
+- **NSGA-III.** 4+ objectives are supported by
+  `pymoo.algorithms.moo.nsga3.NSGA3(ref_dirs=...)`; this driver only ships
+  NSGA-II.  Wrap the driver if needed — the `_StabilityProblem` inner class
+  is algorithm-agnostic.
+- **No weighted scalarization CLI.**  If you need a single weighted scalar
+  (e.g. `--objective "0.5*a + 0.5*b"`), use the scalar `make_objective`
+  with a lambda wrapper or promote it to plan 45.x.
+- **No multi-fidelity Bayesian optimization.**  Deferred to a later plan.
+- **Kernel scope matches plan 43.** `tension-penalty` and `mixed-ε` are
+  out of scope for the same reason: `brady2d_stability_score` does not
+  route those kernels through the full cascade.
+- **Plots are not produced.** Fronts persist as JSON; visualization lives
+  downstream (notebook consumers, dashboard scripts).
+
+## 10. References
+
+- Plan 41 — Brady-Livescu 2D analytical stability pipeline (L1–L7).
+- Plan 42 — C++ bridge runtime-parameterized stencils (L8).
+- Plan 43 — Stability optimization framework (scalar drivers).
+- Plan 44 — L3r BL42 reflecting-BC layer (the objective the Pareto driver
+  most often wants).
+- Plan 45 — Multi-objective Pareto optimization (this layer).
+- Deb, K., Pratap, A., Agarwal, S., & Meyarivan, T. (2002). "A fast and
+  elitist multiobjective genetic algorithm: NSGA-II." *IEEE Transactions on
+  Evolutionary Computation*, 6(2), 182-197.
+- pymoo 0.6 documentation:
+  - https://pymoo.org/getting_started/part_2.html
+  - https://pymoo.org/algorithms/moo/nsga2.html
+  - https://pymoo.org/misc/indicators.html

--- a/scripts/stencil_gen/stencil_gen/benchmarks/brady_livescu_2d.py
+++ b/scripts/stencil_gen/stencil_gen/benchmarks/brady_livescu_2d.py
@@ -1,0 +1,121 @@
+"""Brady & Livescu 2019 §4.3 two-dimensional varying-coefficient benchmark.
+
+Reference problem from:
+  Brady, P.T. and Livescu, D. (2019). "High-order, stable, and conservative
+  boundary schemes for central and compact finite differences."
+  Computers & Fluids, 183, pp. 84-101.
+
+Section 4.3 (pp. 92-94) defines the 2D scalar advection test:
+
+    u_t + grad(psi) . grad(u) = 0    on [0, sqrt(2)]^2, t in [0, 1000]
+
+    psi(x, y) = sqrt((x + 0.25)^2 + (y + 0.25)^2)
+    c_x(x, y) = (x + 0.25) / psi(x, y)
+    c_y(x, y) = (y + 0.25) / psi(x, y)
+
+    u(x, y, 0) = sin(2*pi*psi(x, y))
+    u(0, y, t) = sin(2*pi*(psi(0, y) - t))    (inflow, Dirichlet)
+    u(x, 0, t) = sin(2*pi*(psi(x, 0) - t))    (inflow, Dirichlet)
+
+    Exact: u(x, y, t) = sin(2*pi*(psi(x, y) - t))
+
+The coefficient field (c_x, c_y) is a unit radial vector pointing away from
+(-0.25, -0.25), giving a smooth, spatially-varying advection velocity that
+tests stability and accuracy of boundary closures under non-constant
+coefficients.
+"""
+
+import math
+
+import numpy as np
+
+L_DOMAIN: float = math.sqrt(2.0)
+"""Domain side length: sqrt(2)."""
+
+PSI_OFFSET: float = 0.25
+"""Offset in the stream function: psi = sqrt((x + 0.25)^2 + (y + 0.25)^2)."""
+
+
+def psi(x, y):
+    """Stream function psi(x, y) = sqrt((x + 0.25)^2 + (y + 0.25)^2).
+
+    Vectorized: accepts scalar or array inputs.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    return np.sqrt((x + PSI_OFFSET) ** 2 + (y + PSI_OFFSET) ** 2)
+
+
+def c_x(x, y):
+    """x-component of the advection velocity: (x + 0.25) / psi(x, y).
+
+    Vectorized: accepts scalar or array inputs.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    return (x + PSI_OFFSET) / psi(x, y)
+
+
+def c_y(x, y):
+    """y-component of the advection velocity: (y + 0.25) / psi(x, y).
+
+    Vectorized: accepts scalar or array inputs.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    return (y + PSI_OFFSET) / psi(x, y)
+
+
+def exact_solution(x, y, t):
+    """Exact solution u(x, y, t) = sin(2*pi*(psi(x, y) - t)).
+
+    Vectorized: accepts scalar or array inputs.
+    """
+    return np.sin(2.0 * np.pi * (psi(x, y) - t))
+
+
+def initial_condition(x, y):
+    """Initial condition u(x, y, 0) = sin(2*pi*psi(x, y)).
+
+    Equivalent to exact_solution(x, y, 0).
+    """
+    return exact_solution(x, y, 0.0)
+
+
+def inflow_bc_x(y, t):
+    """Inflow Dirichlet BC at x=0: u(0, y, t) = sin(2*pi*(psi(0, y) - t))."""
+    return exact_solution(0.0, y, t)
+
+
+def inflow_bc_y(x, t):
+    """Inflow Dirichlet BC at y=0: u(x, 0, t) = sin(2*pi*(psi(x, 0) - t))."""
+    return exact_solution(x, 0.0, t)
+
+
+def make_coefficient_field(N: int):
+    """Build the 2D coefficient field on a uniform N x N grid.
+
+    Returns (x, y, c_x_field, c_y_field) on [0, L_DOMAIN]^2.
+    The grid includes all N points in each direction (indices 0..N-1),
+    with inflow boundaries at i=0 (x=0) and j=0 (y=0).
+
+    Parameters
+    ----------
+    N : int
+        Number of grid points in each direction.
+
+    Returns
+    -------
+    x : np.ndarray, shape (N, N)
+        x-coordinates on the 2D grid.
+    y : np.ndarray, shape (N, N)
+        y-coordinates on the 2D grid.
+    c_x_field : np.ndarray, shape (N, N)
+        x-component of advection velocity at each grid point.
+    c_y_field : np.ndarray, shape (N, N)
+        y-component of advection velocity at each grid point.
+    """
+    x1d = np.linspace(0.0, L_DOMAIN, N)
+    y1d = np.linspace(0.0, L_DOMAIN, N)
+    xg, yg = np.meshgrid(x1d, y1d, indexing="ij")
+    return xg, yg, c_x(xg, yg), c_y(xg, yg)

--- a/scripts/stencil_gen/stencil_gen/benchmarks/brady_livescu_4_2.py
+++ b/scripts/stencil_gen/stencil_gen/benchmarks/brady_livescu_4_2.py
@@ -1,0 +1,77 @@
+"""Brady & Livescu 2019 §4.2 reflecting-hyperbolic eigenvalue benchmark.
+
+Reference problem from:
+  Brady, P.T. and Livescu, D. (2019). "High-order, stable, and conservative
+  boundary schemes for central and compact finite differences."
+  Computers & Fluids, 183, pp. 84-101.
+
+Section 4.2 (pp. 91-92) defines the 1D coupled hyperbolic system:
+
+    u_t = v_x
+    v_t = u_x          on [0, 1],  t in [0, 500]
+
+    u(0, t) = 0         (Dirichlet, reflecting)
+    v(1, t) = 0         (Dirichlet, reflecting)
+
+    u(x, 0) = -(3*pi/2) * sin(3*pi*x/2)
+    v(x, 0) = 0
+
+The system is a linearised wave equation with constant unit wave speeds
+(+1 and -1).  The reflecting BCs are energy-conserving, so the continuous
+operator has a purely imaginary spectrum: eigenvalues lambda_k = +/- i*w_k
+where w_k = (2k - 1)*pi/2 for positive integer k.
+
+Exact solution (standing wave from d'Alembert decomposition, Eqs. 50-51):
+
+    u(x, t) = -(3*pi/2) * sin(3*pi*x/2) * cos(3*pi*t/2)
+    v(x, t) = -(3*pi/2) * cos(3*pi*x/2) * sin(3*pi*t/2)
+
+The initial condition excites a single eigenmode (k=2, w = 3*pi/2).
+"""
+
+import numpy as np
+
+L_DOMAIN: float = 1.0
+"""Domain length: [0, 1]."""
+
+
+def initial_u(x: np.ndarray) -> np.ndarray:
+    """Initial condition u(x, 0) = -(3*pi/2) * sin(3*pi*x/2)."""
+    x = np.asarray(x, dtype=float)
+    return -1.5 * np.pi * np.sin(1.5 * np.pi * x)
+
+
+def initial_v(x: np.ndarray) -> np.ndarray:
+    """Initial condition v(x, 0) = 0."""
+    x = np.asarray(x, dtype=float)
+    return np.zeros_like(x)
+
+
+def exact_solution(x: np.ndarray, t: float) -> tuple[np.ndarray, np.ndarray]:
+    """Exact solution (u, v) at time t (Eqs. 50-51 of Brady & Livescu 2019).
+
+    Standing-wave superposition from d'Alembert decomposition:
+        u(x, t) = -(3*pi/2) * sin(3*pi*x/2) * cos(3*pi*t/2)
+        v(x, t) = -(3*pi/2) * cos(3*pi*x/2) * sin(3*pi*t/2)
+
+    Vectorized: accepts scalar or array x.
+    """
+    x = np.asarray(x, dtype=float)
+    omega = 1.5 * np.pi
+    amp = -1.5 * np.pi
+    u = amp * np.sin(omega * x) * np.cos(omega * t)
+    v = amp * np.cos(omega * x) * np.sin(omega * t)
+    return u, v
+
+
+def continuous_eigenvalues(k_max: int = 20) -> np.ndarray:
+    """Continuous eigenvalues of the BL 4.2 operator with reflecting BCs.
+
+    The eigenproblem on [0, 1] with u(0) = 0, v(1) = 0 yields:
+        lambda_k = +/- i * (2k - 1) * pi / 2,   k = 1, 2, ..., k_max
+
+    Returns an array of 2*k_max complex eigenvalues (dtype complex128).
+    """
+    ks = np.arange(1, k_max + 1)
+    omega = (2 * ks - 1) * np.pi / 2.0
+    return np.concatenate([1j * omega, -1j * omega])

--- a/scripts/stencil_gen/stencil_gen/brady2d_stability.py
+++ b/scripts/stencil_gen/stencil_gen/brady2d_stability.py
@@ -1,0 +1,1341 @@
+"""Layered stability scoring for the Brady-Livescu 2D benchmark.
+
+Implements a multi-layer analytical stability pipeline for the Brady & Livescu
+2019 §4.3 two-dimensional varying-coefficient scalar advection test.  Each layer
+is strictly cheaper than the next, allowing early rejection of unstable schemes.
+
+Layers:
+    L1 — Interior + boundary group velocity error (1D, per direction)
+    L2 — Rigorous GKS Kreiss determinant test
+    L3 — 1D eigenvalue max Re(lambda(-D_bc)) at multiple N
+    L4 — Per-point local GV error on the 2D varying-coefficient field
+    L5 — 2D anisotropy over the coefficient field
+    L6 — Non-normality diagnostics (spectral/numerical abscissa, Kreiss constant)
+    L7 — Sparse 2D Arnoldi eigenvalue of the full BL operator
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Literal
+
+import numpy as np
+
+from stencil_gen.gks_kreiss import BoundaryRow, KreissResult, kreiss_stability_check
+from stencil_gen.group_velocity import (
+    GroupVelocityProfile,
+    anisotropy_over_coefficient_field,
+    boundary_group_velocity,
+    boundary_group_velocity_classical,
+    interior_group_velocity,
+    local_group_velocity_2d_varying,
+    max_local_gv_error_2d,
+)
+from stencil_gen.non_normality import (
+    NonNormalityReport,
+    compute_non_normality,
+    spectral_abscissa_sparse,
+)
+from stencil_gen.phs import (
+    build_diff_matrix_rbf,
+    stability_eigenvalue,
+    stability_eigenvalue_from_matrix,
+)
+from stencil_gen.cpp_bridge import BridgeResult, run_cpp_brady2d
+
+logger = logging.getLogger("stencil_gen.brady2d_stability")
+
+# Scheme parameters (duplicated from sweeps._common to avoid circular dep)
+_SCHEME_PARAMS = {
+    "E2": {"p": 1, "q": 1, "nextra": 1, "nu": 1},
+    "E4": {"p": 2, "q": 3, "nextra": 0, "nu": 1},
+}
+
+# Layer-1 thresholds
+L1_TOL = 0.05  # 5% dispersion error
+
+# Layer-3 threshold: max Re(eigenvalue of -D_bc) must be non-positive
+STABILITY_TOL = 1e-10
+
+# Layer-4 threshold: 10% — looser than L1 because the varying-coefficient
+# scaling amplifies the baseline dispersion error.
+L4_TOL = 0.1
+
+# Layer-5 threshold: 5% anisotropy error projected onto local propagation direction.
+L5_TOL = 0.05
+
+# BL §4.2 tolerance: continuous spectrum is exactly imaginary; tight tolerance.
+BL42_TOL = 1e-10
+
+# Fraction of the resolved band over which to measure max |gv_error|.
+# Using 10% of the cutoff restricts evaluation to very well-resolved
+# wavenumbers where even boundary stencils (especially the outermost
+# one-sided row) are expected to be accurate.  This makes L1 a coarse
+# filter that only rejects schemes with fundamentally broken dispersion.
+_RESOLVED_FRAC = 0.1
+
+
+@dataclass
+class StabilityReport:
+    """Result of the layered stability analysis.
+
+    Each layer populates its corresponding field with a dict of per-layer
+    metrics.  If a layer is not run (skipped or short-circuited), its field
+    remains None.
+
+    Numeric ``layerN`` are the primary cascade; ``layer_bl42`` runs during
+    the L3 tier (parallel 1D eigenvalue check on the Brady-Livescu §4.2
+    reflecting-hyperbolic model problem).
+    """
+
+    layer1: dict | None = None
+    layer2: KreissResult | None = None
+    layer3: dict | None = None
+    layer4: dict | None = None
+    layer5: dict | None = None
+    layer6: dict | None = None  # reserved for standalone non-normality
+    layer7: dict | None = None
+    layer8: dict | None = None
+    layer_bl42: dict | None = None
+    non_normality: NonNormalityReport | None = None
+    kreiss: KreissResult | None = None
+    overall_verdict: Literal["pass", "fail", "unknown"] = "unknown"
+    failed_layer: int | None = None
+    failed_reason: str = ""
+    compute_time: float = 0.0
+
+    @classmethod
+    def empty(cls) -> StabilityReport:
+        """Create an empty report with all layers set to None."""
+        return cls()
+
+    def __str__(self) -> str:
+        """Per-layer summary table."""
+        lines = ["Brady-Livescu 2D Stability Report"]
+        lines.append("=" * 60)
+
+        # Layer 1
+        if self.layer1 is not None:
+            d = self.layer1
+            status = "PASS" if d.get("boundary_gv_err", 1.0) <= L1_TOL else "FAIL"
+            lines.append(
+                f"L1  GV error        : {status:4s}  "
+                f"boundary_gv_err={d.get('boundary_gv_err', float('nan')):.4e}"
+            )
+
+        # Layer 2 (Kreiss)
+        if self.layer2 is not None:
+            kr = self.layer2
+            status = "PASS" if kr.is_stable else "FAIL"
+            lines.append(
+                f"L2  Kreiss GKS      : {status:4s}  "
+                f"sigma_min={kr.witness_sigma_min:.4e}  "
+                f"verdict={kr.imaginary_axis_perturbation_verdict}"
+            )
+
+        # Layer 3
+        if self.layer3 is not None:
+            d = self.layer3
+            mse = d.get("max_stab_eig", float("nan"))
+            status = "PASS" if mse <= STABILITY_TOL else "FAIL"
+            lines.append(
+                f"L3  1D eigenvalue   : {status:4s}  "
+                f"max_stab_eig={mse:.4e}"
+            )
+
+        # Layer 3r (BL §4.2 reflecting hyperbolic)
+        if self.layer_bl42 is not None:
+            d = self.layer_bl42
+            msa = d.get("max_spectral_abscissa", float("nan"))
+            status = "PASS" if msa <= BL42_TOL else "FAIL"
+            per_n = ", ".join(
+                f"{n}:{v:.2e}"
+                for n, v in sorted(d.get("spectral_abscissa_by_n", {}).items())
+            )
+            lines.append(
+                f"L3r BL42 reflecting: {status:4s}  "
+                f"max_re={msa:.4e}  per_n=[{per_n}]"
+            )
+
+        # Layer 4
+        if self.layer4 is not None:
+            d = self.layer4
+            err = d.get("max_local_gv_error", float("nan"))
+            status = "PASS" if err <= L4_TOL else "FAIL"
+            lines.append(
+                f"L4  Local GV 2D     : {status:4s}  "
+                f"max_local_gv_error={err:.4e}"
+            )
+
+        # Layer 5
+        if self.layer5 is not None:
+            d = self.layer5
+            err = d.get("max_aligned_error", float("nan"))
+            status = "PASS" if err <= L5_TOL else "FAIL"
+            lines.append(
+                f"L5  Anisotropy      : {status:4s}  "
+                f"max_aligned_error={err:.4e}"
+            )
+
+        # Layer 6 (standalone 1D non-normality)
+        if self.layer6 is not None:
+            d = self.layer6
+            sa = d.get("spectral_abscissa", float("nan"))
+            tgb = d.get("transient_growth_bound", float("nan"))
+            sa_ok = sa <= STABILITY_TOL
+            tgb_ok = tgb <= L6_TRANSIENT_GROWTH_TOL
+            status = "PASS" if (sa_ok and tgb_ok) else "FAIL"
+            lines.append(
+                f"L6  Non-normality   : {status:4s}  "
+                f"kreiss_K={d.get('kreiss_constant', float('nan')):.2f}  "
+                f"tgb={tgb:.2f}  "
+                f"henrici={d.get('henrici_departure', float('nan')):.4e}"
+            )
+
+        # Layer 7
+        if self.layer7 is not None:
+            d = self.layer7
+            msa = d.get("max_spectral_abscissa", float("nan"))
+            status = "PASS" if msa <= L7_TOL else "FAIL"
+            lines.append(
+                f"L7  2D eigenvalue   : {status:4s}  "
+                f"max_spectral_abscissa={msa:.4e}"
+            )
+
+        # Non-normality (2D, from L7)
+        if self.non_normality is not None and self.layer7 is not None:
+            nn = self.non_normality
+            lines.append(
+                f"L7+ Non-normality  :       "
+                f"kreiss_K={nn.kreiss_constant:.2f}  "
+                f"tgb={nn.transient_growth_bound:.2f}  "
+                f"henrici={nn.henrici_departure:.4e}"
+            )
+
+        # Layer 8
+        if self.layer8 is not None:
+            d = self.layer8
+            stable = bool(d.get("stable", False))
+            linf = float(d.get("final_linf", float("nan")))
+            status = "PASS" if (stable and linf <= L8_FINAL_LINF_TOL) else "FAIL"
+            lines.append(
+                f"L8  C++ simulation  : {status:4s}  "
+                f"final_linf={linf:.4e}  "
+                f"wall={float(d.get('wall_time_s', 0.0)):.2f}s"
+            )
+
+        lines.append("-" * 60)
+        lines.append(
+            f"Overall: {self.overall_verdict.upper()}"
+            + (f"  (failed at layer {self.failed_layer}: {self.failed_reason})"
+               if self.failed_layer is not None else "")
+        )
+        lines.append(f"Compute time: {self.compute_time:.2f}s")
+        return "\n".join(lines)
+
+
+def _gv_error_scalar(profile: GroupVelocityProfile) -> float:
+    """Max absolute GV error in the resolved portion of the spectrum.
+
+    Evaluates over xi in (0, cutoff_xi * _RESOLVED_FRAC], giving a
+    conservative measure that focuses on wavenumbers the scheme is expected
+    to resolve well.
+    """
+    xi_max = profile.cutoff_xi * _RESOLVED_FRAC
+    mask = (profile.xi > 0) & (profile.xi <= xi_max)
+    if not np.any(mask):
+        return 1.0  # no resolved wavenumbers → maximum error
+    return float(np.max(np.abs(profile.gv_error[mask])))
+
+
+def _derive_classical_boundary(p: int, nu: int, alpha_list: list[float]):
+    """Derive classical boundary rows with conservation and substitute alphas.
+
+    Parameters
+    ----------
+    p : int
+        Interior half-bandwidth.
+    nu : int
+        Derivative order.
+    alpha_list : list[float]
+        Alpha values ordered by symbol index (alpha_0, alpha_1, ...).
+
+    Returns
+    -------
+    (updated_rows, alpha_values_dict)
+        updated_rows: list[BoundaryRow] with conservation applied.
+        alpha_values_dict: {Symbol: float} mapping for substitution.
+    """
+    from stencil_gen.boundary import derive_boundary
+    from stencil_gen.conservation import build_conservation_system, solve_conservation
+
+    result = derive_boundary(p=p, nu=nu, s=0)
+    equations, w_syms, last_free = build_conservation_system(
+        result.r, result.t, p, result.rows, result.interior_coeffs,
+    )
+    _, updated_rows = solve_conservation(
+        equations, w_syms, last_free, result.all_free_params, result.rows,
+    )
+    alpha_values = dict(zip(result.all_free_params, alpha_list))
+    return updated_rows, alpha_values
+
+
+def layer1_interior_boundary_gv(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    n_xi: int = 200,
+) -> dict:
+    """L1: Interior + boundary group velocity error (1D, per direction).
+
+    Checks dispersion quality by computing GV error profiles for the interior
+    and boundary stencils, then reducing each to a single scalar (max absolute
+    error over the well-resolved portion of the spectrum).
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.  For classical: {"alpha": [float, ...]}.
+        For RBF kernels: {"sigma": float} or {"epsilon": float}.
+    n_xi : int
+        Number of wavenumber samples in [0.01, pi].
+
+    Returns
+    -------
+    dict with keys:
+        interior_gv_err_x : float
+            Max |gv_error| for interior stencil over resolved wavenumbers.
+        interior_gv_err_y : float
+            Same as x (Cartesian grid → identical stencil in both directions).
+        boundary_gv_err : float
+            Max over all boundary rows of max |gv_error| over resolved band.
+        cutoff_fraction : float
+            min(cutoff_xi) over boundary rows / pi.
+    """
+    sp = _SCHEME_PARAMS[scheme]
+    p, q, nextra, nu = sp["p"], sp["q"], sp["nextra"], sp["nu"]
+    xi_array = np.linspace(0.01, np.pi, n_xi)
+
+    # Interior GV profile (same stencil for x and y on Cartesian grid)
+    interior_prof = interior_group_velocity(p, nu, xi_array)
+    interior_err = _gv_error_scalar(interior_prof)
+
+    # Boundary GV profiles
+    if kernel == "classical":
+        alpha_list = params["alpha"]
+        boundary_rows, alpha_values = _derive_classical_boundary(p, nu, alpha_list)
+        boundary_profiles = boundary_group_velocity_classical(
+            boundary_rows, alpha_values, order=q, xi_array=xi_array,
+        )
+    else:
+        # RBF kernels: sigma for tension, epsilon for gaussian/multiquadric
+        sigma = params.get("sigma", params.get("epsilon", 0.0))
+        boundary_profiles = boundary_group_velocity(
+            p, q, nextra, nu, sigma, kernel, xi_array,
+        )
+
+    # Scalar reductions
+    boundary_errs = [_gv_error_scalar(prof) for prof in boundary_profiles.values()]
+    max_boundary_err = max(boundary_errs) if boundary_errs else 0.0
+
+    cutoffs = [prof.cutoff_xi for prof in boundary_profiles.values()]
+    min_cutoff = min(cutoffs) if cutoffs else 0.0
+    cutoff_frac = min_cutoff / np.pi
+
+    return {
+        "interior_gv_err_x": interior_err,
+        "interior_gv_err_y": interior_err,
+        "boundary_gv_err": max_boundary_err,
+        "cutoff_fraction": cutoff_frac,
+    }
+
+
+def _extract_stencil_data(
+    D: np.ndarray, p: int,
+) -> tuple[np.ndarray, np.ndarray, list[BoundaryRow]]:
+    """Extract interior weights/offsets and boundary rows from a D matrix.
+
+    Uses the middle row for interior weights and the first p rows as
+    boundary rows (matching the number of admissible kappa roots for a
+    2p+1-point centered stencil in the GKS framework).
+
+    Parameters
+    ----------
+    D : np.ndarray
+        Full N×N differentiation matrix.
+    p : int
+        Interior half-bandwidth.
+
+    Returns
+    -------
+    (interior_weights, interior_offsets, boundary_rows)
+    """
+    n = D.shape[0]
+    mid = n // 2
+    offsets = np.arange(-p, p + 1)
+    interior_weights = D[mid, mid + offsets]
+
+    boundary_rows: list[BoundaryRow] = []
+    for i in range(p):
+        brow = D[i, :]
+        bcols = np.nonzero(np.abs(brow) > 1e-15)[0]
+        boundary_rows.append((brow[bcols], bcols))
+
+    return interior_weights, offsets, boundary_rows
+
+
+def layer2_kreiss_gks(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    n: int = 20,
+) -> KreissResult:
+    """L2: rigorous GKS Kreiss determinant stability check.
+
+    Builds the 1D differentiation matrix, extracts the interior stencil and
+    boundary rows, and runs the full Kreiss determinant sweep to test for
+    boundary-closure instability.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.
+    n : int
+        Grid size for the 1D differentiation matrix.
+
+    Returns
+    -------
+    KreissResult
+        Full Kreiss determinant result including stability verdict.
+    """
+    sp = _SCHEME_PARAMS[scheme]
+    p, q, nextra, nu = sp["p"], sp["q"], sp["nextra"], sp["nu"]
+
+    if kernel == "classical":
+        D = _build_classical_diff_matrix(n, p, nu, params["alpha"])
+    else:
+        epsilon = params.get("sigma", params.get("epsilon", 0.0))
+        D = build_diff_matrix_rbf(n, p, q, epsilon, kernel, nu, nextra)
+
+    interior_weights, interior_offsets, boundary_rows = _extract_stencil_data(D, p)
+
+    return kreiss_stability_check(
+        interior_weights, interior_offsets, boundary_rows,
+        s_grid_params={"s_max": 10.0, "n_radial": 30, "n_imag": 80, "imag_max": 15.0},
+    )
+
+
+def _build_classical_diff_matrix(
+    n: int,
+    p: int,
+    nu: int,
+    alpha_list: list[float],
+) -> np.ndarray:
+    """Build an n×n differentiation matrix for the classical-alpha family.
+
+    Uses the TEMO boundary derivation with conservation enforcement,
+    substitutes alpha values, and assembles the full matrix with
+    antisymmetric (nu=1) right boundary closure.
+
+    Requires p >= 2 (E4+).  For E2 (p=1) the boundary closure has zero free
+    alpha parameters — ``derive_boundary(p=1)`` computes a negative symbol
+    count and crashes.  Use the RBF path (``kernel="tension"``, ``sigma=0.0``)
+    for E2 instead.
+    """
+    from stencil_gen.interior import derive_interior, full_gamma_array
+
+    boundary_rows, alpha_values = _derive_classical_boundary(p, nu, alpha_list)
+
+    # Dimensions come from the boundary derivation itself
+    r = len(boundary_rows)
+    t = len(boundary_rows[0].coefficients)
+
+    # Build numeric boundary block
+    B = np.zeros((r, t))
+    for i, brow in enumerate(boundary_rows):
+        for j, coeff in enumerate(brow.coefficients):
+            B[i, j] = float(coeff.subs(alpha_values))
+
+    # Interior weights
+    interior_coeffs = derive_interior(0, p, nu)
+    interior_w = [float(c) for c in full_gamma_array(interior_coeffs)]
+
+    # Assemble full matrix
+    D = np.zeros((n, n))
+    # Left boundary
+    for i in range(r):
+        for j in range(t):
+            D[i, j] = B[i, j]
+    # Interior
+    for i in range(r, n - r):
+        for k_idx, j in enumerate(range(i - p, i + p + 1)):
+            D[i, j] = interior_w[k_idx]
+    # Right boundary (antisymmetric for nu=1)
+    sign = -1 if nu % 2 == 1 else 1
+    for i in range(r):
+        row = n - 1 - i
+        for j in range(t):
+            D[row, n - 1 - j] = sign * B[i, j]
+    return D
+
+
+def layer3_1d_eigenvalue(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    n_values: tuple[int, ...] = (20, 40, 80),
+) -> dict:
+    """L3: 1D eigenvalue stability check at multiple grid sizes.
+
+    For each grid size n, computes the maximum real part of eigenvalues of
+    -D_bc (the semi-discrete advection operator with inflow BC removed).
+    A non-positive value means the 1D constant-coefficient scheme is stable.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.  For classical: {"alpha": [float, ...]}.
+        For RBF kernels: {"sigma": float} or {"epsilon": float}.
+    n_values : tuple[int, ...]
+        Grid sizes at which to evaluate stability.
+
+    Returns
+    -------
+    dict with keys:
+        eigenvalues : dict[int, float]
+            {n: max_real_eigenvalue} for each grid size.
+        max_stab_eig : float
+            Maximum over all grid sizes.
+    """
+    sp = _SCHEME_PARAMS[scheme]
+    p, q, nextra, nu = sp["p"], sp["q"], sp["nextra"], sp["nu"]
+
+    eigenvalues = {}
+    for n in n_values:
+        if kernel == "classical":
+            alpha_list = params["alpha"]
+            D = _build_classical_diff_matrix(n, p, nu, alpha_list)
+            se = stability_eigenvalue_from_matrix(D)
+        else:
+            epsilon = params.get("sigma", params.get("epsilon", 0.0))
+            se = stability_eigenvalue(n, p, q, epsilon, kernel, nu, nextra)
+        eigenvalues[n] = se
+
+    return {
+        "eigenvalues": eigenvalues,
+        "max_stab_eig": max(eigenvalues.values()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# BL §4.2 reflecting-hyperbolic block operator
+# ---------------------------------------------------------------------------
+
+
+def build_bl42_operator(D: np.ndarray) -> "scipy.sparse.csr_matrix":
+    """Build the reduced 2×2 block operator for Brady-Livescu §4.2.
+
+    Constructs L = [[0, D/h], [D/h, 0]] for the coupled hyperbolic system
+    u_t = v_x, v_t = u_x on [0, 1], then removes the Dirichlet DOFs
+    (u at x=0, v at x=1) to produce the (2N-2) × (2N-2) reduced operator.
+
+    Parameters
+    ----------
+    D : np.ndarray
+        1D differentiation matrix of shape (N, N) on a unit-spaced grid.
+
+    Returns
+    -------
+    scipy.sparse.csr_matrix
+        Reduced operator of shape (2N-2, 2N-2).
+    """
+    import scipy.sparse as sp
+
+    from stencil_gen.benchmarks.brady_livescu_4_2 import L_DOMAIN
+
+    N = D.shape[0]
+    h = L_DOMAIN / (N - 1)
+    D_scaled = sp.csr_matrix(D) / h
+
+    Z = sp.csr_matrix((N, N))
+    L_full = sp.bmat([[Z, D_scaled], [D_scaled, Z]], format="csr")
+
+    keep = np.concatenate([np.arange(1, N), np.arange(N, 2 * N - 1)])
+    L_red = L_full[np.ix_(keep, keep)]
+    return L_red.tocsr()
+
+
+def layer_bl42_reflecting_hyperbolic(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    n_values: tuple[int, ...] = (21, 41, 81),
+) -> dict:
+    """L3r: BL §4.2 reflecting-hyperbolic eigenvalue stability check.
+
+    For each grid size N, builds the 2×2 block operator for the coupled
+    hyperbolic system u_t = v_x, v_t = u_x with reflecting BCs, and
+    computes the spectral abscissa.  The continuous spectrum is purely
+    imaginary; any positive real part indicates boundary-closure instability.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.
+    n_values : tuple[int, ...]
+        Grid sizes at which to evaluate stability.
+
+    Returns
+    -------
+    dict with keys:
+        spectral_abscissa_by_n : dict[int, float]
+            {N: max Re(lambda)} for each grid size.
+        max_spectral_abscissa : float
+            Maximum over all grid sizes.
+        purely_imaginary : bool
+            True iff max_spectral_abscissa < BL42_TOL.
+    """
+    sp = _SCHEME_PARAMS[scheme]
+    p, q, nextra, nu = sp["p"], sp["q"], sp["nextra"], sp["nu"]
+
+    spectral_abscissa_by_n = {}
+    for N in n_values:
+        if kernel == "classical":
+            D = _build_classical_diff_matrix(N, p, nu, params["alpha"])
+        else:
+            epsilon = params.get("sigma", params.get("epsilon", 0.0))
+            D = build_diff_matrix_rbf(N, p, q, epsilon, kernel, nu, nextra)
+        L_red = build_bl42_operator(D)
+        max_re, _ = spectral_abscissa_sparse(L_red, k=10)
+        spectral_abscissa_by_n[N] = max_re
+
+    max_sa = max(spectral_abscissa_by_n.values())
+    return {
+        "spectral_abscissa_by_n": spectral_abscissa_by_n,
+        "max_spectral_abscissa": max_sa,
+        "purely_imaginary": max_sa < BL42_TOL,
+    }
+
+
+def layer4_local_gv_2d(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    N: int = 31,
+) -> dict:
+    """L4: per-point local group velocity error on the Brady-Livescu 2D field.
+
+    Freezes coefficients at each grid point and evaluates the interior stencil's
+    group velocity error scaled by the local wave speed.  This is the first-order
+    WKB approximation to the varying-coefficient dispersion error.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type (unused for interior stencil — interior weights are
+        scheme-determined — but kept for API consistency with other layers).
+    params : dict
+        Kernel-specific parameters (unused at this layer).
+    N : int
+        Grid resolution for the coefficient field.
+
+    Returns
+    -------
+    dict with keys:
+        max_local_gv_error : float
+            Maximum absolute local GV error over all grid points and wavenumbers.
+        worst_point : tuple[int, int]
+            (i, j) indices of the grid point with the largest error.
+        worst_xi : float
+            Wavenumber at which the largest error occurs.
+    """
+    from stencil_gen.benchmarks.brady_livescu_2d import make_coefficient_field
+    from stencil_gen.interior import derive_interior, full_gamma_array
+
+    sp = _SCHEME_PARAMS[scheme]
+    p, nu = sp["p"], sp["nu"]
+
+    # Build interior stencil (same for x and y on Cartesian grid)
+    coeffs = derive_interior(0, p, nu)
+    w = np.array([float(c) for c in full_gamma_array(coeffs)])
+    offsets = np.arange(-p, p + 1, dtype=float)
+    stencil = (w, offsets)
+
+    # Compute the interior GV profile to determine the resolved band cutoff
+    profile = interior_group_velocity(p, nu, np.linspace(0.01, np.pi, 200))
+    xi_max = profile.cutoff_xi * _RESOLVED_FRAC
+    xi_array = np.linspace(0.01, xi_max, 200)
+
+    _, _, c_x, c_y = make_coefficient_field(N)
+
+    result = local_group_velocity_2d_varying(stencil, stencil, c_x, c_y, xi_array)
+
+    # Compute max absolute error over all points and the resolved band
+    err_x = np.abs(result["gv_error_x_field"])
+    err_y = np.abs(result["gv_error_y_field"])
+    combined = np.maximum(err_x, err_y)
+    max_err = float(np.max(combined))
+
+    # Find the worst point and wavenumber
+    flat_idx = int(np.argmax(combined))
+    i, j, k = np.unravel_index(flat_idx, combined.shape)
+
+    return {
+        "max_local_gv_error": max_err,
+        "worst_point": (int(i), int(j)),
+        "worst_xi": float(xi_array[k]),
+    }
+
+
+def layer5_anisotropy(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    N: int = 31,
+) -> dict:
+    """L5: 2D anisotropy error projected onto the Brady-Livescu coefficient field.
+
+    Evaluates the scheme's angular group velocity error at a representative
+    wavenumber, then projects onto the local propagation direction at each
+    grid point of the varying-coefficient field.  This detects grid anisotropy
+    interacting with the radial flow pattern of the BL benchmark.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type (unused — interior anisotropy is scheme-determined — but
+        kept for API consistency with other layers).
+    params : dict
+        Kernel-specific parameters (unused at this layer).
+    N : int
+        Grid resolution for the coefficient field.
+
+    Returns
+    -------
+    dict with keys:
+        max_aligned_error : float
+            Maximum |C_numerical - C_exact| projected onto local propagation.
+        worst_point : tuple[int, int]
+            (i, j) index of the grid point with the largest error.
+        worst_theta : float
+            Local propagation angle at the worst point.
+    """
+    from stencil_gen.benchmarks.brady_livescu_2d import make_coefficient_field
+
+    sp = _SCHEME_PARAMS[scheme]
+    p, nu = sp["p"], sp["nu"]
+
+    _, _, c_x, c_y = make_coefficient_field(N)
+
+    # Cover the range of local propagation angles in the BL field.
+    # The BL field has angles in (0, pi/4) approximately (first quadrant,
+    # below the diagonal), so [0.01, pi/2 - 0.01] comfortably covers it.
+    theta_array = np.linspace(0.01, np.pi / 2 - 0.01, 200)
+
+    # Use a representative wavenumber at 20% of the cutoff — inside the
+    # well-resolved band but large enough for anisotropy to be visible.
+    profile = interior_group_velocity(p, nu, np.linspace(0.01, np.pi, 200))
+    xi_mag = profile.cutoff_xi * 0.2
+
+    return anisotropy_over_coefficient_field(scheme, c_x, c_y, theta_array, xi_mag)
+
+
+def layer6_non_normality(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    n: int = 80,
+) -> dict:
+    """L6: non-normality diagnostics on the 1D differentiation matrix.
+
+    Runs the full non-normality analysis (spectral/numerical abscissa, Henrici
+    departure, Kreiss constant, transient growth bound) on the 1D first-derivative
+    operator with inflow BC removed.  This is cheaper than the 2D L7 check
+    (~seconds vs ~tens of seconds) and catches operators with dangerous transient
+    growth even when eigenvalues are stable.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.
+    n : int
+        Grid size for the 1D differentiation matrix.
+
+    Returns
+    -------
+    dict with keys:
+        spectral_abscissa : float
+        numerical_abscissa : float
+        henrici_departure : float
+        kreiss_constant : float
+        transient_growth_bound : float
+        compute_time : float
+        non_normality_report : NonNormalityReport
+    """
+    sp = _SCHEME_PARAMS[scheme]
+    p, q, nextra, nu = sp["p"], sp["q"], sp["nextra"], sp["nu"]
+
+    if kernel == "classical":
+        D = _build_classical_diff_matrix(n, p, nu, params["alpha"])
+    else:
+        epsilon = params.get("sigma", params.get("epsilon", 0.0))
+        D = build_diff_matrix_rbf(n, p, q, epsilon, kernel, nu, nextra)
+
+    # Remove inflow row/column (row 0) to form the semi-discrete operator
+    # for the homogeneous stability problem: -D_bc
+    L_1d = -D[1:, 1:]
+
+    report = compute_non_normality(L_1d)
+    logger.debug(
+        "L6 %s/%s n=%d: spectral_abscissa=%.6e, kreiss_K=%.2f, "
+        "tgb=%.2f, compute_time=%.1fs",
+        scheme, kernel, n, report.spectral_abscissa,
+        report.kreiss_constant, report.transient_growth_bound,
+        report.compute_time,
+    )
+
+    return {
+        "spectral_abscissa": report.spectral_abscissa,
+        "numerical_abscissa": report.numerical_abscissa,
+        "henrici_departure": report.henrici_departure,
+        "kreiss_constant": report.kreiss_constant,
+        "transient_growth_bound": report.transient_growth_bound,
+        "compute_time": report.compute_time,
+        "non_normality_report": report,
+    }
+
+
+def build_sparse_2d_operator(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    N: int,
+) -> tuple:
+    """Build the sparse 2D semi-discrete operator for the Brady-Livescu benchmark.
+
+    Constructs the full N²×N² advection operator L = -(Cx @ Dx_2D + Cy @ Dy_2D)
+    using Kronecker products of 1D differentiation matrices, then removes inflow
+    rows/columns (i=0 and j=0) to produce the reduced operator for stability
+    analysis.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.
+    N : int
+        Number of grid points per direction.
+
+    Returns
+    -------
+    (L_red, keep_idx) : tuple[scipy.sparse.csr_matrix, np.ndarray]
+        L_red : the reduced operator of shape ((N-1)², (N-1)²).
+        keep_idx : integer array of retained DOF indices into the full N² system.
+    """
+    import scipy.sparse as sp
+
+    from stencil_gen.benchmarks.brady_livescu_2d import L_DOMAIN, make_coefficient_field
+
+    spar = _SCHEME_PARAMS[scheme]
+    p, q, nextra, nu = spar["p"], spar["q"], spar["nextra"], spar["nu"]
+
+    # Build 1D differentiation matrix
+    if kernel == "classical":
+        D1 = _build_classical_diff_matrix(N, p, nu, params["alpha"])
+    else:
+        epsilon = params.get("sigma", params.get("epsilon", 0.0))
+        D1 = build_diff_matrix_rbf(N, p, q, epsilon, kernel, nu, nextra)
+
+    # build_diff_matrix_rbf returns weights for unit grid spacing (h=1,
+    # integer grid {0, 1, ..., N-1}).  The physical domain [0, L_DOMAIN] has
+    # spacing h = L_DOMAIN / (N - 1), so scale D by 1/h to get the physical
+    # derivative operator.
+    h = L_DOMAIN / (N - 1)
+    D1_sp = sp.csr_matrix(D1) / h
+    I_N = sp.eye(N, format="csr")
+
+    # Kronecker products for column-major (Fortran-order) flattening:
+    # u_flat[j*N + i] = u[i, j], where i=x-index, j=y-index
+    Dx_2D = sp.kron(I_N, D1_sp, format="csr")  # x-derivative
+    Dy_2D = sp.kron(D1_sp, I_N, format="csr")  # y-derivative
+
+    # Coefficient fields from Brady-Livescu benchmark
+    _, _, cx_field, cy_field = make_coefficient_field(N)
+
+    # Flatten in Fortran order to match Kronecker product convention
+    cx_vec = cx_field.flatten("F")
+    cy_vec = cy_field.flatten("F")
+
+    Cx = sp.diags(cx_vec, format="csr")
+    Cy = sp.diags(cy_vec, format="csr")
+
+    # Full 2D advection operator: L = -(Cx @ Dx + Cy @ Dy)
+    L_2D = -(Cx @ Dx_2D + Cy @ Dy_2D)
+
+    # Remove inflow DOFs: i=0 (x=0) and j=0 (y=0)
+    N2 = N * N
+    flat_indices = np.arange(N2)
+    ii = flat_indices % N   # x-index
+    jj = flat_indices // N  # y-index
+    keep_mask = (ii > 0) & (jj > 0)
+    keep_idx = flat_indices[keep_mask]
+
+    L_red = L_2D[np.ix_(keep_idx, keep_idx)].tocsr()
+
+    return L_red, keep_idx
+
+
+# Layer-7 threshold: max Re(eigenvalue of 2D varying-coefficient operator).
+#
+# The Brady-Livescu radial flow field has div(c) = 1/psi > 0 (diverging
+# flow), so the continuous operator is not skew-symmetric.  The homogeneous
+# stability problem (inflow DOFs removed) inherently has positive spectral
+# abscissa because the divergence-driven energy growth is not balanced by
+# inflow energy supply.  The full problem is stable because the outflow
+# boundary closures provide dissipation and RK4 at CFL=0.8 accommodates
+# the eigenvalue locations.
+#
+# Calibration (with correct h = L_DOMAIN/(N-1) scaling):
+#   - Known-stable tension E4 sigma=3.0: max Re ~ 0.018
+#   - Known-unstable Gaussian E4 eps=0.1: max Re ~ 3.1
+# A threshold of 0.1 cleanly separates these regimes.
+L7_TOL = 0.1
+
+
+def layer7_sparse_2d_eigenvalue(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    n_values: tuple[int, ...] = (21, 31, 61),
+) -> dict:
+    """L7: sparse 2D Arnoldi eigenvalue check on the full varying-coefficient operator.
+
+    For each grid size N, builds the full 2D Brady-Livescu advection operator
+    with inflow DOFs removed, then computes the spectral abscissa (max Re(lambda))
+    via sparse Arnoldi iteration.  This is the definitive semi-discrete stability
+    test for the 2D varying-coefficient problem.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.
+    n_values : tuple[int, ...]
+        Grid sizes per direction at which to evaluate stability.
+
+    Returns
+    -------
+    dict with keys:
+        eigenvalues : dict[int, float]
+            {N: max_real_eigenvalue} for each grid size.
+        max_spectral_abscissa : float
+            Maximum over all grid sizes.
+    """
+    eigenvalues = {}
+    for n in n_values:
+        L_red, _ = build_sparse_2d_operator(scheme, kernel, params, n)
+        max_re, _ = spectral_abscissa_sparse(L_red, k=20)
+        eigenvalues[n] = max_re
+        logger.debug(
+            "L7 %s/%s N=%d: max Re(lambda) = %.6e",
+            scheme, kernel, n, max_re,
+        )
+
+    return {
+        "eigenvalues": eigenvalues,
+        "max_spectral_abscissa": max(eigenvalues.values()),
+    }
+
+
+# Layer-6 threshold: transient growth bound on the 1D operator.
+# This is the standalone non-normality check on the 1D diff matrix, cheaper
+# than the full 2D L7 check.  The threshold is the same as L7 since the
+# 1D operator should be at least as well-behaved as the 2D one.
+L6_TRANSIENT_GROWTH_TOL = 50.0
+
+# Transient growth bound threshold for L7+non-normality combined check.
+L7_TRANSIENT_GROWTH_TOL = 50.0
+
+
+def layer7_with_non_normality(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    N: int = 31,
+) -> NonNormalityReport:
+    """L7 + L6: non-normality diagnostics on the full 2D BL operator.
+
+    Builds the reduced 2D Brady-Livescu operator at a single grid size and
+    computes the full non-normality report (spectral abscissa, numerical
+    abscissa, Henrici departure, pseudospectral abscissa, Kreiss constant,
+    transient growth bound).
+
+    This links L6 infrastructure to the actual BL operator — L6 defines the
+    metric functions, this wires them to the BL coefficient field.
+
+    Failure criteria:
+    - spectral_abscissa > L7_TOL (5e-3), OR
+    - transient_growth_bound > L7_TRANSIENT_GROWTH_TOL (50.0).
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.
+    N : int
+        Grid points per direction.  Default 31 gives a (30×30 = 900)-DOF
+        reduced operator, small enough for dense SVD in the resolvent
+        computation.
+
+    Returns
+    -------
+    NonNormalityReport
+        Full non-normality diagnostics for the 2D BL operator.
+    """
+    L_red, _ = build_sparse_2d_operator(scheme, kernel, params, N)
+    report = compute_non_normality(L_red)
+    logger.debug(
+        "L7+non-normality %s/%s N=%d: spectral_abscissa=%.6e, "
+        "transient_growth_bound=%.2f, kreiss_constant=%.2f, compute_time=%.1fs",
+        scheme, kernel, N, report.spectral_abscissa,
+        report.transient_growth_bound, report.kreiss_constant,
+        report.compute_time,
+    )
+    return report
+
+
+# Layer-8 threshold: final L∞ error at t=10 must be bounded. Classical E4u on
+# the uniform Brady-Livescu domain produces L∞ ~ 2e-3 at N=31, t=10; so 1.0 is
+# a loose ceiling that only catches blow-up, not high-order accuracy loss.
+L8_FINAL_LINF_TOL = 1.0
+
+
+# Dispatch table: (scheme, kernel) → Lua scheme.type string understood by
+# stencil::from_lua. Plan 42.7a wires the three spline families alongside
+# the classical branch; E2 variants remain deferred (plan 42.10a).
+_L8_SCHEME_TYPE = {
+    ("E4", "classical"): "E4u",
+    ("E4", "tension"): "tension_E4u",
+    ("E4", "gaussian"): "gaussian_E4u",
+    ("E4", "multiquadric"): "multiquadric_E4u",
+}
+
+
+def layer8_cpp_simulation(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    *,
+    N: int = 31,
+    t_final: float = 10.0,
+) -> dict:
+    """L8: end-to-end C++ simulation via the shoccs Brady-Livescu 2D harness.
+
+    Renders a Lua config from the plan-42 template with the supplied scheme
+    parameters, invokes the compiled shoccs binary, and reports the final
+    L∞ error. A layer-8 pass means the analytical predictions of L1–L7 survive
+    contact with the real solver; a failure flags an inconsistency to chase.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4"). Plan 42 first cut supports "E4" only.
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+        Plan 42.7a wires all four for the E4 scheme; E2 variants remain
+        deferred (plan 42.10a).
+    params : dict
+        Scheme-specific parameters; passed through verbatim to
+        :func:`run_cpp_brady2d`. Classical uses ``{"alpha": [...]}``,
+        tension uses ``{"sigma": ...}``, gaussian and multiquadric use
+        ``{"epsilon": ...}``.
+    N : int
+        Grid resolution (points per side). Default 31 matches the
+        Brady-Livescu §4.3 coarsest grid.
+    t_final : float
+        Physical end time. Default 10.0 — short enough to run in a
+        few seconds, long enough to catch an exponential blow-up.
+
+    Returns
+    -------
+    dict with keys:
+        final_linf : float
+            Final L∞ error at t_final (nan on simulation failure).
+        stable : bool
+            True iff the simulation ran to completion with a finite L∞
+            below the hard blow-up ceiling used by
+            :func:`run_cpp_brady2d`.
+        wall_time_s : float
+            Wall-clock seconds for the C++ invocation.
+        bridge_result : BridgeResult
+            Full bridge result for debugging (exit_code, stderr, traces).
+
+    Raises
+    ------
+    NotImplementedError
+        When ``(scheme, kernel)`` has no registered Lua scheme type. Items
+        42.7a onward extend the dispatch table.
+    """
+    key = (scheme, kernel)
+    if key not in _L8_SCHEME_TYPE:
+        raise NotImplementedError(
+            f"layer8_cpp_simulation has no dispatch for (scheme={scheme!r}, "
+            f"kernel={kernel!r}); only {sorted(_L8_SCHEME_TYPE)} supported so far",
+        )
+    scheme_type = _L8_SCHEME_TYPE[key]
+
+    result: BridgeResult = run_cpp_brady2d(
+        scheme_type, params, N=N, t_final=t_final,
+    )
+
+    logger.debug(
+        "L8 %s/%s N=%d t_final=%g: final_linf=%.4e stable=%s wall=%.1fs",
+        scheme, kernel, N, t_final, result.final_linf, result.stable,
+        result.wall_time_s,
+    )
+
+    return {
+        "final_linf": result.final_linf,
+        "stable": result.stable,
+        "wall_time_s": result.wall_time_s,
+        "bridge_result": result,
+    }
+
+
+def brady2d_stability_score(
+    scheme: str,
+    kernel: str,
+    params: dict,
+    *,
+    max_layer: int = 7,
+    short_circuit: bool = True,
+    layer8_N: int = 31,
+    layer8_t_final: float = 10.0,
+) -> StabilityReport:
+    """Run the layered stability analysis pipeline.
+
+    Executes layers 1 through ``max_layer`` in order, populating the
+    corresponding fields of a :class:`StabilityReport`.  If
+    ``short_circuit`` is True (default), execution stops at the first
+    failing layer.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name ("E2" or "E4").
+    kernel : str
+        Kernel type ("classical", "tension", "gaussian", "multiquadric").
+    params : dict
+        Kernel-specific parameters.
+    max_layer : int
+        Highest layer to run (1–8). Layer 8 invokes the compiled shoccs
+        binary via :func:`layer8_cpp_simulation` and is gated behind
+        earlier layers passing when ``short_circuit`` is True.
+    short_circuit : bool
+        If True, stop at the first failing layer.
+    layer8_N : int
+        Grid resolution forwarded to :func:`layer8_cpp_simulation` when
+        ``max_layer >= 8``.
+    layer8_t_final : float
+        Physical end time forwarded to :func:`layer8_cpp_simulation`
+        when ``max_layer >= 8``.
+
+    Returns
+    -------
+    StabilityReport
+        Populated report with per-layer results and overall verdict.
+    """
+    t0 = time.perf_counter()
+    report = StabilityReport.empty()
+
+    def _record_failure(layer_num: int, reason: str) -> None:
+        """Record a failure if this is the first one."""
+        if report.failed_layer is None:
+            report.failed_layer = layer_num
+            report.failed_reason = reason
+
+    def _should_stop() -> bool:
+        return short_circuit and report.failed_layer is not None
+
+    # --- Layer 1: interior + boundary group velocity error ---
+    if max_layer >= 1:
+        report.layer1 = layer1_interior_boundary_gv(scheme, kernel, params)
+        err = report.layer1["boundary_gv_err"]
+        if err > L1_TOL:
+            _record_failure(1, f"boundary_gv_err={err:.4e} > L1_TOL={L1_TOL}")
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+    # --- Layer 2: rigorous GKS Kreiss determinant test ---
+    if max_layer >= 2:
+        kr = layer2_kreiss_gks(scheme, kernel, params)
+        report.layer2 = kr
+        report.kreiss = kr
+        if not kr.is_stable:
+            _record_failure(
+                2, f"Kreiss GKS unstable: sigma_min={kr.witness_sigma_min:.4e}"
+            )
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+    # --- Layer 3: 1D eigenvalue check at multiple grid sizes ---
+    if max_layer >= 3:
+        report.layer3 = layer3_1d_eigenvalue(scheme, kernel, params)
+        mse = report.layer3["max_stab_eig"]
+        if mse > STABILITY_TOL:
+            _record_failure(3, f"max_stab_eig={mse:.4e} > STABILITY_TOL={STABILITY_TOL}")
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+    # --- Layer 3r: BL §4.2 reflecting-hyperbolic eigenvalue check ---
+    if max_layer >= 3:
+        report.layer_bl42 = layer_bl42_reflecting_hyperbolic(
+            scheme, kernel, params,
+        )
+        max_re = report.layer_bl42["max_spectral_abscissa"]
+        if max_re > BL42_TOL:
+            _record_failure(
+                3,
+                f"BL42 max_spectral_abscissa={max_re:.4e} > BL42_TOL={BL42_TOL}",
+            )
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+    # --- Layer 4: per-point local GV error on 2D varying-coefficient field ---
+    if max_layer >= 4:
+        report.layer4 = layer4_local_gv_2d(scheme, kernel, params)
+        gv_err = report.layer4["max_local_gv_error"]
+        if gv_err > L4_TOL:
+            _record_failure(4, f"max_local_gv_error={gv_err:.4e} > L4_TOL={L4_TOL}")
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+    # --- Layer 5: 2D anisotropy over the coefficient field ---
+    if max_layer >= 5:
+        report.layer5 = layer5_anisotropy(scheme, kernel, params)
+        aniso_err = report.layer5["max_aligned_error"]
+        if aniso_err > L5_TOL:
+            _record_failure(5, f"max_aligned_error={aniso_err:.4e} > L5_TOL={L5_TOL}")
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+    # --- Layer 6: non-normality diagnostics on 1D operator ---
+    if max_layer >= 6:
+        l6 = layer6_non_normality(scheme, kernel, params)
+        report.layer6 = l6
+        report.non_normality = l6["non_normality_report"]
+        sa = l6["spectral_abscissa"]
+        tgb = l6["transient_growth_bound"]
+        if sa > STABILITY_TOL:
+            _record_failure(
+                6, f"1D spectral_abscissa={sa:.4e} > STABILITY_TOL={STABILITY_TOL}"
+            )
+        elif tgb > L6_TRANSIENT_GROWTH_TOL:
+            _record_failure(
+                6,
+                f"1D transient_growth_bound={tgb:.2f} "
+                f"> L6_TRANSIENT_GROWTH_TOL={L6_TRANSIENT_GROWTH_TOL}",
+            )
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+    # --- Layer 7: sparse 2D Arnoldi eigenvalue ---
+    if max_layer >= 7:
+        report.layer7 = layer7_sparse_2d_eigenvalue(scheme, kernel, params)
+        msa = report.layer7["max_spectral_abscissa"]
+        if msa > L7_TOL:
+            _record_failure(
+                7, f"max_spectral_abscissa={msa:.4e} > L7_TOL={L7_TOL}"
+            )
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+        # Non-normality diagnostics on the 2D BL operator (combined L6+L7)
+        report.non_normality = layer7_with_non_normality(scheme, kernel, params)
+        if report.non_normality.transient_growth_bound > L7_TRANSIENT_GROWTH_TOL:
+            _record_failure(
+                7,
+                f"transient_growth_bound="
+                f"{report.non_normality.transient_growth_bound:.2f} "
+                f"> L7_TRANSIENT_GROWTH_TOL={L7_TRANSIENT_GROWTH_TOL}",
+            )
+        if _should_stop():
+            report.overall_verdict = "fail"
+            report.compute_time = time.perf_counter() - t0
+            return report
+
+    # --- Layer 8: end-to-end C++ simulation ---
+    if max_layer >= 8:
+        report.layer8 = layer8_cpp_simulation(
+            scheme, kernel, params,
+            N=layer8_N, t_final=layer8_t_final,
+        )
+        stable = bool(report.layer8["stable"])
+        linf = float(report.layer8["final_linf"])
+        if not stable:
+            _record_failure(
+                8,
+                f"C++ simulation unstable: final_linf={linf:.4e} "
+                f"(exit_code={report.layer8['bridge_result'].exit_code})",
+            )
+        elif linf > L8_FINAL_LINF_TOL:
+            _record_failure(
+                8,
+                f"final_linf={linf:.4e} > L8_FINAL_LINF_TOL={L8_FINAL_LINF_TOL}",
+            )
+
+    # Final verdict
+    report.overall_verdict = "fail" if report.failed_layer is not None else "pass"
+    report.compute_time = time.perf_counter() - t0
+    return report

--- a/scripts/stencil_gen/stencil_gen/cpp_bridge.py
+++ b/scripts/stencil_gen/stencil_gen/cpp_bridge.py
@@ -1,0 +1,205 @@
+"""Python → C++ bridge for the Brady-Livescu 2D stability validator.
+
+Builds Lua configs from a template and drives the compiled shoccs binary so
+plan 41's analytical stability stack can validate survivors end-to-end in the
+real solver.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+REPO_ROOT: Path = Path(__file__).resolve().parents[3]
+LUA_TEMPLATE_DIR: Path = REPO_ROOT / "lua-configs"
+BRADY_LIVESCU_TEMPLATE: Path = LUA_TEMPLATE_DIR / "brady_livescu_4_3.lua"
+SHOCCS_BINARY: Path = REPO_ROOT / "build" / "src" / "app" / "shoccs"
+
+
+@dataclass
+class BridgeResult:
+    final_linf: float = float("nan")
+    linf_trace: np.ndarray = field(default_factory=lambda: np.empty(0))
+    t_trace: np.ndarray = field(default_factory=lambda: np.empty(0))
+    stable: bool = False
+    wall_time_s: float = 0.0
+    exit_code: int = 0
+    stderr: str = ""
+
+
+def _format_lua_number(x: float) -> str:
+    """Format a Python float as a Lua-parseable numeric literal.
+
+    Uses repr() to preserve full double precision, which matters for the alpha
+    coefficients that must match known_values.json exactly.
+    """
+    return repr(float(x))
+
+
+def _format_lua_array(values: list[float]) -> str:
+    return "{" + ", ".join(_format_lua_number(v) for v in values) + "}"
+
+
+def _scheme_table_for(scheme_type: str, params: dict[str, Any]) -> str:
+    """Emit a Lua scheme sub-table for the requested type and parameters.
+
+    Classical schemes pass `alpha` as an array. Spline families (added in
+    42.7) pass a scalar `sigma` or `epsilon`. The shape of params dictates
+    which parameter is emitted.
+    """
+    entries: list[str] = ["order = 1", f'type = "{scheme_type}"']
+    if "alpha" in params:
+        entries.append(f"alpha = {_format_lua_array(list(params['alpha']))}")
+    if "sigma" in params:
+        entries.append(f"sigma = {_format_lua_number(params['sigma'])}")
+    if "epsilon" in params:
+        entries.append(f"epsilon = {_format_lua_number(params['epsilon'])}")
+    return "{ " + ", ".join(entries) + " }"
+
+
+def make_brady2d_lua(
+    scheme_type: str,
+    params: dict[str, Any],
+    *,
+    N: int,
+    t_final: float,
+    template: Path = BRADY_LIVESCU_TEMPLATE,
+) -> str:
+    """Render the Brady-Livescu 2D Lua config with the supplied parameters.
+
+    Substitutes the three explicit markers --{{N}}--, --{{T_FINAL}}--, and
+    --{{SCHEME_TABLE}}-- with their runtime values. No regex, no Lua AST
+    parsing — just str.replace().
+    """
+    src = template.read_text()
+    src = src.replace("--{{N}}--", str(int(N)))
+    src = src.replace("--{{T_FINAL}}--", _format_lua_number(t_final))
+    src = src.replace("--{{SCHEME_TABLE}}--", _scheme_table_for(scheme_type, params))
+    return src
+
+
+def _parse_system_csv(path: Path) -> tuple[np.ndarray, np.ndarray]:
+    """Parse `logs/system.csv` written by the shoccs scalar-wave system.
+
+    Columns (0-indexed) are: Timestamp=0, Time=1, Step=2, Linf=3, Min=4, ...
+    Returns (t_trace, linf_trace). Both are empty if the file has no data rows.
+    """
+    times: list[float] = []
+    linfs: list[float] = []
+    with path.open() as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if not row or not row[0] or not row[0][0].isdigit():
+                continue
+            try:
+                times.append(float(row[1]))
+                linfs.append(float(row[3]))
+            except (IndexError, ValueError):
+                continue
+    return np.asarray(times), np.asarray(linfs)
+
+
+def run_cpp_brady2d(
+    scheme_type: str,
+    params: dict[str, Any],
+    *,
+    N: int = 31,
+    t_final: float = 10.0,
+    timeout: float = 300.0,
+    template: Path = BRADY_LIVESCU_TEMPLATE,
+    binary: Path = SHOCCS_BINARY,
+) -> BridgeResult:
+    """Run the shoccs Brady-Livescu 2D test and return the parsed result.
+
+    Renders the Lua template with `make_brady2d_lua`, writes it to a
+    NamedTemporaryFile, and invokes `binary` with cwd set to a per-call
+    tempdir. The shoccs binary writes `logs/system.csv` under its cwd, so
+    using a private tempdir isolates concurrent invocations — callers can
+    run this in parallel without racing on the same CSV.
+
+    On nonzero exit, timeout, or parse failure, returns a BridgeResult with
+    `final_linf=nan`, `stable=False`, and the diagnostic captured in
+    `exit_code`/`stderr`.
+    """
+    lua_source = make_brady2d_lua(
+        scheme_type, params, N=N, t_final=t_final, template=template
+    )
+
+    with tempfile.TemporaryDirectory(prefix="shoccs-brady2d-") as tmpdir:
+        tmp = Path(tmpdir)
+        lua_path = tmp / "brady_livescu_4_3.lua"
+        lua_path.write_text(lua_source)
+        (tmp / "logs").mkdir(exist_ok=True)
+
+        start = time.perf_counter()
+        try:
+            completed = subprocess.run(
+                [str(binary), str(lua_path)],
+                cwd=tmp,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as e:
+            wall = time.perf_counter() - start
+            return BridgeResult(
+                final_linf=float("nan"),
+                stable=False,
+                wall_time_s=wall,
+                exit_code=-1,
+                stderr=f"timeout after {timeout}s: {e}",
+            )
+        wall = time.perf_counter() - start
+
+        if completed.returncode != 0:
+            return BridgeResult(
+                final_linf=float("nan"),
+                stable=False,
+                wall_time_s=wall,
+                exit_code=completed.returncode,
+                stderr=completed.stderr,
+            )
+
+        csv_path = tmp / "logs" / "system.csv"
+        if not csv_path.exists():
+            return BridgeResult(
+                final_linf=float("nan"),
+                stable=False,
+                wall_time_s=wall,
+                exit_code=completed.returncode,
+                stderr=f"logs/system.csv not found under {tmp}",
+            )
+
+        t_trace, linf_trace = _parse_system_csv(csv_path)
+        if linf_trace.size == 0:
+            return BridgeResult(
+                final_linf=float("nan"),
+                stable=False,
+                wall_time_s=wall,
+                exit_code=completed.returncode,
+                stderr="system.csv has no data rows",
+            )
+
+        final_linf = float(linf_trace[-1])
+        stable = (
+            math.isfinite(final_linf) and not math.isnan(final_linf) and final_linf < 10.0
+        )
+        return BridgeResult(
+            final_linf=final_linf,
+            linf_trace=linf_trace,
+            t_trace=t_trace,
+            stable=stable,
+            wall_time_s=wall,
+            exit_code=completed.returncode,
+            stderr=completed.stderr,
+        )

--- a/scripts/stencil_gen/stencil_gen/gks_kreiss.py
+++ b/scripts/stencil_gen/stencil_gen/gks_kreiss.py
@@ -1,0 +1,565 @@
+"""Rigorous GKS Kreiss determinant stability test for semi-discrete boundary closures.
+
+Implements the Kreiss stability condition from Trefethen 1983 (pp. 206-207,
+"Group velocity interpretation of the stability theory of Gustafsson, Kreiss,
+and Sundstrom", *J. Comput. Phys.* 49, pp. 199-217).
+
+For the semi-discrete left-boundary problem u_t = -sum_k a_k u_{n+k}, a mode
+u_n(t) = e^(st) kappa^n requires s + sum_k a_k kappa^k = 0. For each s in
+the right half-plane, the admissible roots are those with |kappa| < 1. The
+r x r Kreiss matrix M(s) is built from the r admissible roots and the r
+boundary rows, and sigma_min(M(s)) is the Kreiss determinant condition
+indicator. The boundary closure is GKS-stable iff sigma_min(M(s)) > 0 for
+all s with Re(s) >= 0, with imaginary-axis perturbation used to classify
+tangent modes per Trefethen p. 207.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger("stencil_gen.gks_kreiss")
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+BoundaryRow = tuple[np.ndarray, np.ndarray]
+"""(weights, column_offsets) for one boundary row of the closure."""
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class DefectiveKappaError(RuntimeError):
+    """Raised when admissible kappa roots are defective (repeated)."""
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KreissResult:
+    """Result of the rigorous Kreiss determinant stability check."""
+
+    is_stable: bool
+    """True if no sigma_min violation was found in the sampled s-grid."""
+
+    witness_s: Optional[complex] = None
+    """The s value at which the minimum sigma_min was found (None if stable)."""
+
+    witness_sigma_min: float = float("inf")
+    """The minimum singular value at the witness point."""
+
+    imaginary_axis_perturbation_verdict: str = "not_checked"
+    """One of: 'not_checked', 'no_candidates', 'all_incoming',
+    'outgoing_mode_detected', 'defective'."""
+
+    defective_kappa_detected: bool = False
+    """True if defective (repeated) admissible kappa roots were encountered."""
+
+    s_grid_shape: tuple[int, ...] = ()
+    """Shape of the s-grid used for the sweep."""
+
+    compute_time: float = 0.0
+    """Wall-clock time in seconds for the full check."""
+
+    sigma_min_field: Optional[np.ndarray] = field(default=None, repr=False)
+    """The sigma_min values over the entire s-grid (for diagnostics)."""
+
+    s_grid: Optional[np.ndarray] = field(default=None, repr=False)
+    """The complex s-grid used for the sweep."""
+
+    n_admissible_roots: int = 0
+    """Number of admissible kappa roots (|kappa| < 1) at the witness point."""
+
+
+# ---------------------------------------------------------------------------
+# Primitive functions (implemented in 41.3b-41.3f)
+# ---------------------------------------------------------------------------
+
+
+def kappa_roots(
+    interior_weights: np.ndarray,
+    interior_offsets: np.ndarray,
+    s: complex,
+    *,
+    repeat_tol: float = 1e-7,
+) -> tuple[np.ndarray, np.ndarray, bool]:
+    """Find all roots kappa of the characteristic polynomial Q(kappa) = 0.
+
+    For the interior stencil u_t = -sum_k a_k u_{n+k}, the mode ansatz
+    u_n(t) = e^(st) kappa^n yields s + sum_k a_k kappa^k = 0. Multiply
+    through by kappa^L_left to clear negative powers.
+
+    Returns
+    -------
+    all_roots : np.ndarray
+        All roots of Q(kappa).
+    admissible : np.ndarray
+        Roots with |kappa| < 1 (strictly inside the unit disk).
+    is_defective : bool
+        True if any pair of admissible roots has separation < repeat_tol.
+    """
+    offsets = np.asarray(interior_offsets, dtype=int)
+    weights = np.asarray(interior_weights, dtype=complex)
+    L_left = -int(np.min(offsets))
+    shifted = offsets + L_left  # now all >= 0
+
+    # Polynomial degree
+    degree = int(np.max(shifted))
+    # If the s*kappa^L_left term contributes at a higher degree, extend
+    degree = max(degree, L_left)
+
+    # Build coefficient array: Q(kappa) = sum_k a_k * kappa^shifted[k] + s * kappa^L_left
+    # numpy.roots expects coefficients from highest to lowest degree
+    coeffs = np.zeros(degree + 1, dtype=complex)
+    for w, sh in zip(weights, shifted):
+        coeffs[sh] += w
+    coeffs[L_left] += s
+
+    # numpy.roots expects [c_n, c_{n-1}, ..., c_1, c_0] (highest degree first)
+    poly_coeffs = coeffs[::-1]
+
+    all_roots = np.roots(poly_coeffs)
+
+    # Admissible: strictly inside the unit disk
+    admissible = all_roots[np.abs(all_roots) < 1.0 - 1e-12]
+
+    # Defective check: any pair of admissible roots with separation < repeat_tol
+    is_defective = False
+    if len(admissible) > 1:
+        for i in range(len(admissible)):
+            for j in range(i + 1, len(admissible)):
+                if abs(admissible[i] - admissible[j]) < repeat_tol:
+                    is_defective = True
+                    break
+            if is_defective:
+                break
+
+    return all_roots, admissible, is_defective
+
+
+def _kappa_roots_from_poly(
+    poly_coeffs: np.ndarray,
+    *,
+    repeat_tol: float = 1e-7,
+) -> tuple[np.ndarray, np.ndarray, bool]:
+    """Find roots from explicit polynomial coefficients (highest degree first).
+
+    Helper for testing defective-root detection without constructing stencils.
+
+    Returns same tuple as kappa_roots: (all_roots, admissible, is_defective).
+    """
+    all_roots = np.roots(poly_coeffs)
+    admissible = all_roots[np.abs(all_roots) < 1.0 - 1e-12]
+
+    is_defective = False
+    if len(admissible) > 1:
+        for i in range(len(admissible)):
+            for j in range(i + 1, len(admissible)):
+                if abs(admissible[i] - admissible[j]) < repeat_tol:
+                    is_defective = True
+                    break
+            if is_defective:
+                break
+
+    return all_roots, admissible, is_defective
+
+
+def kreiss_matrix(
+    interior_weights: np.ndarray,
+    interior_offsets: np.ndarray,
+    boundary_rows: list[BoundaryRow],
+    s: complex,
+) -> np.ndarray:
+    """Build the r x r Kreiss matrix M(s) from admissible roots and boundary rows.
+
+    M[i, ell] = s * kappa_ell^i + sum_j w_{ij} * kappa_ell^j
+
+    where i indexes boundary rows and ell indexes admissible kappa roots.
+
+    Raises ValueError if len(admissible) != len(boundary_rows).
+    """
+    _, admissible, is_defective = kappa_roots(interior_weights, interior_offsets, s)
+    if is_defective:
+        raise DefectiveKappaError(
+            f"Defective admissible kappa roots at s={s}"
+        )
+
+    r = len(boundary_rows)
+    if len(admissible) != r:
+        raise ValueError(
+            f"Number of admissible roots ({len(admissible)}) != "
+            f"number of boundary rows ({r})"
+        )
+
+    M = np.zeros((r, r), dtype=complex)
+    for i, (weights, col_offsets) in enumerate(boundary_rows):
+        weights = np.asarray(weights, dtype=complex)
+        col_offsets = np.asarray(col_offsets, dtype=int)
+        for ell, kappa in enumerate(admissible):
+            # Temporal contribution: s * kappa^i
+            M[i, ell] = s * kappa**i
+            # Spatial operator contribution: sum_j w_{ij} * kappa^j
+            for w, j in zip(weights, col_offsets):
+                M[i, ell] += w * kappa**j
+
+    return M
+
+
+def min_singular_value(
+    interior_weights: np.ndarray,
+    interior_offsets: np.ndarray,
+    boundary_rows: list[BoundaryRow],
+    s: complex,
+) -> float:
+    """Compute sigma_min(M(s)), the minimum singular value of the Kreiss matrix.
+
+    Returns np.inf on DefectiveKappaError or shape mismatch.
+    """
+    try:
+        M = kreiss_matrix(interior_weights, interior_offsets, boundary_rows, s)
+    except (DefectiveKappaError, ValueError):
+        return np.inf
+    svs = np.linalg.svd(M, compute_uv=False)
+    return float(svs[-1])
+
+
+def make_s_grid(
+    s_max: float = 10.0,
+    n_radial: int = 40,
+    n_imag: int = 120,
+    imag_max: float = 20.0,
+    eps_imag: float = 1e-6,
+) -> np.ndarray:
+    """Build an L-shaped contour grid in the right half of the complex s-plane.
+
+    The grid combines a logarithmically-spaced radial sweep with a dense
+    imaginary-axis strip at Re(s) = eps_imag, covering Im(s) in
+    [-imag_max, imag_max].
+
+    Returns a 2D array of shape ``(n_imag, n_radial + 1)`` where:
+    - Column 0 is the imaginary-axis strip at ``Re(s) = eps_imag``.
+    - Columns 1..n_radial are logarithmically spaced from ``1e-4`` to ``s_max``.
+    """
+    # Real parts: imaginary-axis strip, then log-spaced into the right half-plane
+    re_values = np.concatenate(
+        [[eps_imag], np.logspace(-4, np.log10(s_max), n_radial)]
+    )
+    # Imaginary parts: uniform spacing
+    im_values = np.linspace(-imag_max, imag_max, n_imag)
+    # Meshgrid → 2D grid of complex s values
+    Re, Im = np.meshgrid(re_values, im_values)
+    return Re + 1j * Im
+
+
+def _sweep_grid(
+    interior_weights: np.ndarray,
+    interior_offsets: np.ndarray,
+    boundary_rows: list[BoundaryRow],
+    s_grid: np.ndarray,
+) -> tuple[np.ndarray, int]:
+    """Evaluate min_singular_value at every point of s_grid.
+
+    Returns
+    -------
+    sigma_field : np.ndarray
+        sigma_min values, same shape as s_grid.
+    argmin_idx : int
+        Flat index of the global minimum in sigma_field.
+    """
+    flat = s_grid.ravel()
+    sigma_flat = np.empty(len(flat))
+    for i, s in enumerate(flat):
+        sigma_flat[i] = min_singular_value(
+            interior_weights, interior_offsets, boundary_rows, s
+        )
+    sigma_field = sigma_flat.reshape(s_grid.shape)
+    argmin_idx = int(np.argmin(sigma_flat))
+    return sigma_field, argmin_idx
+
+
+def _refine_witness(
+    interior_weights: np.ndarray,
+    interior_offsets: np.ndarray,
+    boundary_rows: list[BoundaryRow],
+    s_start: complex,
+    *,
+    min_s_magnitude: float = 0.0,
+) -> complex:
+    """Refine a candidate witness s via Nelder-Mead minimization of log(sigma_min).
+
+    Constrains Re(s) >= 0 by reflecting into the right half-plane.
+    Optionally constrains |s| >= min_s_magnitude by adding a barrier penalty,
+    preventing convergence to the trivial zero at s=0 that exists for all
+    consistent first-derivative operators.
+
+    Parameters
+    ----------
+    interior_weights, interior_offsets, boundary_rows
+        Stencil and boundary closure specification.
+    s_start : complex
+        Initial guess for the witness (typically the grid-sweep argmin).
+    min_s_magnitude : float
+        Barrier to prevent convergence to the trivial zero at s=0.
+
+    Returns
+    -------
+    complex
+        The refined s at which sigma_min is locally minimized.
+    """
+    from scipy.optimize import minimize
+
+    def objective(re_im: np.ndarray) -> float:
+        # Reflect Re(s) < 0 into the right half-plane
+        re_s = abs(re_im[0])
+        im_s = re_im[1]
+        s = complex(re_s, im_s)
+        # Barrier to keep |s| > min_s_magnitude
+        if min_s_magnitude > 0 and abs(s) < min_s_magnitude:
+            return 100.0  # large penalty
+        sv = min_singular_value(
+            interior_weights, interior_offsets, boundary_rows, s
+        )
+        return float(np.log(sv + 1e-300))
+
+    x0 = np.array([s_start.real, s_start.imag])
+    result = minimize(objective, x0, method="Nelder-Mead",
+                      options={"xatol": 1e-10, "fatol": 1e-12, "maxiter": 2000})
+    return complex(abs(result.x[0]), result.x[1])
+
+
+def _classify_imag_axis(
+    interior_weights: np.ndarray,
+    interior_offsets: np.ndarray,
+    s_candidate: complex,
+    delta: float = 1e-4,
+) -> str:
+    """Classify a near-imaginary-axis candidate s via kappa perturbation.
+
+    For a candidate s_0 near the imaginary axis, recompute kappa roots at
+    s_0 and s_0 + delta, match by nearest-neighbor, and classify
+    unit-modulus kappas as incoming or outgoing per Trefethen p. 207.
+
+    Note on naming convention: "outgoing_mode_detected" means a physical
+    outgoing mode was found at the boundary — this is a GKS violation
+    (instability). "all_incoming" means all near-unit-circle modes move
+    outward under perturbation — this is the stable (non-violation) case.
+    The terminology follows Trefethen: an "outgoing" mode at the boundary
+    is one whose group velocity points away from the boundary into the
+    interior, meaning it is generated by the boundary and should not exist
+    in a well-posed problem.
+
+    Parameters
+    ----------
+    interior_weights, interior_offsets
+        Interior stencil specification.
+    s_candidate : complex
+        The candidate s value near the imaginary axis.
+    delta : float
+        Perturbation magnitude in Re(s) for the incoming/outgoing test.
+
+    Returns
+    -------
+    str
+        One of: 'no_candidates', 'all_incoming', 'outgoing_mode_detected',
+        'defective'.
+    """
+    unit_tol = 1e-4  # how close to |kappa|=1 a root must be to count
+    repeat_tol = 1e-7  # defective threshold for near-unit roots
+
+    # Roots at s_0
+    all_0, _, _ = kappa_roots(
+        interior_weights, interior_offsets, s_candidate
+    )
+
+    # Find near-unit-circle roots at s_0
+    near_unit = [k for k in all_0 if abs(abs(k) - 1.0) < unit_tol]
+    if not near_unit:
+        return "no_candidates"
+
+    # Defective check restricted to near-unit-circle roots only.
+    # (The kappa_roots defective flag checks all admissible roots, which
+    # would false-positive on roots deep inside the unit disk.)
+    for i in range(len(near_unit)):
+        for j in range(i + 1, len(near_unit)):
+            if abs(near_unit[i] - near_unit[j]) < repeat_tol:
+                return "defective"
+
+    # Roots at s_0 + delta (perturb into the right half-plane)
+    all_delta, _, _ = kappa_roots(
+        interior_weights, interior_offsets, s_candidate + delta
+    )
+
+    # Match near-unit roots to perturbed roots by nearest-neighbor
+    for k0 in near_unit:
+        # Find closest root in the perturbed set
+        distances = np.abs(all_delta - k0)
+        k_delta = all_delta[np.argmin(distances)]
+
+        # If |k_delta| < |k0|, the root moved inward (toward origin)
+        # under a Re(s) increase — this is an "outgoing mode" (GKS violation)
+        if abs(k_delta) < abs(k0) - 1e-10:
+            return "outgoing_mode_detected"
+
+    return "all_incoming"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator (implemented in 41.3g)
+# ---------------------------------------------------------------------------
+
+
+def kreiss_stability_check(
+    interior_weights: np.ndarray,
+    interior_offsets: np.ndarray,
+    boundary_rows: list[BoundaryRow],
+    *,
+    s_grid_params: Optional[dict] = None,
+    sigma_tol: float = 1e-8,
+    refine: bool = True,
+    min_s_magnitude: float = 0.1,
+) -> KreissResult:
+    """Run the full Kreiss determinant stability check.
+
+    Sweeps the s-grid, optionally refines any witness, classifies
+    imaginary-axis modes, and returns a KreissResult.
+
+    Parameters
+    ----------
+    interior_weights : np.ndarray
+        Weights of the interior finite-difference stencil.
+    interior_offsets : np.ndarray
+        Grid offsets of the interior stencil (e.g., [-2, -1, 0, 1, 2]).
+    boundary_rows : list[BoundaryRow]
+        Each element is (weights, column_offsets) for one boundary row.
+    s_grid_params : dict, optional
+        Keyword arguments passed to make_s_grid.
+    sigma_tol : float
+        Threshold below which sigma_min indicates instability.
+    refine : bool
+        Whether to refine the witness via Nelder-Mead.
+    min_s_magnitude : float
+        Exclude the trivial zero near s=0 by masking grid points with
+        |s| < min_s_magnitude.  For consistent first-derivative operators,
+        sigma_min(M(0)) = 0 because the constant mode kappa=1 satisfies
+        both interior and boundary equations.  This universal zero is not
+        a GKS violation.
+    """
+    import time
+
+    t0 = time.perf_counter()
+
+    grid_kw = s_grid_params or {}
+    s_grid = make_s_grid(**grid_kw)
+
+    try:
+        sigma_field, _ = _sweep_grid(
+            interior_weights, interior_offsets, boundary_rows, s_grid
+        )
+    except DefectiveKappaError:
+        return KreissResult(
+            is_stable=False,
+            defective_kappa_detected=True,
+            s_grid_shape=s_grid.shape,
+            compute_time=time.perf_counter() - t0,
+            s_grid=s_grid,
+        )
+
+    flat_sigma = sigma_field.ravel()
+    flat_s = s_grid.ravel()
+
+    # Mask out the trivial zero near s=0 (constant-mode artifact).
+    mask = np.abs(flat_s) >= min_s_magnitude
+    if not np.any(mask):
+        logger.warning("All grid points masked by min_s_magnitude=%.2e", min_s_magnitude)
+        mask[:] = True  # fall back to unmasked
+
+    masked_sigma = np.where(mask, flat_sigma, np.inf)
+    argmin_idx = int(np.argmin(masked_sigma))
+    min_sigma = float(masked_sigma[argmin_idx])
+    witness_s = complex(flat_s[argmin_idx])
+
+    # Refine from the grid argmin to find the true local minimum of sigma_min.
+    # The grid may not sample close enough to a genuine zero, so we always
+    # refine (when requested) rather than applying a sweep-stage threshold.
+    if refine:
+        try:
+            witness_s = _refine_witness(
+                interior_weights, interior_offsets, boundary_rows, witness_s,
+                min_s_magnitude=min_s_magnitude,
+            )
+            min_sigma = min_singular_value(
+                interior_weights, interior_offsets, boundary_rows, witness_s
+            )
+        except DefectiveKappaError:
+            return KreissResult(
+                is_stable=False,
+                witness_s=witness_s,
+                witness_sigma_min=min_sigma,
+                defective_kappa_detected=True,
+                s_grid_shape=s_grid.shape,
+                compute_time=time.perf_counter() - t0,
+                sigma_min_field=sigma_field,
+                s_grid=s_grid,
+            )
+
+    # After refinement, apply sigma_tol to determine stability
+    if min_sigma >= sigma_tol:
+        return KreissResult(
+            is_stable=True,
+            witness_s=witness_s,
+            witness_sigma_min=min_sigma,
+            s_grid_shape=s_grid.shape,
+            compute_time=time.perf_counter() - t0,
+            sigma_min_field=sigma_field,
+            s_grid=s_grid,
+            n_admissible_roots=len(boundary_rows),
+        )
+
+    # Potential violation found — but if the refined witness drifted back
+    # toward s=0 (the trivial zero), it's not a genuine violation.
+    if abs(witness_s) < min_s_magnitude:
+        logger.debug(
+            "Witness at s=%.4e drifted to trivial zero; reporting stable",
+            witness_s,
+        )
+        return KreissResult(
+            is_stable=True,
+            witness_s=witness_s,
+            witness_sigma_min=min_sigma,
+            imaginary_axis_perturbation_verdict="trivial_zero",
+            s_grid_shape=s_grid.shape,
+            compute_time=time.perf_counter() - t0,
+            sigma_min_field=sigma_field,
+            s_grid=s_grid,
+            n_admissible_roots=len(boundary_rows),
+        )
+
+    # Classify imaginary-axis behavior at the witness
+    imag_verdict = _classify_imag_axis(
+        interior_weights, interior_offsets, witness_s
+    )
+
+    is_stable = imag_verdict == "all_incoming"
+
+    return KreissResult(
+        is_stable=is_stable,
+        witness_s=witness_s,
+        witness_sigma_min=min_sigma,
+        imaginary_axis_perturbation_verdict=imag_verdict,
+        s_grid_shape=s_grid.shape,
+        compute_time=time.perf_counter() - t0,
+        sigma_min_field=sigma_field,
+        s_grid=s_grid,
+        n_admissible_roots=len(boundary_rows),
+    )

--- a/scripts/stencil_gen/stencil_gen/group_velocity.py
+++ b/scripts/stencil_gen/stencil_gen/group_velocity.py
@@ -1,0 +1,1263 @@
+"""Group velocity analysis for finite difference stencils.
+
+Provides tools for computing modified wavenumber, phase velocity, and group
+velocity from stencil coefficients.  For the model equation u_t + u_x = 0
+semi-discretized as du/dt = -D*u, the modified wavenumber kappa*(xi) of D
+gives the dispersion relation omega = Im(kappa*(xi)).  The group velocity
+is C(xi) = d(omega)/d(xi) = d(Im(kappa*))/d(xi).
+
+References:
+  Trefethen, "Group velocity in finite difference schemes", 1982.
+  Trefethen, "Stability and group velocity", 1983 (GKS connection).
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+def modified_wavenumber(
+    weights,
+    i_eval: int,
+    node_indices,
+    xi_array: np.ndarray,
+) -> np.ndarray:
+    """Compute modified wavenumber kappa*(xi) for given stencil weights.
+
+    Parameters
+    ----------
+    weights : array-like
+        Stencil coefficients w_j.
+    i_eval : int
+        Grid index where derivative is evaluated.
+    node_indices : array-like of int
+        Grid indices used by the stencil.
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+
+    Returns
+    -------
+    np.ndarray (complex)
+        kappa*(xi) = sum_j w_j exp(i (j - i_eval) xi)
+    """
+    offsets = np.asarray(node_indices) - i_eval
+    return modified_wavenumber_nonuniform(weights, offsets, xi_array)
+
+
+def group_velocity_numerical(kappa_star: np.ndarray, xi_array: np.ndarray) -> np.ndarray:
+    """Compute group velocity C(xi) = d(Im(kappa*))/d(xi) numerically.
+
+    Uses numpy.gradient for the numerical differentiation.
+
+    Parameters
+    ----------
+    kappa_star : np.ndarray (complex)
+        Modified wavenumber array.
+    xi_array : np.ndarray
+        Wavenumber values xi.
+
+    Returns
+    -------
+    np.ndarray (real)
+        Group velocity C(xi).
+    """
+    return np.gradient(np.imag(kappa_star), xi_array)
+
+
+def group_velocity_exact(
+    weights,
+    i_eval: int,
+    node_indices,
+    xi_array: np.ndarray,
+) -> np.ndarray:
+    """Compute group velocity analytically from stencil weights.
+
+    C(xi) = Re(sum_j w_j (j - i_eval) exp(i (j - i_eval) xi))
+
+    This avoids numerical differentiation entirely.
+
+    Parameters
+    ----------
+    weights : array-like
+        Stencil coefficients w_j.
+    i_eval : int
+        Grid index where derivative is evaluated.
+    node_indices : array-like of int
+        Grid indices used by the stencil.
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+
+    Returns
+    -------
+    np.ndarray (real)
+        Group velocity C(xi).
+    """
+    offsets = np.asarray(node_indices) - i_eval
+    return group_velocity_exact_nonuniform(weights, offsets, xi_array)
+
+
+def modified_wavenumber_nonuniform(
+    weights,
+    offsets,
+    xi_array: np.ndarray,
+) -> np.ndarray:
+    """Compute modified wavenumber for non-uniformly spaced stencil nodes.
+
+    Generalization of :func:`modified_wavenumber` for real-valued offsets
+    (e.g. cut-cell stencils where the wall position is at a fractional
+    distance from the evaluation point).
+
+    Parameters
+    ----------
+    weights : array-like
+        Stencil coefficients w_j.
+    offsets : array-like of float
+        Normalized distances (x_j - x_i)/h from the evaluation point.
+        May be non-integer for cut-cell grids.
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+
+    Returns
+    -------
+    np.ndarray (complex)
+        kappa*(xi) = sum_j w_j exp(i * offset_j * xi)
+    """
+    w = np.asarray(weights, dtype=complex)
+    d = np.asarray(offsets, dtype=float)
+    phase = np.exp(1j * np.outer(xi_array, d))
+    return phase @ w
+
+
+def group_velocity_exact_nonuniform(
+    weights,
+    offsets,
+    xi_array: np.ndarray,
+) -> np.ndarray:
+    """Compute group velocity analytically for non-uniform offsets.
+
+    C(xi) = Re(sum_j w_j * offset_j * exp(i * offset_j * xi))
+
+    Generalization of :func:`group_velocity_exact` for real-valued offsets.
+
+    Parameters
+    ----------
+    weights : array-like
+        Stencil coefficients w_j.
+    offsets : array-like of float
+        Normalized distances (x_j - x_i)/h from the evaluation point.
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+
+    Returns
+    -------
+    np.ndarray (real)
+        Group velocity C(xi).
+    """
+    w = np.asarray(weights, dtype=complex)
+    d = np.asarray(offsets, dtype=float)
+    phase = np.exp(1j * np.outer(xi_array, d))
+    return np.real(phase @ (w * d))
+
+
+def phase_velocity(kappa_star: np.ndarray, xi_array: np.ndarray) -> np.ndarray:
+    """Compute phase velocity c(xi) = Im(kappa*(xi)) / xi.
+
+    At xi=0 the limit is taken from the next nonzero xi value.
+
+    Parameters
+    ----------
+    kappa_star : np.ndarray (complex)
+        Modified wavenumber array.
+    xi_array : np.ndarray
+        Wavenumber values xi.
+
+    Returns
+    -------
+    np.ndarray (real)
+        Phase velocity c(xi).
+    """
+    c = np.empty_like(xi_array, dtype=float)
+    nonzero = xi_array != 0.0
+    c[nonzero] = np.imag(kappa_star[nonzero]) / xi_array[nonzero]
+    # Handle xi=0 via L'Hopital: lim Im(kappa*)/xi = group velocity at 0
+    zero_mask = ~nonzero
+    if np.any(zero_mask):
+        # Use the first nonzero point as approximation
+        first_nonzero = np.argmax(nonzero)
+        c[zero_mask] = c[first_nonzero] if first_nonzero > 0 else 1.0
+    return c
+
+
+def group_velocity_error(
+    C: np.ndarray,
+    C_exact: float = 1.0,
+) -> np.ndarray:
+    """Compute relative group velocity error.
+
+    Parameters
+    ----------
+    C : np.ndarray
+        Computed group velocity.
+    C_exact : float
+        Exact group velocity (default 1.0 for u_t + u_x = 0).
+
+    Returns
+    -------
+    np.ndarray
+        (C - C_exact) / C_exact
+    """
+    return (C - C_exact) / C_exact
+
+
+@dataclass
+class GroupVelocity2DResult:
+    """2D group velocity analysis results for tensor-product stencils.
+
+    For dimension-by-dimension operators where the 2D dispersion relation
+    factors as omega = a*kappa_x*(xi) + b*kappa_y*(eta), the group velocity
+    vector is C = (C_x, C_y) with C_x = a * d(Im(kappa_x*))/d(xi) and
+    C_y = b * d(Im(kappa_y*))/d(eta).
+
+    All 2D arrays use shape (N_xi, N_eta) with indexing='ij'.
+    """
+
+    xi: np.ndarray  # 1D wavenumber array for x-direction
+    eta: np.ndarray  # 1D wavenumber array for y-direction
+    C_x: np.ndarray  # 2D group velocity x-component
+    C_y: np.ndarray  # 2D group velocity y-component
+    speed: np.ndarray  # 2D group speed |C|
+    angle: np.ndarray  # 2D group propagation angle atan2(C_y, C_x)
+    angle_error: np.ndarray  # 2D angle deviation from wave normal
+
+
+@dataclass
+class AnisotropyResult:
+    """Anisotropy profile for a given interior scheme at fixed wavenumber magnitude.
+
+    For a wave propagating at angle theta (advection velocity (cos(theta),
+    sin(theta))) with wavenumber magnitude xi_mag, reports the numerical
+    group velocity vector and its deviation from the exact result.
+
+    The exact group velocity is (cos(theta), sin(theta)) with speed 1.
+    """
+
+    theta: np.ndarray  # propagation angle array
+    C_x: np.ndarray  # group velocity x-component
+    C_y: np.ndarray  # group velocity y-component
+    speed: np.ndarray  # group speed |C| (equals speed ratio since exact speed = 1)
+    angle: np.ndarray  # group propagation angle atan2(C_y, C_x)
+    angle_error: np.ndarray  # angle deviation from propagation direction theta
+
+
+def _make_anisotropy_result(
+    theta: np.ndarray, C_x: np.ndarray, C_y: np.ndarray,
+) -> "AnisotropyResult":
+    """Construct AnisotropyResult from 2D group velocity components."""
+    speed = np.sqrt(C_x**2 + C_y**2)
+    angle = np.arctan2(C_y, C_x)
+    angle_error = angle - theta
+    return AnisotropyResult(
+        theta=theta, C_x=C_x, C_y=C_y,
+        speed=speed, angle=angle, angle_error=angle_error,
+    )
+
+
+@dataclass
+class GroupVelocityProfile:
+    """Group velocity analysis results for a single stencil row."""
+
+    xi: np.ndarray
+    kappa_star: np.ndarray
+    phase_velocity: np.ndarray
+    group_velocity: np.ndarray
+    gv_error: np.ndarray
+    order: int
+    cutoff_xi: float  # first xi beyond which C stays permanently non-positive
+
+
+@dataclass
+class GKSModeInfo:
+    """Diagnostic information for a boundary-localized eigenmode.
+
+    Bridges per-stencil group velocity analysis with full-operator eigenvalue
+    analysis by identifying nearly-neutral eigenmodes concentrated near a
+    boundary and checking whether the interior stencil's group velocity at
+    the mode's dominant wavenumber directs energy into the domain.
+    """
+
+    eigenvalue: complex  # eigenvalue of -D_bc
+    boundary_wavenumber: float  # dominant xi from FFT of boundary eigenvector portion
+    group_velocity: float  # interior C(xi) at boundary_wavenumber
+    is_outgoing: bool  # True if mode radiates energy from boundary into domain
+
+
+def group_velocity_2d(
+    kappa_x_star: np.ndarray,
+    kappa_y_star: np.ndarray,
+    xi_array: np.ndarray,
+    eta_array: np.ndarray,
+    a: float = 1.0,
+    b: float = 1.0,
+) -> GroupVelocity2DResult:
+    """Compute 2D group velocity for tensor-product stencils.
+
+    For dimension-by-dimension operators where the 2D dispersion relation
+    factors as ``omega = a*kappa_x*(xi) + b*kappa_y*(eta)``, the group
+    velocity vector is:
+
+    - ``C_x(xi, eta) = a * d(Im(kappa_x*))/d(xi)``  (depends only on xi)
+    - ``C_y(xi, eta) = b * d(Im(kappa_y*))/d(eta)``  (depends only on eta)
+
+    Parameters
+    ----------
+    kappa_x_star : np.ndarray (complex)
+        Modified wavenumber for x-direction stencil, shape (N_xi,).
+    kappa_y_star : np.ndarray (complex)
+        Modified wavenumber for y-direction stencil, shape (N_eta,).
+    xi_array : np.ndarray
+        Wavenumber values for x-direction, shape (N_xi,).
+    eta_array : np.ndarray
+        Wavenumber values for y-direction, shape (N_eta,).
+    a : float
+        Wave speed coefficient in x-direction (default 1.0).
+    b : float
+        Wave speed coefficient in y-direction (default 1.0).
+
+    Returns
+    -------
+    GroupVelocity2DResult
+    """
+    # 1D group velocities via numerical differentiation
+    C_x_1d = a * np.gradient(np.imag(kappa_x_star), xi_array)
+    C_y_1d = b * np.gradient(np.imag(kappa_y_star), eta_array)
+
+    # Broadcast to 2D grid with shape (N_xi, N_eta)
+    C_x = np.broadcast_to(C_x_1d[:, np.newaxis], (len(xi_array), len(eta_array))).copy()
+    C_y = np.broadcast_to(C_y_1d[np.newaxis, :], (len(xi_array), len(eta_array))).copy()
+
+    speed = np.sqrt(C_x**2 + C_y**2)
+    angle = np.arctan2(C_y, C_x)
+
+    # Wave normal angle on the 2D grid
+    xi_2d, eta_2d = np.meshgrid(xi_array, eta_array, indexing="ij")
+    theta_wave = np.arctan2(eta_2d, xi_2d)
+    angle_error = angle - theta_wave
+
+    return GroupVelocity2DResult(
+        xi=xi_array,
+        eta=eta_array,
+        C_x=C_x,
+        C_y=C_y,
+        speed=speed,
+        angle=angle,
+        angle_error=angle_error,
+    )
+
+
+def anisotropy_profile(
+    p: int,
+    nu: int,
+    theta_array: np.ndarray,
+    xi_mag: float,
+) -> AnisotropyResult:
+    """Compute group speed and angle error vs propagation angle for an interior scheme.
+
+    For the advection equation ``u_t + cos(theta)*u_x + sin(theta)*u_y = 0``
+    discretized with tensor-product stencils of half-bandwidth *p* and
+    derivative order *nu*, this function evaluates the numerical group velocity
+    at wavenumber magnitude *xi_mag* for each propagation angle in
+    *theta_array*.
+
+    The exact group velocity is ``(cos(theta), sin(theta))`` with unit speed.
+    The numerical group velocity deviates due to grid anisotropy — e.g., for
+    E2, Trefethen (1982) shows that diagonal propagation (theta = pi/4) has
+    higher group speed than axis-aligned propagation (theta = 0).
+
+    Parameters
+    ----------
+    p : int
+        Interior half-bandwidth (E2 → p=1, E4 → p=2, E6 → p=3, E8 → p=4).
+    nu : int
+        Derivative order (typically 1 for advection).
+    theta_array : np.ndarray
+        Wave propagation angles in radians.
+    xi_mag : float
+        Wavenumber magnitude |xi| in [0, pi].
+
+    Returns
+    -------
+    AnisotropyResult
+    """
+    from stencil_gen.interior import derive_interior, full_gamma_array
+
+    # Interior stencil weights
+    coeffs = derive_interior(0, p, nu)
+    w = [float(c) for c in full_gamma_array(coeffs)]
+    nodes = list(range(-p, p + 1))
+
+    # Wavenumber components (g is even, so use |cos|, |sin|)
+    xi_vals = xi_mag * np.abs(np.cos(theta_array))
+    eta_vals = xi_mag * np.abs(np.sin(theta_array))
+
+    # Evaluate 1D group velocity analytically at these wavenumbers
+    C_at_xi = group_velocity_exact(w, 0, nodes, xi_vals)
+    C_at_eta = group_velocity_exact(w, 0, nodes, eta_vals)
+
+    # 2D group velocity components: C = (a * g(xi), b * g(eta))
+    C_x = np.cos(theta_array) * C_at_xi
+    C_y = np.sin(theta_array) * C_at_eta
+
+    return _make_anisotropy_result(theta_array, C_x, C_y)
+
+
+def boundary_group_velocity_2d(
+    boundary_rows_x: dict[int, "GroupVelocityProfile"],
+    interior_y: "GroupVelocityProfile",
+    theta_array: np.ndarray,
+    xi_mag: float,
+) -> dict[int, AnisotropyResult]:
+    """Compute 2D group velocity at a boundary using boundary x-stencils and interior y.
+
+    At a boundary in x (left wall), the x-direction uses boundary stencils
+    while the y-direction uses interior stencils.  The 2D dispersion relation
+    near the boundary is ``omega = a*kappa_x_bdy*(xi) + b*kappa_y_int*(eta)``
+    where ``a = cos(theta)``, ``b = sin(theta)`` for a wave propagating at
+    angle *theta*.
+
+    This reveals whether the boundary distorts the group velocity angle,
+    bending waves toward or away from the boundary.
+
+    Parameters
+    ----------
+    boundary_rows_x : dict[int, GroupVelocityProfile]
+        Boundary group velocity profiles for the x-direction (from
+        :func:`boundary_group_velocity` or similar).
+    interior_y : GroupVelocityProfile
+        Interior group velocity profile for the y-direction.
+    theta_array : np.ndarray
+        Wave propagation angles in radians.
+    xi_mag : float
+        Wavenumber magnitude |xi| in [0, pi].
+
+    Returns
+    -------
+    dict[int, AnisotropyResult]
+        Keyed by boundary row index.  Each entry gives the 2D group velocity
+        at that boundary row for all propagation angles.
+    """
+    # Wavenumber components along each direction
+    xi_vals = xi_mag * np.abs(np.cos(theta_array))
+    eta_vals = xi_mag * np.abs(np.sin(theta_array))
+
+    # Interior y-direction group velocity interpolated at eta_vals
+    C_y_1d = np.interp(eta_vals, interior_y.xi, interior_y.group_velocity)
+
+    results: dict[int, AnisotropyResult] = {}
+    for row_idx, prof in boundary_rows_x.items():
+        # Boundary x-direction group velocity interpolated at xi_vals
+        C_x_1d = np.interp(xi_vals, prof.xi, prof.group_velocity)
+
+        # 2D group velocity components
+        C_x = np.cos(theta_array) * C_x_1d
+        C_y = np.sin(theta_array) * C_y_1d
+
+        results[row_idx] = _make_anisotropy_result(theta_array, C_x, C_y)
+
+    return results
+
+
+def _build_profile(
+    weights,
+    offsets,
+    xi_array: np.ndarray,
+    order: int,
+) -> GroupVelocityProfile:
+    """Build a GroupVelocityProfile from stencil weights and node offsets."""
+    kstar = modified_wavenumber_nonuniform(weights, offsets, xi_array)
+    C = group_velocity_exact_nonuniform(weights, offsets, xi_array)
+    c = phase_velocity(kstar, xi_array)
+    gv_err = group_velocity_error(C)
+
+    # Find cutoff: first xi beyond which C stays non-positive.
+    # Scan from high end to handle non-monotonic boundary stencils where
+    # C(xi) may dip below zero briefly then recover.
+    last_positive_idx = 0
+    for idx in range(1, len(xi_array)):
+        if C[idx] > 0.0:
+            last_positive_idx = idx
+    if last_positive_idx + 1 < len(xi_array):
+        cutoff = float(xi_array[last_positive_idx + 1])
+    else:
+        cutoff = float(xi_array[-1])
+
+    return GroupVelocityProfile(
+        xi=xi_array,
+        kappa_star=kstar,
+        phase_velocity=c,
+        group_velocity=C,
+        gv_error=gv_err,
+        order=order,
+        cutoff_xi=cutoff,
+    )
+
+
+def interior_group_velocity(
+    p: int,
+    nu: int,
+    xi_array: np.ndarray,
+) -> GroupVelocityProfile:
+    """Compute group velocity profile for an interior scheme.
+
+    Parameters
+    ----------
+    p : int
+        RHS half-bandwidth (explicit scheme, s=0).
+    nu : int
+        Derivative order (1 or 2).
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+
+    Returns
+    -------
+    GroupVelocityProfile
+    """
+    from stencil_gen.interior import derive_interior, full_gamma_array
+
+    coeffs = derive_interior(0, p, nu)
+    w = [float(c) for c in full_gamma_array(coeffs)]
+    nodes = list(range(-p, p + 1))
+
+    return _build_profile(w, np.asarray(nodes), xi_array, order=2 * p)
+
+
+def boundary_group_velocity(
+    p: int,
+    q: int,
+    nextra: int,
+    nu: int,
+    sigma: float,
+    kernel: str,
+    xi_array: np.ndarray,
+) -> dict[int, GroupVelocityProfile]:
+    """Compute group velocity profiles for all boundary rows.
+
+    Uses RBF/tension boundary weights from :func:`uniform_boundary_weights_rbf`.
+
+    Parameters
+    ----------
+    p : int
+        Interior half-bandwidth.
+    q : int
+        Polynomial degree for boundary RBF augmentation.
+    nextra : int
+        Extra boundary rows/columns.
+    nu : int
+        Derivative order (1 or 2).
+    sigma : float
+        RBF shape / tension parameter.
+    kernel : str
+        RBF kernel type (``"tension"``, ``"gaussian"``, ``"multiquadric"``).
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+
+    Returns
+    -------
+    dict[int, GroupVelocityProfile]
+        Keyed by boundary row index (0 to r-1).
+    """
+    from stencil_gen.phs import uniform_boundary_weights_rbf
+    from stencil_gen.temo import compute_dimensions
+
+    dims = compute_dimensions(p, q, 0, nextra, nu)
+    r, t = dims.r, dims.t
+    nodes = np.arange(t)
+
+    profiles: dict[int, GroupVelocityProfile] = {}
+    for i in range(r):
+        w = uniform_boundary_weights_rbf(i, t, nu, q, sigma, kernel=kernel)
+        w_float = [float(c) for c in w]
+        profiles[i] = _build_profile(w_float, nodes - i, xi_array, order=q)
+
+    return profiles
+
+
+def boundary_group_velocity_classical(
+    boundary_rows,
+    alpha_values: dict,
+    order: int,
+    xi_array: np.ndarray,
+) -> dict[int, GroupVelocityProfile]:
+    """Compute group velocity profiles for classical (non-RBF) boundary rows.
+
+    Takes the symbolic ``BoundaryRow`` list from :func:`derive_boundary` (or the
+    conservation-updated rows from :func:`solve_conservation`) and substitutes
+    concrete alpha values to obtain numerical stencil coefficients.
+
+    Parameters
+    ----------
+    boundary_rows : list[BoundaryRow]
+        Boundary rows with symbolic coefficients in alpha parameters.
+    alpha_values : dict
+        Mapping from alpha symbols to numeric values (e.g.,
+        ``{alpha_0: -0.77, alpha_1: 0.16}``).
+    order : int
+        Polynomial accuracy order of the boundary scheme (q = 2*(p+s) - 1
+        for the classical Brady & Livescu stencils).
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+
+    Returns
+    -------
+    dict[int, GroupVelocityProfile]
+        Keyed by boundary row index.
+    """
+    t = len(boundary_rows[0].coefficients)
+    nodes = np.arange(t)
+
+    profiles: dict[int, GroupVelocityProfile] = {}
+    for row in boundary_rows:
+        i = row.row_index
+        w_float = [float(c.xreplace(alpha_values))
+                   if hasattr(c, 'xreplace') else float(c)
+                   for c in row.coefficients]
+        profiles[i] = _build_profile(w_float, nodes - i, xi_array, order=order)
+
+    return profiles
+
+
+def cut_cell_group_velocity(
+    cut_cell_result,
+    psi_sym,
+    psi_val: float,
+    alpha_values: dict,
+    xi_array: np.ndarray,
+    order: int | None = None,
+) -> dict[int, GroupVelocityProfile]:
+    """Compute group velocity profiles for all rows of a cut-cell stencil.
+
+    Evaluates the symbolic psi-dependent stencil coefficients at a specific
+    ``psi_val`` and ``alpha_values``, then computes group velocity profiles
+    using the non-uniform offsets from the cut-cell grid geometry.
+
+    Parameters
+    ----------
+    cut_cell_result : CutCellResult
+        Precomputed symbolic cut-cell stencil (from ``derive_cut_cell_mathematica``
+        or ``derive_cut_cell_scheme``).
+    psi_sym : Symbol
+        The SymPy symbol for psi used in ``cut_cell_result``.
+    psi_val : float
+        Numeric psi value in [0, 1].
+    alpha_values : dict
+        Mapping from alpha symbols to numeric values.
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+    order : int, optional
+        Polynomial accuracy order.  Defaults to the scheme's boundary
+        accuracy ``q`` inferred from the dimensions.
+
+    Returns
+    -------
+    dict[int, GroupVelocityProfile]
+        Keyed by row index (0 to R-1) of the floating stencil.
+    """
+    F = cut_cell_result.floating
+    dims = cut_cell_result.dims
+    R, T = F.rows, F.cols
+
+    if order is None:
+        # dims.r = q + 1 + nextra, but nextra is not recoverable from dims
+        # alone, so this overestimates q when nextra > 0.  Callers with
+        # nextra > 0 should pass order explicitly.
+        order = max(1, dims.r - 1)
+
+    subs = {psi_sym: psi_val, **alpha_values}
+
+    profiles: dict[int, GroupVelocityProfile] = {}
+    for i in range(R):
+        # Evaluate symbolic coefficients numerically
+        w = [float(F[i, j].xreplace(subs)) for j in range(T)]
+
+        # Non-uniform offsets: wall at -(psi_val + i), grid points at j - i
+        offsets = [-(psi_val + i)] + [j - i for j in range(T - 1)]
+
+        profiles[i] = _build_profile(w, offsets, xi_array, order=order)
+
+    return profiles
+
+
+@dataclass
+class PsiSweepResult:
+    """Results from sweeping psi across the cut-cell parameter range.
+
+    Attributes
+    ----------
+    psi_values : np.ndarray
+        Array of psi values swept.
+    profiles : dict[float, dict[int, GroupVelocityProfile]]
+        Nested dict: ``{psi_val: {row_index: GroupVelocityProfile}}``.
+    worst_row : int
+        Row index with the largest group velocity error across all psi values.
+    worst_psi : float
+        Psi value with the largest group velocity error.
+    min_C : float
+        Most negative group velocity across all psi values and rows.
+    has_sign_reversal : bool
+        True if any boundary row has C > 0 at wavenumbers where the interior
+        stencil has C < 0 (parasitic energy reversal).
+    """
+
+    psi_values: np.ndarray
+    profiles: dict[float, dict[int, GroupVelocityProfile]]
+    worst_row: int
+    worst_psi: float
+    min_C: float
+    has_sign_reversal: bool
+
+
+def psi_sweep_group_velocity(
+    scheme_params,
+    psi_values: np.ndarray,
+    alpha_values: dict,
+    xi_array: np.ndarray,
+    order: int | None = None,
+) -> PsiSweepResult:
+    """Sweep psi across the cut-cell parameter range, computing group velocity.
+
+    Derives the symbolic cut-cell stencil once from ``scheme_params``, then
+    evaluates group velocity profiles at each psi value.  Also computes the
+    interior group velocity to detect sign reversals.
+
+    Parameters
+    ----------
+    scheme_params : SchemeParams
+        Scheme parameters (p, q, s, nextra, nu).
+    psi_values : np.ndarray
+        Array of psi values in [0, 1] to sweep.
+    alpha_values : dict
+        Mapping from alpha symbols to numeric values.
+    xi_array : np.ndarray
+        Wavenumber values xi in [0, pi].
+    order : int, optional
+        Polynomial accuracy order passed to :func:`cut_cell_group_velocity`.
+
+    Returns
+    -------
+    PsiSweepResult
+    """
+    from sympy import Symbol
+
+    from stencil_gen.temo import derive_cut_cell_mathematica, derive_cut_cell_scheme
+
+    psi_sym = Symbol("psi")
+    # Use singularity-free Mathematica workflow for schemes with zeros;
+    # otherwise use the standard pipeline.
+    if scheme_params.zeros:
+        cc_result = derive_cut_cell_mathematica(scheme_params, psi_sym)
+    else:
+        cc_result = derive_cut_cell_scheme(scheme_params, psi_sym)
+
+    # Map caller's alpha_values (which may use their own symbols) to the
+    # result's alpha_symbols.  If the caller passes an empty dict or uses
+    # symbols that already match, this is a no-op.
+    if not alpha_values:
+        alpha_values = {s: 0 for s in cc_result.alpha_symbols}
+
+    # Compute interior group velocity for sign reversal detection
+    interior = interior_group_velocity(
+        p=scheme_params.p, nu=scheme_params.nu, xi_array=xi_array,
+    )
+    C_int = interior.group_velocity
+
+    profiles: dict[float, dict[int, GroupVelocityProfile]] = {}
+    worst_row = 0
+    worst_psi = float(psi_values[0])
+    worst_err = 0.0
+    global_min_C = float("inf")
+    has_sign_reversal = False
+
+    for pv in psi_values:
+        pv_f = float(pv)
+        profs = cut_cell_group_velocity(
+            cc_result, psi_sym, pv_f, alpha_values, xi_array, order=order,
+        )
+        profiles[pv_f] = profs
+
+        for row_idx, prof in profs.items():
+            C = prof.group_velocity
+
+            # Track worst group velocity error
+            max_err = float(np.max(np.abs(prof.gv_error)))
+            if max_err > worst_err:
+                worst_err = max_err
+                worst_row = row_idx
+                worst_psi = pv_f
+
+            # Track most negative C
+            row_min = float(np.min(C))
+            if row_min < global_min_C:
+                global_min_C = row_min
+
+            # Detect sign reversal: boundary C > 0 where interior C < 0
+            reversal_mask = (C > 0) & (C_int < 0)
+            if np.any(reversal_mask):
+                has_sign_reversal = True
+
+    return PsiSweepResult(
+        psi_values=np.asarray(psi_values),
+        profiles=profiles,
+        worst_row=worst_row,
+        worst_psi=worst_psi,
+        min_C=global_min_C,
+        has_sign_reversal=has_sign_reversal,
+    )
+
+
+def local_group_velocity(
+    weights_func,
+    x: np.ndarray,
+    xi_array: np.ndarray,
+) -> np.ndarray:
+    """Compute local group velocity for a varying-coefficient problem.
+
+    For a varying-coefficient problem ``u_t + a(x)*u_x = 0``, the stencil
+    coefficients may be x-dependent (e.g., through ``a(x)`` scaling or
+    through ``psi(x)`` for cut cells).  At each grid point,
+    ``weights_func(x)`` returns the local stencil weights and offsets, and
+    the group velocity is computed from those.
+
+    Parameters
+    ----------
+    weights_func : callable
+        ``weights_func(x_val) -> (weights, offsets)`` where *weights* is a
+        1-D array of stencil coefficients and *offsets* is a 1-D array of
+        (possibly non-integer) grid offsets from the evaluation point.
+    x : np.ndarray
+        Grid point coordinates, shape ``(N_x,)``.
+    xi_array : np.ndarray
+        Wavenumber values xi in ``[0, pi]``, shape ``(N_xi,)``.
+
+    Returns
+    -------
+    np.ndarray, shape ``(N_x, N_xi)``
+        Local group velocity ``C[i_x, i_xi]`` at each grid point and
+        wavenumber.
+    """
+    N_x = len(x)
+    N_xi = len(xi_array)
+    C = np.empty((N_x, N_xi))
+
+    for i in range(N_x):
+        weights, offsets = weights_func(x[i])
+        C[i, :] = group_velocity_exact_nonuniform(weights, offsets, xi_array)
+
+    return C
+
+
+@dataclass
+class RayTraceResult:
+    """Trajectory of a ray traced through a group velocity field.
+
+    Attributes
+    ----------
+    t : np.ndarray
+        Time array, shape ``(N_t,)``.
+    x : np.ndarray
+        Position trajectory, shape ``(N_t,)``.
+    xi : np.ndarray
+        Wavenumber trajectory, shape ``(N_t,)``.
+    """
+
+    t: np.ndarray
+    x: np.ndarray
+    xi: np.ndarray
+
+
+def ray_trace_group_velocity(
+    C_field: np.ndarray,
+    x_grid: np.ndarray,
+    xi_array: np.ndarray,
+    xi_0: float,
+    x_0: float,
+    t_final: float,
+    dt: float,
+) -> RayTraceResult:
+    """Trace a ray through a spatially varying group velocity field.
+
+    Integrates the ray equations:
+
+    - ``dx/dt = C(x, xi)``   (group velocity)
+    - ``dxi/dt = -dC/dx``    (refraction; Trefethen 1982, Eq. 4.9b)
+
+    using classical RK4, with bilinear interpolation of the group velocity
+    field ``C_field`` (from :func:`local_group_velocity`).
+
+    Parameters
+    ----------
+    C_field : np.ndarray, shape ``(N_x, N_xi)``
+        Local group velocity field ``C[i_x, i_xi]``.
+    x_grid : np.ndarray, shape ``(N_x,)``
+        Grid point coordinates corresponding to axis 0 of *C_field*.
+    xi_array : np.ndarray, shape ``(N_xi,)``
+        Wavenumber values corresponding to axis 1 of *C_field*.
+    xi_0 : float
+        Initial wavenumber.
+    x_0 : float
+        Initial position.
+    t_final : float
+        Final integration time.
+    dt : float
+        Time step.
+
+    Returns
+    -------
+    RayTraceResult
+    """
+    from scipy.interpolate import RegularGridInterpolator
+
+    # Build interpolators for C and dC/dx
+    interp_C = RegularGridInterpolator(
+        (x_grid, xi_array), C_field, method="linear", bounds_error=False,
+        fill_value=None,
+    )
+
+    # dC/dx via finite differences along the x-axis
+    dCdx = np.gradient(C_field, x_grid, axis=0)
+    interp_dCdx = RegularGridInterpolator(
+        (x_grid, xi_array), dCdx, method="linear", bounds_error=False,
+        fill_value=None,
+    )
+
+    # RK4 integration
+    n_steps = max(1, int(np.ceil(t_final / dt)))
+    dt_actual = t_final / n_steps
+
+    t_arr = np.empty(n_steps + 1)
+    x_arr = np.empty(n_steps + 1)
+    xi_arr = np.empty(n_steps + 1)
+
+    t_arr[0] = 0.0
+    x_arr[0] = x_0
+    xi_arr[0] = xi_0
+
+    def rhs(x_val, xi_val):
+        pt = np.array([[x_val, xi_val]])
+        dx_dt = float(interp_C(pt)[0])
+        dxi_dt = -float(interp_dCdx(pt)[0])
+        return dx_dt, dxi_dt
+
+    for n in range(n_steps):
+        x_n, xi_n = x_arr[n], xi_arr[n]
+
+        k1x, k1xi = rhs(x_n, xi_n)
+        k2x, k2xi = rhs(x_n + 0.5 * dt_actual * k1x, xi_n + 0.5 * dt_actual * k1xi)
+        k3x, k3xi = rhs(x_n + 0.5 * dt_actual * k2x, xi_n + 0.5 * dt_actual * k2xi)
+        k4x, k4xi = rhs(x_n + dt_actual * k3x, xi_n + dt_actual * k3xi)
+
+        x_arr[n + 1] = x_n + (dt_actual / 6.0) * (k1x + 2 * k2x + 2 * k3x + k4x)
+        xi_arr[n + 1] = xi_n + (dt_actual / 6.0) * (k1xi + 2 * k2xi + 2 * k3xi + k4xi)
+        t_arr[n + 1] = t_arr[n] + dt_actual
+
+    return RayTraceResult(t=t_arr, x=x_arr, xi=xi_arr)
+
+
+def gks_group_velocity_check(
+    D: np.ndarray,
+    xi_array: np.ndarray,
+    neutral_tol: float = 0.1,
+    localization_tol: float = 0.3,
+    side: str = "left",
+) -> list[GKSModeInfo]:
+    """Identify boundary modes whose group velocity indicates GKS-type instability.
+
+    For the advection equation u_t + u_x = 0 semi-discretized as du/dt = -Du,
+    computes eigenvalues and eigenvectors of -D_bc (D with the inflow row/column
+    removed).  Identifies boundary-localized, nearly-neutral eigenmodes and
+    checks whether the interior stencil's group velocity at each mode's dominant
+    wavenumber directs energy from the boundary into the domain — the hallmark
+    of GKS instability (Trefethen 1983).
+
+    Parameters
+    ----------
+    D : np.ndarray
+        Full N×N differentiation matrix (approximating d/dx).
+    xi_array : np.ndarray
+        Wavenumber array in [0, pi] for group velocity evaluation.
+    neutral_tol : float
+        Fraction of max|Re(lambda)| below which an eigenvalue is considered
+        nearly-neutral.  Default 0.1.
+    localization_tol : float
+        Minimum fraction of eigenvector energy in the boundary region
+        required to classify a mode as boundary-localized.  Default 0.3.
+    side : str
+        Which boundary to analyse.  ``"left"`` (default) removes row/col 0
+        (Dirichlet at x=0).  ``"right"`` removes the last row/col (Dirichlet
+        at x=L) and flips the outgoing-mode sign convention.  ``"bottom"``
+        and ``"top"`` are reserved for 2D operators (deferred to phase 41.6)
+        and raise ``NotImplementedError``.
+
+    Returns
+    -------
+    list[GKSModeInfo]
+        One entry per boundary-localized, nearly-neutral eigenmode.
+    """
+    _valid_sides = ("left", "right", "bottom", "top")
+    if side not in _valid_sides:
+        raise ValueError(f"side must be one of {_valid_sides}, got {side!r}")
+    if side in ("bottom", "top"):
+        raise NotImplementedError(
+            f"side={side!r} requires a 2D differentiation matrix; "
+            "deferred to phase 41.6"
+        )
+
+    n = D.shape[0]
+    if side == "left":
+        D_bc = D[1:, 1:]  # remove inflow row/column (Dirichlet at x=0)
+    else:  # side == "right"
+        D_bc = D[:-1, :-1]  # remove outflow row/column (Dirichlet at x=L)
+    m = D_bc.shape[0]
+
+    eigenvalues, eigenvectors = np.linalg.eig(-D_bc)
+
+    # Nearly-neutral threshold
+    max_abs_real = np.max(np.abs(eigenvalues.real))
+    threshold = max(neutral_tol * max_abs_real, 1e-10)
+
+    # Interior group velocity profile from D's middle row
+    mid = n // 2
+    row = D[mid, :]
+    cols = np.nonzero(np.abs(row) > 1e-15)[0]
+    C_profile = group_velocity_exact(row[cols], mid, cols, xi_array)
+
+    # Boundary region width: ~1/4 of domain, at least 4 points
+    bw = max(4, m // 4)
+
+    results: list[GKSModeInfo] = []
+    for idx in range(len(eigenvalues)):
+        lam = eigenvalues[idx]
+
+        # Skip conjugate duplicates: keep the positive-imaginary member
+        if lam.imag < -1e-10:
+            continue
+
+        if abs(lam.real) > threshold:
+            continue
+
+        v = eigenvectors[:, idx]
+        energy = np.abs(v) ** 2
+        total = np.sum(energy)
+        if total < 1e-30:
+            continue
+
+        # Check boundary localization
+        left_frac = np.sum(energy[:bw]) / total
+        right_frac = np.sum(energy[-bw:]) / total
+
+        if max(left_frac, right_frac) < localization_tol:
+            continue  # interior mode, not boundary-localized
+
+        # Use the side where more energy is concentrated
+        if left_frac >= right_frac:
+            portion = v[:bw]
+            mode_side = "left"
+        else:
+            portion = v[-bw:]
+            mode_side = "right"
+
+        # Estimate dominant wavenumber via zero-padded FFT
+        pad_len = max(256, 4 * len(portion))
+        spec = np.abs(np.fft.fft(portion, n=pad_len))
+        nyq = pad_len // 2
+        # Skip DC (k=0); search bins 1..nyq for the peak
+        peak = int(np.argmax(spec[1 : nyq + 1])) + 1
+        dom_xi = float(peak * 2 * np.pi / pad_len)
+
+        # Interpolate interior group velocity at the dominant wavenumber
+        C_val = float(np.interp(dom_xi, xi_array, C_profile))
+
+        # Outgoing = energy radiating from boundary into domain interior.
+        # Left boundary: rightward (C > 0) enters the domain.
+        # Right boundary: leftward (C < 0) enters the domain.
+        # When side="right", the sign convention flips: the boundary is at x=L,
+        # so C < 0 (leftward into the domain from the right boundary) is outgoing.
+        if mode_side == "left":
+            is_out = C_val > 0
+        else:
+            is_out = C_val < 0
+
+        results.append(
+            GKSModeInfo(
+                eigenvalue=lam,
+                boundary_wavenumber=dom_xi,
+                group_velocity=C_val,
+                is_outgoing=is_out,
+            )
+        )
+
+    return results
+
+
+def local_group_velocity_2d_varying(
+    interior_stencil_x: tuple[np.ndarray, np.ndarray],
+    interior_stencil_y: tuple[np.ndarray, np.ndarray],
+    c_x_field: np.ndarray,
+    c_y_field: np.ndarray,
+    xi_array: np.ndarray,
+) -> dict:
+    """Compute local group velocity error on a 2D varying-coefficient field.
+
+    For the PDE ``u_t + c_x(x,y) u_x + c_y(x,y) u_y = 0`` discretized with
+    tensor-product interior stencils, the local (frozen-coefficient) group
+    velocity at grid point ``(i,j)`` is ``(c_x[i,j]*C_x(xi), c_y[i,j]*C_y(xi))``
+    where ``C_x`` and ``C_y`` are the 1D interior group velocity profiles.
+
+    For smooth ``(c_x, c_y)`` fields, this local-frozen-coefficient analysis
+    is the first-order WKB approximation to the varying-coefficient dispersion
+    relation (see e.g. Trefethen 1982, Vichnevetsky & Bowles 1982).
+
+    Parameters
+    ----------
+    interior_stencil_x : (weights, offsets)
+        Interior stencil for the x-direction.
+    interior_stencil_y : (weights, offsets)
+        Interior stencil for the y-direction.
+    c_x_field : np.ndarray, shape (Ny, Nx)
+        x-component of the coefficient field.
+    c_y_field : np.ndarray, shape (Ny, Nx)
+        y-component of the coefficient field.
+    xi_array : np.ndarray, shape (N_xi,)
+        Wavenumber values in [0, pi].
+
+    Returns
+    -------
+    dict with keys:
+        C_x_field : np.ndarray, shape (Ny, Nx, N_xi)
+            Local group velocity in x at each grid point.
+        C_y_field : np.ndarray, shape (Ny, Nx, N_xi)
+            Local group velocity in y at each grid point.
+        gv_error_x_field : np.ndarray, shape (Ny, Nx, N_xi)
+            ``c_x[i,j] * gv_error_x(xi)`` — absolute GV error in x.
+        gv_error_y_field : np.ndarray, shape (Ny, Nx, N_xi)
+            ``c_y[i,j] * gv_error_y(xi)`` — absolute GV error in y.
+    """
+    w_x, off_x = np.asarray(interior_stencil_x[0]), np.asarray(interior_stencil_x[1])
+    w_y, off_y = np.asarray(interior_stencil_y[0]), np.asarray(interior_stencil_y[1])
+
+    # 1D GV profiles (same for all grid points)
+    C_x_1d = group_velocity_exact_nonuniform(w_x, off_x, xi_array)  # shape (N_xi,)
+    C_y_1d = group_velocity_exact_nonuniform(w_y, off_y, xi_array)
+
+    # 1D GV error: (C - 1) / 1
+    gv_err_x_1d = group_velocity_error(C_x_1d)  # shape (N_xi,)
+    gv_err_y_1d = group_velocity_error(C_y_1d)
+
+    # Broadcast: c_field[i,j] * profile[xi] → (Ny, Nx, N_xi)
+    C_x_out = c_x_field[:, :, np.newaxis] * C_x_1d[np.newaxis, np.newaxis, :]
+    C_y_out = c_y_field[:, :, np.newaxis] * C_y_1d[np.newaxis, np.newaxis, :]
+
+    gv_err_x_out = c_x_field[:, :, np.newaxis] * gv_err_x_1d[np.newaxis, np.newaxis, :]
+    gv_err_y_out = c_y_field[:, :, np.newaxis] * gv_err_y_1d[np.newaxis, np.newaxis, :]
+
+    return {
+        "C_x_field": C_x_out,
+        "C_y_field": C_y_out,
+        "gv_error_x_field": gv_err_x_out,
+        "gv_error_y_field": gv_err_y_out,
+    }
+
+
+def max_local_gv_error_2d(result: dict) -> float:
+    """Scalar reduction: max absolute local GV error over all points and wavenumbers.
+
+    Parameters
+    ----------
+    result : dict
+        Output of :func:`local_group_velocity_2d_varying`.
+
+    Returns
+    -------
+    float
+        ``max(|gv_error_x_field|, |gv_error_y_field|)`` over all (i, j, xi).
+    """
+    max_x = float(np.max(np.abs(result["gv_error_x_field"])))
+    max_y = float(np.max(np.abs(result["gv_error_y_field"])))
+    return max(max_x, max_y)
+
+
+# Scheme → half-bandwidth mapping (duplicated from brady2d_stability to avoid
+# circular dependency; only E2 and E4 are in scope).
+_SCHEME_P = {"E2": 1, "E4": 2}
+
+
+def anisotropy_over_coefficient_field(
+    scheme: str,
+    c_x_field: np.ndarray,
+    c_y_field: np.ndarray,
+    theta_array: np.ndarray,
+    xi_mag: float,
+) -> dict:
+    """Evaluate 2D anisotropy error projected onto a spatially varying advection field.
+
+    For each grid point ``(i, j)`` the local propagation direction is
+    ``(c_x[i,j], c_y[i,j]) / |(c_x, c_y)|``.  The scheme's
+    :func:`anisotropy_profile` — computed once at wavenumber magnitude
+    *xi_mag* — gives the numerical group velocity error as a function of
+    propagation angle.  This function interpolates that error at each
+    grid point's local angle and returns the maximum over the field.
+
+    The aligned error at a point is the Euclidean norm of the group
+    velocity error vector ``|C_numerical - C_exact|`` at the local
+    propagation angle, which captures both speed and angular deviations.
+
+    Parameters
+    ----------
+    scheme : str
+        Scheme name (``"E2"`` or ``"E4"``).
+    c_x_field, c_y_field : np.ndarray, shape (Ny, Nx)
+        Spatially varying advection velocity components.
+    theta_array : np.ndarray
+        Propagation angles (radians) at which the anisotropy profile
+        is evaluated.  Should cover at least the range of local angles
+        in ``arctan2(c_y_field, c_x_field)``.
+    xi_mag : float
+        Wavenumber magnitude in ``[0, pi]``.
+
+    Returns
+    -------
+    dict
+        ``max_aligned_error`` : float
+            Maximum ``|C_numerical - C_exact|`` over all grid points.
+        ``worst_point`` : tuple[int, int]
+            ``(i, j)`` index of the grid point with the largest error.
+        ``worst_theta`` : float
+            Local propagation angle at the worst point.
+    """
+    p = _SCHEME_P[scheme]
+    anis = anisotropy_profile(p, nu=1, theta_array=theta_array, xi_mag=xi_mag)
+
+    # Error vector magnitude at each theta in theta_array:
+    # exact GV = (cos(theta), sin(theta)), numerical = (C_x, C_y)
+    err_mag = np.sqrt(
+        (anis.C_x - np.cos(anis.theta)) ** 2
+        + (anis.C_y - np.sin(anis.theta)) ** 2
+    )
+
+    # Local propagation angle at each grid point
+    theta_local = np.arctan2(c_y_field, c_x_field)  # shape (Ny, Nx)
+
+    # Interpolate err_mag onto local angles.  np.interp requires sorted
+    # xp, so sort theta_array and err_mag together.
+    sort_idx = np.argsort(theta_array)
+    theta_sorted = theta_array[sort_idx]
+    err_sorted = err_mag[sort_idx]
+    aligned_error = np.interp(theta_local, theta_sorted, err_sorted)
+
+    # Scalar reduction
+    flat_idx = int(np.argmax(aligned_error))
+    worst_ij = np.unravel_index(flat_idx, aligned_error.shape)
+
+    return {
+        "max_aligned_error": float(np.max(aligned_error)),
+        "worst_point": (int(worst_ij[0]), int(worst_ij[1])),
+        "worst_theta": float(theta_local[worst_ij]),
+    }

--- a/scripts/stencil_gen/stencil_gen/non_normality.py
+++ b/scripts/stencil_gen/stencil_gen/non_normality.py
@@ -1,0 +1,550 @@
+"""Non-normality diagnostics for semi-discrete spatial operators.
+
+Computes spectral and pseudospectral stability metrics that detect
+transient growth not visible from eigenvalues alone.  Calibration bands
+follow Trefethen & Embree, *Spectra and Pseudospectra* (2005), ch. 14.
+
+Metrics provided:
+- spectral abscissa: max Re(lambda) — asymptotic stability indicator
+- numerical abscissa: max eigenvalue of (L + L^T)/2 — instantaneous growth rate
+- Henrici departure from normality: ||LL^T - L^TL||_F / ||L||_F^2
+- eigenvector condition number: cond(V) where L = V diag(lambda) V^{-1}
+- pseudospectral abscissa: max Re(s) such that sigma_min(sI - L) <= epsilon
+- Kreiss constant: max Re(s)/sigma_min(sI - L) for Re(s) > 0
+- transient growth bound: e * Kreiss constant (Kreiss matrix theorem)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import numpy as np
+
+logger = logging.getLogger("stencil_gen.non_normality")
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NonNormalityReport:
+    """Collected non-normality diagnostics for a spatial operator."""
+
+    spectral_abscissa: float
+    """max Re(lambda(L)) — asymptotic stability indicator."""
+
+    numerical_abscissa: float
+    """max eigenvalue of (L + L^T)/2 — instantaneous growth rate."""
+
+    henrici_departure: float
+    """||LL^T - L^TL||_F / ||L||_F^2 — departure from normality."""
+
+    eigenvector_condition: float
+    """cond(V) where L = V diag(lambda) V^{-1}.  NaN if N too large."""
+
+    pseudospectral_abscissae: dict[float, float]
+    """epsilon -> alpha_epsilon for each requested epsilon."""
+
+    kreiss_constant: float
+    """max Re(s) / sigma_min(sI - L) over Re(s) > 0."""
+
+    transient_growth_bound: float
+    """e * kreiss_constant — upper bound on max_{t>=0} ||exp(Lt)||."""
+
+    n: int
+    """Matrix dimension."""
+
+    compute_time: float
+    """Wall-clock seconds for the full computation."""
+
+    notes: list[str] = field(default_factory=list)
+    """Diagnostic notes (convergence warnings, fallbacks, etc.)."""
+
+
+# ---------------------------------------------------------------------------
+# Individual metric functions (stubs — implemented in 41.8b through 41.8e)
+# ---------------------------------------------------------------------------
+
+
+def spectral_abscissa_sparse(L, k: int = 20, shift_invert: bool = True, rng_seed: int = 0):
+    """Compute max Re(lambda) of sparse matrix L via Arnoldi iteration.
+
+    Parameters
+    ----------
+    L : scipy.sparse matrix or dense ndarray
+        The spatial operator.
+    k : int
+        Number of eigenvalues to compute.
+    shift_invert : bool
+        Whether to use shift-invert mode on ArpackNoConvergence.
+    rng_seed : int
+        Seed for the ARPACK starting vector. scipy 1.17's ``eigs`` draws a
+        fresh OS-entropy Generator per call when rng is None, making
+        convergence path non-deterministic across processes for operators
+        (e.g. BL42) whose eigenvalues cluster on the imaginary axis. Passing
+        a fixed integer here pins that starting vector so repeated calls —
+        including across subprocess invocations — return identical values.
+
+    Returns
+    -------
+    tuple[float, np.ndarray]
+        (max_real_part, all_computed_eigenvalues)
+    """
+    import scipy.sparse as sp
+    from scipy.sparse.linalg import eigs, ArpackNoConvergence, ArpackError
+
+    n = L.shape[0]
+
+    # Dense fallback for small matrices
+    if n <= 900 and (not sp.issparse(L) or n <= k + 1):
+        A = L.toarray() if sp.issparse(L) else np.asarray(L)
+        evals = np.linalg.eigvals(A)
+        return float(np.max(evals.real)), evals
+
+    # Ensure sparse format for Arnoldi
+    if not sp.issparse(L):
+        L = sp.csr_matrix(L)
+
+    # Clamp k to valid range: k must be < n for eigs
+    k_use = min(k, n - 2) if n > 2 else 1
+
+    # Primary: standard Arnoldi for rightmost eigenvalues
+    try:
+        evals = eigs(L, k=k_use, which="LR", return_eigenvectors=False,
+                     rng=rng_seed)
+        return float(np.max(evals.real)), evals
+    except ArpackNoConvergence as exc:
+        logger.debug("eigs(which='LR') did not converge: %s", exc)
+        if exc.eigenvalues is not None and len(exc.eigenvalues) > 0:
+            # Some eigenvalues did converge — use them
+            evals = exc.eigenvalues
+            logger.debug("Using %d partially converged eigenvalues", len(evals))
+            return float(np.max(evals.real)), evals
+
+    # Retry with shift-invert around the imaginary axis
+    if shift_invert:
+        try:
+            evals = eigs(L, k=k_use, sigma=0.0, which="LR",
+                         return_eigenvectors=False, rng=rng_seed)
+            return float(np.max(evals.real)), evals
+        except (ArpackNoConvergence, ArpackError) as exc:
+            logger.debug("Shift-invert eigs failed: %s", exc)
+            if isinstance(exc, ArpackNoConvergence) and exc.eigenvalues is not None and len(exc.eigenvalues) > 0:
+                evals = exc.eigenvalues
+                return float(np.max(evals.real)), evals
+
+    # Final fallback: densify if small enough
+    if n <= 900:
+        A = L.toarray() if sp.issparse(L) else np.asarray(L)
+        evals = np.linalg.eigvals(A)
+        return float(np.max(evals.real)), evals
+
+    raise RuntimeError(
+        f"spectral_abscissa_sparse: all Arnoldi attempts failed for {n}x{n} "
+        f"matrix and N > 900 prevents dense fallback"
+    )
+
+
+def numerical_abscissa_sparse(L, rng_seed: int = 0) -> float:
+    """Compute max eigenvalue of (L + L^T)/2 — the numerical abscissa.
+
+    Parameters
+    ----------
+    L : scipy.sparse matrix or dense ndarray
+        The spatial operator.
+    rng_seed : int
+        Seed for the ARPACK starting vector. scipy 1.17's ``eigsh`` draws a
+        fresh OS-entropy Generator per call when rng is None, making
+        convergence path non-deterministic across processes for operators
+        whose top Hermitian-part eigenvalues are clustered. Passing a fixed
+        integer here pins that starting vector so repeated calls — including
+        across subprocess invocations — return identical values. Only
+        relevant for the sparse Arnoldi path (``n > 900``).
+
+    Returns
+    -------
+    float
+        The numerical abscissa (instantaneous growth rate).
+    """
+    import scipy.sparse as sp
+    from scipy.sparse.linalg import eigsh, ArpackNoConvergence, ArpackError
+
+    n = L.shape[0]
+
+    # Build Hermitian part H = (L + L^T) / 2
+    if sp.issparse(L):
+        H = (L + L.T) / 2.0
+    else:
+        A = np.asarray(L, dtype=float)
+        H = (A + A.T) / 2.0
+
+    # Dense path for small matrices
+    if n <= 900 and (not sp.issparse(H) or n <= 2):
+        H_dense = H.toarray() if sp.issparse(H) else np.asarray(H)
+        evals = np.linalg.eigvalsh(H_dense)
+        return float(evals[-1])
+
+    if not sp.issparse(H):
+        H = sp.csr_matrix(H)
+
+    k_use = min(1, n - 2) if n > 2 else 1
+    try:
+        evals = eigsh(H, k=k_use, which="LA", return_eigenvectors=False,
+                      rng=rng_seed)
+        return float(np.max(evals))
+    except (ArpackNoConvergence, ArpackError) as exc:
+        logger.debug("eigsh(which='LA') failed: %s", exc)
+        if isinstance(exc, ArpackNoConvergence) and exc.eigenvalues is not None and len(exc.eigenvalues) > 0:
+            return float(np.max(exc.eigenvalues))
+
+    # Dense fallback
+    if n <= 900:
+        H_dense = H.toarray() if sp.issparse(H) else np.asarray(H)
+        evals = np.linalg.eigvalsh(H_dense)
+        return float(evals[-1])
+
+    raise RuntimeError(
+        f"numerical_abscissa_sparse: eigsh failed for {n}x{n} matrix "
+        f"and N > 900 prevents dense fallback"
+    )
+
+
+def henrici_departure(L) -> float:
+    """Compute Henrici departure from normality: ||LL^T - L^TL||_F / ||L||_F^2.
+
+    Parameters
+    ----------
+    L : scipy.sparse matrix or dense ndarray
+        The spatial operator.
+
+    Returns
+    -------
+    float
+        Non-negative scalar; 0 for normal operators.
+    """
+    import scipy.sparse as sp
+    from scipy.sparse.linalg import norm as sp_norm
+
+    if sp.issparse(L):
+        LLt = L @ L.T
+        LtL = L.T @ L
+        diff = LLt - LtL
+        numer = sp_norm(diff, "fro")
+        denom = sp_norm(L, "fro") ** 2
+    else:
+        A = np.asarray(L, dtype=float)
+        diff = A @ A.T - A.T @ A
+        numer = np.linalg.norm(diff, "fro")
+        denom = np.linalg.norm(A, "fro") ** 2
+
+    if denom == 0.0:
+        return 0.0
+    return float(numer / denom)
+
+
+def eigenvector_condition(L, small_dense_threshold: int = 900) -> float:
+    """Compute condition number of the eigenvector matrix.
+
+    Parameters
+    ----------
+    L : scipy.sparse matrix or dense ndarray
+        The spatial operator.
+    small_dense_threshold : int
+        If N > threshold, return np.nan (too expensive for dense eig).
+
+    Returns
+    -------
+    float
+        cond(V) where L = V diag(lambda) V^{-1}, or np.nan if N too large.
+    """
+    import scipy.sparse as sp
+
+    n = L.shape[0]
+    if n > small_dense_threshold:
+        return np.nan
+
+    A = L.toarray() if sp.issparse(L) else np.asarray(L, dtype=float)
+    evals, V = np.linalg.eig(A)
+    return float(np.linalg.cond(V))
+
+
+def _sigma_field(L, s_grid: np.ndarray) -> np.ndarray:
+    """Compute sigma_min(sI - L) over a grid of complex s values.
+
+    For each complex *s* in *s_grid*, forms ``M = sI - L`` and returns
+    the smallest singular value of *M*.  This is the resolvent norm
+    ``||R(s, L)||^{-1}`` used to define ε-pseudospectra.
+
+    Parameters
+    ----------
+    L : scipy.sparse matrix or dense ndarray
+        The spatial operator.
+    s_grid : np.ndarray
+        Complex-valued array of s points (arbitrary shape).
+
+    Returns
+    -------
+    np.ndarray
+        Array of same shape as s_grid with sigma_min values.
+    """
+    import scipy.sparse as sp
+    from scipy.sparse.linalg import svds, ArpackError
+
+    n = L.shape[0]
+    # Dense SVD is preferred for n ≤ 1200: sparse svds(which='SM') is
+    # unreliable for non-symmetric operators and ARPACK failures are very
+    # expensive (~5 s per point at n ≈ 1000), while dense SVD at n=961 is
+    # only ~0.2 s per point.
+    use_dense = n <= 1200
+
+    if sp.issparse(L):
+        L_sp = L.tocsc()
+        I_sp = sp.eye(n, format="csc")
+    else:
+        L_dense = np.asarray(L, dtype=complex)
+        if not use_dense:
+            # Sparse SVD path needs L_sp/I_sp even when input was dense
+            L_sp = sp.csc_matrix(L_dense)
+            I_sp = sp.eye(n, format="csc")
+
+    flat = s_grid.ravel()
+    result = np.empty(flat.shape[0], dtype=float)
+
+    for idx, s in enumerate(flat):
+        if use_dense:
+            if sp.issparse(L):
+                M = (s * I_sp - L_sp).toarray()
+            else:
+                M = s * np.eye(n) - L_dense
+            sv = np.linalg.svd(M, compute_uv=False)
+            result[idx] = float(sv[-1])
+        else:
+            M_sp = s * I_sp - L_sp
+            try:
+                sv = svds(M_sp, k=1, which="SM",
+                          return_singular_vectors=False)
+                result[idx] = float(sv[0])
+            except (ArpackError, Exception) as exc:
+                # Fallback: densify if small enough.  Threshold raised from
+                # 900 to 2000 to support BL-sized 2D operators (n ~ 961).
+                if n <= 2000:
+                    logger.debug("svds failed at s=%s, densifying: %s", s, exc)
+                    M_dense = M_sp.toarray()
+                    sv = np.linalg.svd(M_dense, compute_uv=False)
+                    result[idx] = float(sv[-1])
+                else:
+                    raise RuntimeError(
+                        f"_sigma_field: svds failed at s={s} for {n}x{n} "
+                        f"matrix and N > 2000 prevents dense fallback"
+                    ) from exc
+
+    return result.reshape(s_grid.shape)
+
+
+def pseudospectral_abscissa_estimate(
+    L, epsilon_values, s_grid: np.ndarray
+) -> dict[float, float]:
+    """Estimate pseudospectral abscissa for each epsilon.
+
+    For each epsilon, alpha_epsilon = max Re(s) such that sigma_min(sI - L) <= epsilon.
+    Both functions share the same ``_sigma_field`` evaluation to avoid
+    duplicate SVD cost.
+
+    Parameters
+    ----------
+    L : scipy.sparse matrix or dense ndarray
+        The spatial operator.
+    epsilon_values : sequence of float
+        Perturbation levels.
+    s_grid : np.ndarray
+        Complex-valued grid for the search.
+
+    Returns
+    -------
+    dict[float, float]
+        epsilon -> alpha_epsilon.  -inf if no grid point satisfies.
+    """
+    sigma = _sigma_field(L, s_grid)
+    flat_sigma = sigma.ravel()
+    flat_re = s_grid.ravel().real
+
+    result: dict[float, float] = {}
+    for eps in epsilon_values:
+        mask = flat_sigma <= eps
+        if np.any(mask):
+            result[eps] = float(np.max(flat_re[mask]))
+        else:
+            result[eps] = float("-inf")
+    return result
+
+
+def kreiss_constant_estimate(L, s_grid: np.ndarray) -> float:
+    """Estimate Kreiss constant: max Re(s) / sigma_min(sI - L) for Re(s) > 0.
+
+    Parameters
+    ----------
+    L : scipy.sparse matrix or dense ndarray
+        The spatial operator.
+    s_grid : np.ndarray
+        Complex-valued grid for the search.
+
+    Returns
+    -------
+    float
+        Estimated Kreiss constant.  Returns 0.0 if no grid point has Re(s) > 0.
+    """
+    sigma = _sigma_field(L, s_grid)
+    flat_sigma = sigma.ravel()
+    flat_re = s_grid.ravel().real
+
+    # Only consider points in the open right half-plane
+    mask = flat_re > 0
+    if not np.any(mask):
+        return 0.0
+
+    # K(L) = max_{Re(s) > 0} Re(s) / sigma_min(sI - L)
+    ratios = flat_re[mask] / np.maximum(flat_sigma[mask], 1e-300)
+    return float(np.max(ratios))
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator (41.8f)
+# ---------------------------------------------------------------------------
+
+
+def compute_non_normality(
+    L,
+    *,
+    small_dense_threshold: int = 900,
+    epsilon_values: tuple[float, ...] = (1e-4, 1e-3, 1e-2, 1e-1),
+    s_grid_params: dict | None = None,
+) -> NonNormalityReport:
+    """Compute all non-normality diagnostics for a spatial operator.
+
+    Parameters
+    ----------
+    L : scipy.sparse matrix or dense ndarray
+        The spatial operator.
+    small_dense_threshold : int
+        Threshold for dense-only computations (eigenvector condition).
+    epsilon_values : tuple of float
+        Perturbation levels for pseudospectral abscissa.
+    s_grid_params : dict or None
+        Parameters for the resolvent s-grid.  Keys:
+        ``re_min``, ``re_max``, ``n_re``, ``im_max``, ``n_im``.
+        If None, uses defaults based on the spectral abscissa.
+
+    Returns
+    -------
+    NonNormalityReport
+        Fully populated report with all metrics.
+    """
+    import math
+    import time
+
+    from scipy.sparse.linalg import ArpackNoConvergence
+
+    t0 = time.perf_counter()
+    n = L.shape[0]
+    notes: list[str] = []
+
+    # --- Spectral abscissa ---
+    try:
+        sa, evals = spectral_abscissa_sparse(L, k=min(20, max(1, n - 2)),
+                                             shift_invert=True)
+    except ArpackNoConvergence as exc:
+        notes.append(f"spectral_abscissa: ArpackNoConvergence ({exc})")
+        if exc.eigenvalues is not None and len(exc.eigenvalues) > 0:
+            sa = float(np.max(exc.eigenvalues.real))
+            evals = exc.eigenvalues
+        else:
+            sa = np.nan
+            evals = np.array([])
+
+    # --- Numerical abscissa ---
+    try:
+        na = numerical_abscissa_sparse(L)
+    except Exception as exc:
+        notes.append(f"numerical_abscissa: {type(exc).__name__} ({exc})")
+        na = np.nan
+
+    # --- Henrici departure ---
+    hd = henrici_departure(L)
+
+    # --- Eigenvector condition ---
+    ec = eigenvector_condition(L, small_dense_threshold=small_dense_threshold)
+
+    # --- Build the s-grid for resolvent sampling ---
+    # Default grid resolution: ~30×60 for small matrices, ~8×12 for large
+    # ones (n > 500) to keep runtime feasible with dense SVD (~0.2s/point
+    # at n≈1000, so 96 points ≈ 19s).
+    default_n_re = 8 if n > 500 else 30
+    default_n_im = 12 if n > 500 else 60
+
+    if s_grid_params is not None:
+        re_min = s_grid_params.get("re_min", 1e-3)
+        re_max = s_grid_params.get("re_max", 2.0 * abs(sa) + 1.0 if np.isfinite(sa) else 5.0)
+        n_re = s_grid_params.get("n_re", default_n_re)
+        im_max = s_grid_params.get("im_max", None)
+        n_im = s_grid_params.get("n_im", default_n_im)
+    else:
+        re_min = 1e-3
+        re_max = 2.0 * abs(sa) + 1.0 if np.isfinite(sa) else 5.0
+        n_re = default_n_re
+        im_max = None
+        n_im = default_n_im
+
+    # Estimate ω_max from the imaginary parts of the computed eigenvalues
+    if im_max is None:
+        if len(evals) > 0:
+            im_max = float(np.max(np.abs(evals.imag))) + 1.0
+        else:
+            im_max = 10.0
+    im_max = max(im_max, 1.0)  # ensure at least ±1
+
+    re_vals = np.linspace(re_min, re_max, n_re)
+    im_vals = np.linspace(-im_max, im_max, n_im)
+    s_grid = re_vals[:, None] + 1j * im_vals[None, :]
+
+    # --- Pseudospectral abscissa and Kreiss constant ---
+    # Compute _sigma_field once and reuse for both
+    sigma = _sigma_field(L, s_grid)
+    flat_sigma = sigma.ravel()
+    flat_re = s_grid.ravel().real
+
+    # Pseudospectral abscissa
+    psa: dict[float, float] = {}
+    for eps in epsilon_values:
+        mask = flat_sigma <= eps
+        if np.any(mask):
+            psa[eps] = float(np.max(flat_re[mask]))
+        else:
+            psa[eps] = float("-inf")
+
+    # Kreiss constant
+    rhs_mask = flat_re > 0
+    if np.any(rhs_mask):
+        ratios = flat_re[rhs_mask] / np.maximum(flat_sigma[rhs_mask], 1e-300)
+        kc = float(np.max(ratios))
+    else:
+        kc = 0.0
+
+    tgb = math.e * kc
+
+    elapsed = time.perf_counter() - t0
+
+    return NonNormalityReport(
+        spectral_abscissa=sa,
+        numerical_abscissa=na,
+        henrici_departure=hd,
+        eigenvector_condition=ec,
+        pseudospectral_abscissae=psa,
+        kreiss_constant=kc,
+        transient_growth_bound=tgb,
+        n=n,
+        compute_time=elapsed,
+        notes=notes,
+    )

--- a/scripts/stencil_gen/tests/test_brady2d_stability.py
+++ b/scripts/stencil_gen/tests/test_brady2d_stability.py
@@ -1,0 +1,1527 @@
+"""Tests for stencil_gen.brady2d_stability — layered stability scoring."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from stencil_gen.brady2d_stability import (
+    BL42_TOL,
+    L1_TOL,
+    L4_TOL,
+    L5_TOL,
+    L6_TRANSIENT_GROWTH_TOL,
+    L7_TOL,
+    L7_TRANSIENT_GROWTH_TOL,
+    L8_FINAL_LINF_TOL,
+    STABILITY_TOL,
+    StabilityReport,
+    brady2d_stability_score,
+    build_bl42_operator,
+    build_sparse_2d_operator,
+    layer1_interior_boundary_gv,
+    layer2_kreiss_gks,
+    layer3_1d_eigenvalue,
+    layer4_local_gv_2d,
+    layer5_anisotropy,
+    layer6_non_normality,
+    layer7_sparse_2d_eigenvalue,
+    layer7_with_non_normality,
+    layer8_cpp_simulation,
+    layer_bl42_reflecting_hyperbolic,
+)
+from stencil_gen.cpp_bridge import SHOCCS_BINARY, BridgeResult
+from stencil_gen.gks_kreiss import KreissResult
+from stencil_gen.non_normality import NonNormalityReport
+from stencil_gen.group_velocity import local_group_velocity_2d_varying
+
+
+KNOWN_VALUES_PATH = Path(__file__).parent.parent / "sweeps" / "known_values.json"
+
+
+def _load_known_values():
+    with open(KNOWN_VALUES_PATH) as f:
+        return json.load(f)
+
+
+class TestLayer1:
+    """Layer 1: interior + boundary group velocity error."""
+
+    def test_layer1_classical_e4_passes(self):
+        """Classical E4 with known-good alpha produces boundary_gv_err < L1_TOL."""
+        # Known-good alpha values from E4u_1.t.cpp
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        result = layer1_interior_boundary_gv(
+            "E4", "classical", {"alpha": alpha},
+        )
+        assert result["boundary_gv_err"] < L1_TOL, (
+            f"boundary_gv_err={result['boundary_gv_err']:.6f} >= {L1_TOL}"
+        )
+        assert result["interior_gv_err_x"] < L1_TOL
+        assert result["interior_gv_err_y"] < L1_TOL
+        assert 0 < result["cutoff_fraction"] < 1
+
+    def test_layer1_tension_e4_passes(self):
+        """Tension E4 at sigma=3.0 passes L1."""
+        result = layer1_interior_boundary_gv(
+            "E4", "tension", {"sigma": 3.0},
+        )
+        assert result["boundary_gv_err"] < L1_TOL, (
+            f"boundary_gv_err={result['boundary_gv_err']:.6f} >= {L1_TOL}"
+        )
+        assert result["interior_gv_err_x"] < L1_TOL
+        assert result["interior_gv_err_y"] < L1_TOL
+        assert 0 < result["cutoff_fraction"] < 1
+
+    def test_layer1_gaussian_e4_known_unstable_still_passes_at_this_layer(self):
+        """Gaussian eps=0.1 (known_unstable) passes L1.
+
+        Confirms that L1 is necessary but not sufficient — this scheme is
+        eigenvalue-unstable (fails at L2 or L3) but has acceptable low-frequency
+        dispersion.
+        """
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        result = layer1_interior_boundary_gv(
+            "E4", "gaussian", {"epsilon": eps},
+        )
+        assert result["boundary_gv_err"] < L1_TOL, (
+            f"known-unstable Gaussian eps={eps} boundary_gv_err="
+            f"{result['boundary_gv_err']:.6f} should pass L1"
+        )
+        assert result["interior_gv_err_x"] < L1_TOL
+        assert result["interior_gv_err_y"] < L1_TOL
+
+    def test_layer1_return_keys(self):
+        """Layer 1 returns all expected keys."""
+        result = layer1_interior_boundary_gv(
+            "E4", "tension", {"sigma": 3.0},
+        )
+        expected_keys = {
+            "interior_gv_err_x",
+            "interior_gv_err_y",
+            "boundary_gv_err",
+            "cutoff_fraction",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_layer1_interior_symmetry(self):
+        """interior_gv_err_x == interior_gv_err_y on Cartesian grid."""
+        result = layer1_interior_boundary_gv(
+            "E4", "tension", {"sigma": 3.0},
+        )
+        assert result["interior_gv_err_x"] == result["interior_gv_err_y"]
+
+
+class TestStabilityReport:
+    """Tests for the StabilityReport dataclass."""
+
+    def test_default_values(self):
+        report = StabilityReport()
+        assert report.layer1 is None
+        assert report.layer2 is None
+        assert report.layer3 is None
+        assert report.layer4 is None
+        assert report.layer5 is None
+        assert report.layer6 is None
+        assert report.layer7 is None
+        assert report.layer8 is None
+        assert report.non_normality is None
+        assert report.kreiss is None
+        assert report.failed_layer is None
+        assert report.failed_reason == ""
+        assert report.overall_verdict == "unknown"
+        assert report.compute_time == 0.0
+
+    def test_empty_factory(self):
+        report = StabilityReport.empty()
+        assert report.layer1 is None
+        assert report.layer7 is None
+        assert report.overall_verdict == "unknown"
+        assert report.compute_time == 0.0
+
+    def test_with_layer1(self):
+        result = {"interior_gv_err_x": 0.01, "boundary_gv_err": 0.02}
+        report = StabilityReport(layer1=result, overall_verdict="pass")
+        assert report.layer1 == result
+        assert report.overall_verdict == "pass"
+
+    def test_with_kreiss_result(self):
+        kr = KreissResult(is_stable=True, compute_time=0.5)
+        report = StabilityReport(layer2=kr, kreiss=kr, overall_verdict="pass")
+        assert report.layer2 is kr
+        assert report.kreiss is kr
+        assert report.layer2.is_stable is True
+
+    def test_with_non_normality(self):
+        nn = NonNormalityReport(
+            spectral_abscissa=-1.0,
+            numerical_abscissa=5.0,
+            henrici_departure=0.1,
+            eigenvector_condition=10.0,
+            pseudospectral_abscissae={1e-2: -0.5},
+            kreiss_constant=3.0,
+            transient_growth_bound=3.0 * np.e,
+            n=100,
+            compute_time=1.0,
+        )
+        report = StabilityReport(non_normality=nn, overall_verdict="pass")
+        assert report.non_normality is nn
+        assert report.non_normality.kreiss_constant == 3.0
+
+    def test_failed_report(self):
+        report = StabilityReport(
+            layer1={"boundary_gv_err": 0.01},
+            layer3={"max_stab_eig": 0.5},
+            overall_verdict="fail",
+            failed_layer=3,
+            failed_reason="max_stab_eig=0.5 > STABILITY_TOL",
+        )
+        assert report.overall_verdict == "fail"
+        assert report.failed_layer == 3
+        assert "max_stab_eig" in report.failed_reason
+
+    def test_str_minimal(self):
+        """__str__ works on a minimal (empty) report."""
+        report = StabilityReport.empty()
+        s = str(report)
+        assert "Brady-Livescu 2D Stability Report" in s
+        assert "UNKNOWN" in s
+
+    def test_str_with_layers(self):
+        """__str__ shows layer summaries when populated."""
+        report = StabilityReport(
+            layer1={"boundary_gv_err": 0.01, "interior_gv_err_x": 0.001},
+            layer3={"max_stab_eig": -1e-14},
+            layer4={"max_local_gv_error": 0.003},
+            layer5={"max_aligned_error": 0.02},
+            layer7={"max_spectral_abscissa": -0.001},
+            overall_verdict="pass",
+            compute_time=2.5,
+        )
+        s = str(report)
+        assert "L1" in s
+        assert "L3" in s
+        assert "L4" in s
+        assert "L5" in s
+        assert "L7" in s
+        assert "PASS" in s
+        assert "2.50s" in s
+
+    def test_str_failed_report(self):
+        """__str__ shows failure info when a layer fails."""
+        report = StabilityReport(
+            layer1={"boundary_gv_err": 0.01},
+            overall_verdict="fail",
+            failed_layer=3,
+            failed_reason="max_stab_eig > STABILITY_TOL",
+            compute_time=0.1,
+        )
+        s = str(report)
+        assert "FAIL" in s
+        assert "layer 3" in s
+
+
+class TestLayer3:
+    """Layer 3: 1D eigenvalue stability check at multiple grid sizes."""
+
+    def test_classical_e4_stable(self):
+        """Classical E4 with known-good alpha is stable at all grid sizes."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        result = layer3_1d_eigenvalue("E4", "classical", {"alpha": alpha})
+        for n, se in result["eigenvalues"].items():
+            assert se <= STABILITY_TOL, (
+                f"Classical E4 unstable at n={n}: max Re(lambda)={se:.6e}"
+            )
+        assert result["max_stab_eig"] <= STABILITY_TOL
+
+    def test_tension_e4_sigma_3_stable(self):
+        """Tension E4 at sigma=3.0 is stable at all grid sizes."""
+        result = layer3_1d_eigenvalue("E4", "tension", {"sigma": 3.0})
+        for n, se in result["eigenvalues"].items():
+            assert se <= STABILITY_TOL, (
+                f"Tension E4 sigma=3.0 unstable at n={n}: max Re(lambda)={se:.6e}"
+            )
+        assert result["max_stab_eig"] <= STABILITY_TOL
+
+    def test_gaussian_e4_eps_01_unstable(self):
+        """Gaussian E4 eps=0.1 (known_unstable) fails L3."""
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        result = layer3_1d_eigenvalue(
+            "E4", "gaussian", {"epsilon": eps},
+        )
+        assert result["max_stab_eig"] > STABILITY_TOL, (
+            f"Expected Gaussian eps={eps} to be unstable, got "
+            f"max_stab_eig={result['max_stab_eig']:.6e}"
+        )
+
+    def test_return_keys(self):
+        """Layer 3 returns expected keys."""
+        result = layer3_1d_eigenvalue("E4", "tension", {"sigma": 3.0})
+        assert "eigenvalues" in result
+        assert "max_stab_eig" in result
+        assert set(result["eigenvalues"].keys()) == {20, 40, 80}
+
+    def test_custom_n_values(self):
+        """Custom n_values are respected."""
+        result = layer3_1d_eigenvalue(
+            "E4", "tension", {"sigma": 3.0}, n_values=(15, 30),
+        )
+        assert set(result["eigenvalues"].keys()) == {15, 30}
+
+
+class TestBuildBL42Operator:
+    """Tests for the BL §4.2 reflecting-hyperbolic block operator."""
+
+    def test_shape_at_n21(self):
+        """N=21 returns (40, 40) sparse matrix."""
+        D = np.zeros((21, 21))
+        L = build_bl42_operator(D)
+        assert L.shape == (40, 40)
+
+    def test_block_structure_small_n(self):
+        """N=5, centered difference D: diagonal blocks are zero, off-diagonals are D submatrices."""
+        N = 5
+        D = np.zeros((N, N))
+        for i in range(1, N - 1):
+            D[i, i - 1] = -0.5
+            D[i, i + 1] = 0.5
+        D[0, 0] = -1.0; D[0, 1] = 1.0
+        D[N - 1, N - 2] = -1.0; D[N - 1, N - 1] = 1.0
+
+        L = build_bl42_operator(D)
+        L_dense = L.toarray()
+
+        assert L.shape == (2 * N - 2, 2 * N - 2)
+
+        n = N - 1
+        top_left = L_dense[:n, :n]
+        bottom_right = L_dense[n:, n:]
+        top_right = L_dense[:n, n:]
+        bottom_left = L_dense[n:, :n]
+
+        np.testing.assert_allclose(top_left, 0.0, atol=1e-15)
+        np.testing.assert_allclose(bottom_right, 0.0, atol=1e-15)
+
+        h = 1.0 / (N - 1)
+        D_h = D / h
+        # top-right = u eqs × v vars = D/h with row 0 removed, col N-1 removed
+        np.testing.assert_allclose(top_right, D_h[1:, :-1], atol=1e-15)
+        # bottom-left = v eqs × u vars = D/h with row N-1 removed, col 0 removed
+        np.testing.assert_allclose(bottom_left, D_h[:-1, 1:], atol=1e-15)
+
+    def test_spectrum_near_imaginary_for_centered_scheme(self):
+        """2nd-order centered D at N=21 gives purely imaginary spectrum."""
+        N = 21
+        D = np.zeros((N, N))
+        for i in range(1, N - 1):
+            D[i, i - 1] = -0.5
+            D[i, i + 1] = 0.5
+        D[0, 0] = -1.0; D[0, 1] = 1.0
+        D[N - 1, N - 2] = -1.0; D[N - 1, N - 1] = 1.0
+
+        L = build_bl42_operator(D)
+        eigvals = np.linalg.eigvals(L.toarray())
+        max_re = np.max(np.abs(eigvals.real))
+        assert max_re < 1e-10, f"max |Re(lambda)| = {max_re}"
+
+
+class TestLayerBL42:
+    """Layer BL42 (L3r): reflecting-hyperbolic eigenvalue stability check."""
+
+    def test_classical_e4_passes(self):
+        """Classical E4 with known-good alpha gives purely imaginary spectrum."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        result = layer_bl42_reflecting_hyperbolic(
+            "E4", "classical", {"alpha": alpha},
+        )
+        assert result["max_spectral_abscissa"] < 1e-8, (
+            f"max_spectral_abscissa={result['max_spectral_abscissa']:.4e}"
+        )
+        assert result["purely_imaginary"] is True
+
+    def test_tension_e4_sigma_3_detects_instability(self):
+        """Tension E4 σ=3.0 passes L3 but BL42 catches reflecting-BC instability at larger N."""
+        result = layer_bl42_reflecting_hyperbolic(
+            "E4", "tension", {"sigma": 3.0},
+        )
+        assert result["max_spectral_abscissa"] > 0.1, (
+            f"Expected unstable at higher N, got max_spectral_abscissa={result['max_spectral_abscissa']:.4e}"
+        )
+        assert result["purely_imaginary"] is False
+
+    @pytest.mark.slow
+    def test_gaussian_e4_eps_01_fails(self):
+        """Gaussian E4 at epsilon=0.1 is unstable — large positive spectral abscissa."""
+        result = layer_bl42_reflecting_hyperbolic(
+            "E4", "gaussian", {"epsilon": 0.1},
+        )
+        assert result["max_spectral_abscissa"] > 0.01, (
+            f"Expected unstable, got max_spectral_abscissa={result['max_spectral_abscissa']:.4e}"
+        )
+        assert result["purely_imaginary"] is False
+
+    def test_purely_imaginary_flag(self):
+        """Verify purely_imaginary flag for stable and unstable cases."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        stable = layer_bl42_reflecting_hyperbolic(
+            "E4", "classical", {"alpha": alpha},
+        )
+        assert stable["purely_imaginary"] is True
+
+        unstable = layer_bl42_reflecting_hyperbolic(
+            "E4", "gaussian", {"epsilon": 0.1}, n_values=(21,),
+        )
+        assert unstable["purely_imaginary"] is False
+
+    def test_return_keys(self):
+        """Layer BL42 returns expected keys."""
+        result = layer_bl42_reflecting_hyperbolic(
+            "E4", "tension", {"sigma": 3.0}, n_values=(21,),
+        )
+        assert "spectral_abscissa_by_n" in result
+        assert "max_spectral_abscissa" in result
+        assert "purely_imaginary" in result
+        assert 21 in result["spectral_abscissa_by_n"]
+
+
+class TestLayer4:
+    """Layer 4: per-point local GV error on the Brady-Livescu 2D field."""
+
+    def test_classical_e4_passes(self):
+        """Classical E4 passes L4 on the BL coefficient field."""
+        result = layer4_local_gv_2d("E4", "classical", {})
+        assert result["max_local_gv_error"] <= L4_TOL, (
+            f"E4 local GV error {result['max_local_gv_error']:.4f} exceeds L4_TOL={L4_TOL}"
+        )
+
+    def test_e2_has_larger_error_than_e4(self):
+        """E2 has larger local GV error than E4 (lower-order → worse dispersion)."""
+        r2 = layer4_local_gv_2d("E2", "tension", {"sigma": 0.0}, N=21)
+        r4 = layer4_local_gv_2d("E4", "tension", {"sigma": 3.0}, N=21)
+        assert r2["max_local_gv_error"] > r4["max_local_gv_error"], (
+            "E2 should have larger local GV error than E4"
+        )
+
+    def test_return_keys(self):
+        """Layer 4 returns expected keys."""
+        result = layer4_local_gv_2d("E4", "tension", {"sigma": 3.0}, N=11)
+        assert "max_local_gv_error" in result
+        assert "worst_point" in result
+        assert "worst_xi" in result
+        assert isinstance(result["worst_point"], tuple)
+        assert len(result["worst_point"]) == 2
+
+    def test_worst_xi_in_range(self):
+        """worst_xi should be in (0, pi]."""
+        result = layer4_local_gv_2d("E4", "tension", {"sigma": 3.0}, N=11)
+        assert 0.0 < result["worst_xi"] <= np.pi
+
+    def test_synthetic_bad_stencil_fails(self):
+        """A synthetic stencil with poor GV exceeds L4_TOL.
+
+        Weights [0.5, -0.5] with offsets [-1, 0] give C(xi) = -0.5*cos(xi),
+        which deviates massively from the exact GV of 1.  With c_x == 1
+        everywhere the scaled error is |C(xi) - 1| > 1 for all xi, far
+        exceeding L4_TOL = 0.1.
+        """
+        bad_weights = np.array([0.5, -0.5])
+        bad_offsets = np.array([-1.0, 0.0])
+        bad_stencil = (bad_weights, bad_offsets)
+
+        N = 11
+        c_x = np.ones((N, N))
+        c_y = np.zeros((N, N))
+        xi_array = np.linspace(0.01, np.pi, 50)
+
+        result = local_group_velocity_2d_varying(
+            bad_stencil, bad_stencil, c_x, c_y, xi_array,
+        )
+        err_x = np.abs(result["gv_error_x_field"])
+        max_err = float(np.max(err_x))
+        assert max_err > L4_TOL, (
+            f"Synthetic bad stencil max GV error {max_err:.4f} "
+            f"should exceed L4_TOL={L4_TOL}"
+        )
+
+
+class TestLayer5:
+    """Layer 5: 2D anisotropy over the Brady-Livescu coefficient field."""
+
+    def test_classical_e4_passes(self):
+        """Classical E4 passes L5 on the BL coefficient field."""
+        result = layer5_anisotropy("E4", "classical", {})
+        assert result["max_aligned_error"] <= L5_TOL, (
+            f"E4 anisotropy error {result['max_aligned_error']:.6f} exceeds L5_TOL={L5_TOL}"
+        )
+
+    def test_tension_e4_passes(self):
+        """Tension E4 at sigma=3.0 passes L5."""
+        result = layer5_anisotropy("E4", "tension", {"sigma": 3.0})
+        assert result["max_aligned_error"] <= L5_TOL, (
+            f"Tension E4 anisotropy error {result['max_aligned_error']:.6f} exceeds L5_TOL={L5_TOL}"
+        )
+
+    def test_e2_has_larger_anisotropy_than_e4(self):
+        """E2 has larger anisotropy error than E4 (lower-order → more anisotropic)."""
+        r2 = layer5_anisotropy("E2", "tension", {"sigma": 0.0}, N=21)
+        r4 = layer5_anisotropy("E4", "tension", {"sigma": 3.0}, N=21)
+        assert r2["max_aligned_error"] > r4["max_aligned_error"], (
+            "E2 should have larger anisotropy error than E4"
+        )
+
+    def test_return_keys(self):
+        """Layer 5 returns expected keys."""
+        result = layer5_anisotropy("E4", "tension", {"sigma": 3.0}, N=11)
+        expected_keys = {"max_aligned_error", "worst_point", "worst_theta"}
+        assert set(result.keys()) == expected_keys
+        assert isinstance(result["worst_point"], tuple)
+        assert len(result["worst_point"]) == 2
+
+    def test_worst_point_in_range(self):
+        """worst_point indices should be within the grid dimensions."""
+        N = 21
+        result = layer5_anisotropy("E4", "tension", {"sigma": 3.0}, N=N)
+        i, j = result["worst_point"]
+        assert 0 <= i < N
+        assert 0 <= j < N
+
+    def test_worst_theta_in_range(self):
+        """worst_theta should be in a reasonable angular range."""
+        result = layer5_anisotropy("E4", "tension", {"sigma": 3.0}, N=11)
+        # BL field has angles roughly in (0, pi/4), so worst_theta
+        # should be in the first quadrant.
+        assert 0.0 < result["worst_theta"] < np.pi / 2
+
+    def test_large_xi_mag_exceeds_threshold(self):
+        """At a large wavenumber (80% of cutoff), E2 anisotropy exceeds L5_TOL.
+
+        The default layer5_anisotropy uses 20% of the cutoff, where E2 just
+        barely passes (0.048 vs L5_TOL=0.05).  At 80% of the cutoff the
+        anisotropy error is much larger, providing the failure-side test for
+        the L5 threshold.
+        """
+        from stencil_gen.benchmarks.brady_livescu_2d import make_coefficient_field
+        from stencil_gen.group_velocity import (
+            anisotropy_over_coefficient_field,
+            interior_group_velocity,
+        )
+
+        N = 21
+        _, _, c_x, c_y = make_coefficient_field(N)
+        theta_array = np.linspace(0.01, np.pi / 2 - 0.01, 200)
+
+        # E2 interior cutoff at p=1
+        profile = interior_group_velocity(1, 1, np.linspace(0.01, np.pi, 200))
+        xi_mag = profile.cutoff_xi * 0.8  # 80% of cutoff instead of 20%
+
+        result = anisotropy_over_coefficient_field(
+            "E2", c_x, c_y, theta_array, xi_mag,
+        )
+        assert result["max_aligned_error"] > L5_TOL, (
+            f"E2 at 80% cutoff xi_mag={xi_mag:.3f}: "
+            f"max_aligned_error={result['max_aligned_error']:.6f} "
+            f"should exceed L5_TOL={L5_TOL}"
+        )
+
+
+class TestBuildSparse2D:
+    """Tests for build_sparse_2d_operator."""
+
+    def test_shape_n11(self):
+        """At N=11, the reduced operator has shape (100, 100)."""
+        L_red, keep_idx = build_sparse_2d_operator(
+            "E4", "tension", {"sigma": 3.0}, N=11,
+        )
+        assert L_red.shape == (100, 100), f"Expected (100, 100), got {L_red.shape}"
+        assert len(keep_idx) == 100
+
+    def test_shape_n21(self):
+        """At N=21, the reduced operator has shape (400, 400)."""
+        L_red, keep_idx = build_sparse_2d_operator(
+            "E4", "tension", {"sigma": 3.0}, N=21,
+        )
+        assert L_red.shape == (400, 400), f"Expected (400, 400), got {L_red.shape}"
+        assert len(keep_idx) == 400
+
+    def test_keep_idx_excludes_inflow(self):
+        """keep_idx excludes all DOFs with i=0 or j=0."""
+        N = 11
+        _, keep_idx = build_sparse_2d_operator(
+            "E4", "tension", {"sigma": 3.0}, N=N,
+        )
+        ii = keep_idx % N
+        jj = keep_idx // N
+        assert np.all(ii > 0), "keep_idx should exclude i=0 (x inflow)"
+        assert np.all(jj > 0), "keep_idx should exclude j=0 (y inflow)"
+
+    def test_sparse_format(self):
+        """Output is CSR sparse matrix."""
+        import scipy.sparse as sp
+
+        L_red, _ = build_sparse_2d_operator(
+            "E4", "tension", {"sigma": 3.0}, N=11,
+        )
+        assert sp.issparse(L_red), "L_red should be sparse"
+        assert L_red.format == "csr", f"Expected CSR, got {L_red.format}"
+
+    def test_classical_e4_builds(self):
+        """Classical E4 kernel builds without error."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        L_red, keep_idx = build_sparse_2d_operator(
+            "E4", "classical", {"alpha": alpha}, N=11,
+        )
+        assert L_red.shape == (100, 100)
+
+    def test_eigenvalues_finite(self):
+        """Eigenvalues of the reduced operator are all finite."""
+        L_red, _ = build_sparse_2d_operator(
+            "E4", "tension", {"sigma": 3.0}, N=11,
+        )
+        eigs = np.linalg.eigvals(L_red.toarray())
+        assert np.all(np.isfinite(eigs)), "All eigenvalues should be finite"
+
+
+class TestLayer7:
+    """Layer 7: sparse 2D Arnoldi eigenvalue check on the BL operator."""
+
+    def test_tension_e4_stable(self):
+        """Tension E4 at sigma=3.0 is stable at small grid sizes."""
+        result = layer7_sparse_2d_eigenvalue(
+            "E4", "tension", {"sigma": 3.0}, n_values=(21, 31),
+        )
+        for n, max_re in result["eigenvalues"].items():
+            assert max_re <= L7_TOL, (
+                f"Tension E4 sigma=3.0 unstable at N={n}: "
+                f"max Re(lambda)={max_re:.6e}"
+            )
+        assert result["max_spectral_abscissa"] <= L7_TOL
+
+    def test_classical_e4_stable(self):
+        """Classical E4 with known-good alpha is stable at N=21."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        result = layer7_sparse_2d_eigenvalue(
+            "E4", "classical", {"alpha": alpha}, n_values=(21,),
+        )
+        assert result["max_spectral_abscissa"] <= L7_TOL, (
+            f"Classical E4 unstable: "
+            f"max_spectral_abscissa={result['max_spectral_abscissa']:.6e}"
+        )
+
+    def test_gaussian_e4_eps_01_unstable(self):
+        """Gaussian E4 eps=0.1 (known_unstable) fails L7."""
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        result = layer7_sparse_2d_eigenvalue(
+            "E4", "gaussian", {"epsilon": eps}, n_values=(21,),
+        )
+        assert result["max_spectral_abscissa"] > L7_TOL, (
+            f"Expected Gaussian eps={eps} to be unstable, got "
+            f"max_spectral_abscissa={result['max_spectral_abscissa']:.6e}"
+        )
+
+    def test_return_keys(self):
+        """Layer 7 returns expected keys."""
+        result = layer7_sparse_2d_eigenvalue(
+            "E4", "tension", {"sigma": 3.0}, n_values=(21,),
+        )
+        assert "eigenvalues" in result
+        assert "max_spectral_abscissa" in result
+        assert 21 in result["eigenvalues"]
+
+    def test_custom_n_values(self):
+        """Custom n_values are respected."""
+        result = layer7_sparse_2d_eigenvalue(
+            "E4", "tension", {"sigma": 3.0}, n_values=(11, 21),
+        )
+        assert set(result["eigenvalues"].keys()) == {11, 21}
+
+
+class TestLayer7WithNonNormality:
+    """Layer 7 + L6: non-normality diagnostics on the full 2D BL operator."""
+
+    @pytest.mark.slow
+    def test_classical_e4_passes(self):
+        """Classical E4 with known-good alpha passes the combined L7+L6 check.
+
+        Both the spectral abscissa and transient growth bound must be within
+        tolerances for a scheme that is known to be long-time stable in the
+        Brady-Livescu benchmark.
+        """
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        report = layer7_with_non_normality(
+            "E4", "classical", {"alpha": alpha}, N=21,
+        )
+        assert report.spectral_abscissa <= L7_TOL, (
+            f"Classical E4 spectral_abscissa={report.spectral_abscissa:.6e} "
+            f"exceeds L7_TOL={L7_TOL}"
+        )
+        assert report.transient_growth_bound <= L7_TRANSIENT_GROWTH_TOL, (
+            f"Classical E4 transient_growth_bound={report.transient_growth_bound:.2f} "
+            f"exceeds L7_TRANSIENT_GROWTH_TOL={L7_TRANSIENT_GROWTH_TOL}"
+        )
+        # Sanity: all fields populated and finite
+        assert np.isfinite(report.numerical_abscissa)
+        assert np.isfinite(report.henrici_departure)
+        assert np.isfinite(report.kreiss_constant)
+        assert report.n == 20 * 20  # (21-1)^2 = 400
+
+    @pytest.mark.slow
+    def test_gaussian_e4_eps_01_fails(self):
+        """Gaussian E4 eps=0.1 (known_unstable) fails the combined check.
+
+        This scheme has a positive spectral abscissa in the 2D BL operator,
+        so it must fail at least on the spectral_abscissa criterion.
+        """
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        report = layer7_with_non_normality(
+            "E4", "gaussian", {"epsilon": eps}, N=21,
+        )
+        # The known-unstable scheme must fail on at least one criterion
+        fails_spectral = report.spectral_abscissa > L7_TOL
+        fails_transient = report.transient_growth_bound > L7_TRANSIENT_GROWTH_TOL
+        assert fails_spectral or fails_transient, (
+            f"Gaussian eps={eps} should fail: "
+            f"spectral_abscissa={report.spectral_abscissa:.6e}, "
+            f"transient_growth_bound={report.transient_growth_bound:.2f}"
+        )
+
+    @pytest.mark.slow
+    def test_report_fields_populated(self):
+        """All NonNormalityReport fields are populated for a BL-sized operator."""
+        report = layer7_with_non_normality(
+            "E4", "tension", {"sigma": 3.0}, N=21,
+        )
+        assert np.isfinite(report.spectral_abscissa)
+        assert np.isfinite(report.numerical_abscissa)
+        assert np.isfinite(report.henrici_departure)
+        assert report.henrici_departure >= 0.0
+        assert np.isfinite(report.kreiss_constant)
+        assert report.kreiss_constant >= 0.0
+        assert np.isfinite(report.transient_growth_bound)
+        assert report.compute_time > 0.0
+        assert isinstance(report.pseudospectral_abscissae, dict)
+        assert len(report.pseudospectral_abscissae) > 0
+
+
+class TestLayer2:
+    """Layer 2: rigorous GKS Kreiss determinant stability check."""
+
+    def test_tension_e4_stable(self):
+        """Tension E4 at sigma=3.0 is GKS-stable."""
+        result = layer2_kreiss_gks("E4", "tension", {"sigma": 3.0})
+        assert result.is_stable is True
+
+    def test_gaussian_e4_gks_stable(self):
+        """Gaussian E4 eps=0.1 is GKS-stable (instability is eigenvalue, not boundary).
+
+        The Gaussian eps=0.1 closure is boundary-stable in the GKS sense —
+        its instability is caught at Layer 3 (eigenvalue check), not here.
+        """
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+        result = layer2_kreiss_gks("E4", "gaussian", {"epsilon": eps})
+        assert result.is_stable is True
+
+    def test_returns_kreiss_result(self):
+        """Layer 2 returns a KreissResult."""
+        result = layer2_kreiss_gks("E4", "tension", {"sigma": 3.0})
+        assert isinstance(result, KreissResult)
+        assert result.compute_time > 0.0
+
+
+class TestStabilityScoreOrchestrator:
+    """Tests for brady2d_stability_score orchestrator (41.10b)."""
+
+    def test_tension_e4_passes_layer1(self):
+        """Tension E4 at sigma=3.0 passes at max_layer=1."""
+        report = brady2d_stability_score(
+            "E4", "tension", {"sigma": 3.0}, max_layer=1,
+        )
+        assert report.overall_verdict == "pass"
+        assert report.failed_layer is None
+        assert report.layer1 is not None
+        assert report.layer2 is None  # not run
+        assert report.compute_time > 0.0
+
+    def test_tension_e4_sigma_3_fails_at_l3r(self):
+        """Tension E4 σ=3.0 passes L3 (advection) but fails L3r (BL42 reflecting-hyperbolic)."""
+        report = brady2d_stability_score(
+            "E4", "tension", {"sigma": 3.0}, max_layer=3,
+        )
+        assert report.overall_verdict == "fail"
+        assert report.failed_layer == 3
+        assert "BL42" in report.failed_reason
+        assert report.layer_bl42 is not None
+        assert report.layer1 is not None
+        assert report.layer2 is not None
+        assert report.layer3 is not None
+
+    def test_tension_e4_sigma_3_fails_at_l3r_max_layer_5(self):
+        """Tension E4 σ=3.0 fails at L3r even with max_layer=5; L4+ short-circuited."""
+        report = brady2d_stability_score(
+            "E4", "tension", {"sigma": 3.0}, max_layer=5,
+        )
+        assert report.overall_verdict == "fail"
+        assert report.failed_layer == 3
+        assert "BL42" in report.failed_reason
+        assert report.layer_bl42 is not None
+        assert report.layer1 is not None
+        assert report.layer2 is not None
+        assert report.layer3 is not None
+        assert report.layer4 is None  # short-circuited
+
+    def test_gaussian_eps_01_fails_at_layer_3(self):
+        """Gaussian E4 eps=0.1 (known_unstable) fails at layer 3.
+
+        GKS-stable (passes L2) but eigenvalue-unstable (fails L3).
+        With short_circuit=True, layers 4+ are not run.
+        """
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        report = brady2d_stability_score(
+            "E4", "gaussian", {"epsilon": eps}, max_layer=5,
+        )
+        assert report.overall_verdict == "fail"
+        assert report.failed_layer == 3
+        assert "max_stab_eig" in report.failed_reason
+        # Short-circuited: layers 1-3 populated, 4+ not run
+        assert report.layer1 is not None
+        assert report.layer2 is not None
+        assert report.layer3 is not None
+        assert report.layer4 is None
+        assert report.layer5 is None
+
+    def test_short_circuit_false_runs_all_layers(self):
+        """With short_circuit=False, all layers run even on failure."""
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        report = brady2d_stability_score(
+            "E4", "gaussian", {"epsilon": eps},
+            max_layer=5, short_circuit=False,
+        )
+        assert report.overall_verdict == "fail"
+        # First failure is at layer 3
+        assert report.failed_layer == 3
+        # But all layers up to max_layer are populated
+        assert report.layer1 is not None
+        assert report.layer2 is not None
+        assert report.layer3 is not None
+        assert report.layer4 is not None
+        assert report.layer5 is not None
+
+    def test_compute_time_positive(self):
+        """compute_time is positive."""
+        report = brady2d_stability_score(
+            "E4", "tension", {"sigma": 3.0}, max_layer=1,
+        )
+        assert report.compute_time > 0.0
+
+    def test_str_representation(self):
+        """The report __str__ works after orchestration."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": alpha}, max_layer=3,
+        )
+        s = str(report)
+        assert "Brady-Livescu 2D Stability Report" in s
+        assert "PASS" in s
+
+    def test_kreiss_field_populated(self):
+        """The kreiss field is populated when layer 2 runs."""
+        report = brady2d_stability_score(
+            "E4", "tension", {"sigma": 3.0}, max_layer=2,
+        )
+        assert report.kreiss is not None
+        assert report.kreiss is report.layer2
+        assert report.kreiss.is_stable is True
+
+    def test_max_layer_6_runs_non_normality(self):
+        """max_layer=6 populates layer6 and non_normality fields."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": alpha}, max_layer=6,
+        )
+        assert report.overall_verdict == "pass"
+        assert report.layer6 is not None, "layer6 should be populated at max_layer=6"
+        assert report.non_normality is not None, (
+            "non_normality should be populated at max_layer=6"
+        )
+        assert "spectral_abscissa" in report.layer6
+        assert "kreiss_constant" in report.layer6
+        assert "transient_growth_bound" in report.layer6
+        assert report.layer6["transient_growth_bound"] <= L6_TRANSIENT_GROWTH_TOL
+        # L7 should not be run
+        assert report.layer7 is None
+
+    def test_max_layer_6_differs_from_5(self):
+        """max_layer=6 produces different populated fields than max_layer=5."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        report5 = brady2d_stability_score(
+            "E4", "classical", {"alpha": alpha}, max_layer=5,
+        )
+        report6 = brady2d_stability_score(
+            "E4", "classical", {"alpha": alpha}, max_layer=6,
+        )
+        # max_layer=5 should not have layer6 or non_normality
+        assert report5.layer6 is None
+        assert report5.non_normality is None
+        # max_layer=6 should have both
+        assert report6.layer6 is not None
+        assert report6.non_normality is not None
+
+    def test_max_layer_6_str_shows_l6(self):
+        """The __str__ output at max_layer=6 includes an L6 line."""
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": alpha}, max_layer=6,
+        )
+        s = str(report)
+        assert "L6  Non-normality" in s
+        assert "kreiss_K=" in s
+
+
+class TestLayer6:
+    """Layer 6: standalone 1D non-normality diagnostics."""
+
+    def test_tension_e4_returns_expected_keys(self):
+        """layer6_non_normality returns all expected keys."""
+        result = layer6_non_normality("E4", "tension", {"sigma": 3.0})
+        expected_keys = {
+            "spectral_abscissa",
+            "numerical_abscissa",
+            "henrici_departure",
+            "kreiss_constant",
+            "transient_growth_bound",
+            "compute_time",
+            "non_normality_report",
+        }
+        assert expected_keys == set(result.keys())
+
+    def test_tension_e4_stable(self):
+        """Tension E4 at sigma=3.0 has stable 1D non-normality metrics."""
+        result = layer6_non_normality("E4", "tension", {"sigma": 3.0})
+        assert result["spectral_abscissa"] <= STABILITY_TOL
+        assert result["transient_growth_bound"] <= L6_TRANSIENT_GROWTH_TOL
+        assert result["compute_time"] > 0.0
+
+    def test_e2_phs_stable(self):
+        """E2 PHS (tension sigma=0) has stable 1D non-normality metrics."""
+        result = layer6_non_normality("E2", "tension", {"sigma": 0.0})
+        assert result["spectral_abscissa"] <= STABILITY_TOL
+        assert result["transient_growth_bound"] <= L6_TRANSIENT_GROWTH_TOL
+
+    def test_gaussian_e4_unstable(self):
+        """Gaussian E4 eps=0.1 has positive spectral abscissa (unstable)."""
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        result = layer6_non_normality("E4", "gaussian", {"epsilon": eps})
+        # Known eigenvalue-unstable: spectral abscissa should be positive
+        assert result["spectral_abscissa"] > STABILITY_TOL
+
+    def test_non_normality_report_field(self):
+        """The non_normality_report field is a proper NonNormalityReport."""
+        result = layer6_non_normality("E4", "tension", {"sigma": 3.0}, n=30)
+        nn = result["non_normality_report"]
+        assert isinstance(nn, NonNormalityReport)
+        assert nn.n == 29  # n=30 minus inflow row
+
+
+class TestStabilityReportStr:
+    """Tests for StabilityReport.__str__ rendering of layer_bl42."""
+
+    def test_layer_bl42_pass_printed(self):
+        report = StabilityReport.empty()
+        report.layer_bl42 = {
+            "max_spectral_abscissa": 1e-12,
+            "purely_imaginary": True,
+            "spectral_abscissa_by_n": {21: 1e-12, 41: 5e-13, 81: 2e-14},
+        }
+        text = str(report)
+        assert "L3r BL42 reflecting" in text
+        assert "PASS" in text
+        assert "1.0000e-12" in text
+
+    def test_layer_bl42_fail_printed(self):
+        report = StabilityReport.empty()
+        report.layer_bl42 = {
+            "max_spectral_abscissa": 0.5,
+            "purely_imaginary": False,
+            "spectral_abscissa_by_n": {21: 0.1, 41: 0.3, 81: 0.5},
+        }
+        text = str(report)
+        assert "FAIL" in text
+        assert "5.0000e-01" in text
+
+    def test_layer_bl42_absent_not_printed(self):
+        report = StabilityReport.empty()
+        text = str(report)
+        assert "BL42" not in text
+
+
+class TestBrady2DScoreL3rCascade:
+    """Integration tests for layer_bl42 wiring in the cascade."""
+
+    def test_classical_e4_passes_l3r(self):
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": alpha}, max_layer=3,
+        )
+        assert report.layer_bl42 is not None
+        assert report.layer_bl42["max_spectral_abscissa"] < 1e-8
+        assert report.failed_layer is None
+
+    def test_gaussian_eps_01_fails_at_l3_or_l3r(self):
+        report = brady2d_stability_score(
+            "E4", "gaussian", {"epsilon": 0.1}, max_layer=3,
+            short_circuit=True,
+        )
+        assert report.failed_layer == 3
+        assert "max_stab_eig" in report.failed_reason or "BL42" in report.failed_reason
+
+    def test_l3r_not_run_when_max_layer_is_2(self):
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": alpha}, max_layer=2,
+        )
+        assert report.layer_bl42 is None
+
+    def test_short_circuit_after_l3r_skips_l4(self):
+        report = brady2d_stability_score(
+            "E4", "tension", {"sigma": 3.0}, max_layer=4,
+            short_circuit=True,
+        )
+        assert report.layer_bl42 is not None, "L3r should have run"
+        assert report.layer_bl42["max_spectral_abscissa"] > BL42_TOL, "tension E4 σ=3.0 should fail BL42"
+        assert report.layer4 is None, "short-circuit should skip L4 after L3r failure"
+
+
+class TestBrady2DScoreIntegration:
+    """End-to-end integration tests for the full brady2d_stability_score pipeline.
+
+    These tests run layers 1–7 and are therefore slow (~30s each).
+    """
+
+    @pytest.mark.slow
+    def test_classical_e4_passes_all_layers_1_through_7(self):
+        """Classical E4 with known-good alpha passes all 7 layers.
+
+        This is the primary positive integration test: a scheme known to be
+        long-time stable in the Brady-Livescu benchmark must pass every layer
+        of the analytical pipeline.
+        """
+        alpha = [-0.7733323791884821, 0.1623961700641681]
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": alpha}, max_layer=7,
+        )
+        assert report.overall_verdict == "pass", (
+            f"Expected pass, got {report.overall_verdict} "
+            f"(failed at layer {report.failed_layer}: {report.failed_reason})"
+        )
+        assert report.failed_layer is None
+        # All layers populated
+        assert report.layer1 is not None
+        assert report.layer2 is not None
+        assert report.layer3 is not None
+        assert report.layer4 is not None
+        assert report.layer5 is not None
+        assert report.layer6 is not None
+        assert report.layer7 is not None
+        assert report.layer_bl42 is not None
+        assert report.non_normality is not None
+        assert report.kreiss is not None
+        assert report.compute_time > 0.0
+
+    @pytest.mark.slow
+    def test_gaussian_eps_01_fails_at_layer_2_or_3(self):
+        """Gaussian E4 eps=0.1 (known_unstable) fails at layer 2 or 3.
+
+        This scheme is eigenvalue-unstable.  It may be GKS-boundary-unstable
+        (fail at L2) or pass L2 and fail at L3 (1D eigenvalue check).  Either
+        failure is correct — the important assertion is that the pipeline
+        rejects it and short-circuits before expensive layers.
+        """
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        report = brady2d_stability_score(
+            "E4", "gaussian", {"epsilon": eps}, max_layer=7,
+        )
+        assert report.overall_verdict == "fail"
+        assert report.failed_layer in (2, 3), (
+            f"Expected failure at layer 2 or 3, got layer {report.failed_layer}"
+        )
+        # Short-circuited: later layers should not be populated
+        assert report.layer1 is not None  # always runs
+        if report.failed_layer == 3:
+            assert report.layer2 is not None
+            assert report.layer3 is not None
+            assert report.layer4 is None  # short-circuited
+        assert report.layer7 is None  # definitely not run
+
+    @pytest.mark.slow
+    def test_short_circuit_false_runs_all_layers(self):
+        """With short_circuit=False, all layers run even on a failing scheme.
+
+        The Gaussian E4 eps=0.1 scheme fails early, but with short_circuit=False
+        every layer up to max_layer=7 should still be evaluated and populated.
+        """
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        report = brady2d_stability_score(
+            "E4", "gaussian", {"epsilon": eps},
+            max_layer=7, short_circuit=False,
+        )
+        assert report.overall_verdict == "fail"
+        # First failure is still recorded
+        assert report.failed_layer is not None
+        # But ALL layers are populated despite the failure
+        assert report.layer1 is not None
+        assert report.layer2 is not None
+        assert report.layer3 is not None
+        assert report.layer4 is not None
+        assert report.layer5 is not None
+        assert report.layer6 is not None
+        assert report.layer7 is not None
+        assert report.non_normality is not None
+
+
+class TestLayer8:
+    """Layer 8: end-to-end C++ simulation via the shoccs bridge (plan 42.3a).
+
+    Most tests monkey-patch run_cpp_brady2d so they run hermetically without
+    the compiled binary. One @pytest.mark.slow smoke test invokes the real
+    binary when --run-slow is passed and the build exists.
+    """
+
+    CLASSICAL_ALPHA = [-0.7733323791884821, 0.1623961700641681]
+
+    def _patch_bridge(self, monkeypatch, result: BridgeResult) -> list[dict]:
+        """Replace run_cpp_brady2d with a stub returning ``result``.
+
+        Returns the list of call kwargs so a test can assert on them.
+        """
+        calls: list[dict] = []
+
+        def fake(scheme_type, params, **kwargs):
+            calls.append({"scheme_type": scheme_type, "params": params, **kwargs})
+            return result
+
+        monkeypatch.setattr(
+            "stencil_gen.brady2d_stability.run_cpp_brady2d", fake,
+        )
+        return calls
+
+    def test_classical_dispatch_maps_to_E4u_lua_type(self, monkeypatch):
+        stub = BridgeResult(
+            final_linf=1.75e-3, stable=True, wall_time_s=0.42, exit_code=0,
+        )
+        calls = self._patch_bridge(monkeypatch, stub)
+
+        out = layer8_cpp_simulation(
+            "E4", "classical", {"alpha": self.CLASSICAL_ALPHA},
+            N=31, t_final=10.0,
+        )
+
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["scheme_type"] == "E4u", (
+            "classical E4 must dispatch to Lua type 'E4u' (uniform variant)"
+        )
+        assert call["params"] == {"alpha": self.CLASSICAL_ALPHA}
+        assert call["N"] == 31
+        assert call["t_final"] == 10.0
+
+        assert out["final_linf"] == pytest.approx(1.75e-3)
+        assert out["stable"] is True
+        assert out["wall_time_s"] == pytest.approx(0.42)
+        assert out["bridge_result"] is stub
+
+    def test_unstable_result_propagates(self, monkeypatch):
+        stub = BridgeResult(
+            final_linf=42.0, stable=False, wall_time_s=1.1, exit_code=0,
+        )
+        self._patch_bridge(monkeypatch, stub)
+
+        out = layer8_cpp_simulation(
+            "E4", "classical", {"alpha": self.CLASSICAL_ALPHA},
+        )
+        assert out["stable"] is False
+        assert out["final_linf"] == pytest.approx(42.0)
+
+    def test_unsupported_kernel_raises(self):
+        with pytest.raises(NotImplementedError, match="bogus"):
+            layer8_cpp_simulation(
+                "E4", "bogus", {"sigma": 3.0},
+            )
+
+    def test_unsupported_scheme_raises(self):
+        with pytest.raises(NotImplementedError, match="E2"):
+            layer8_cpp_simulation(
+                "E2", "classical", {"alpha": [0.0, 0.0]},
+            )
+
+    def test_l8_threshold_matches_plan(self):
+        """Plan 42.3a specifies the L8 pass threshold as final_linf <= 1.0."""
+        assert L8_FINAL_LINF_TOL == 1.0
+
+    def test_default_n_and_t_final(self, monkeypatch):
+        stub = BridgeResult(final_linf=1e-3, stable=True)
+        calls = self._patch_bridge(monkeypatch, stub)
+
+        layer8_cpp_simulation("E4", "classical", {"alpha": self.CLASSICAL_ALPHA})
+
+        call = calls[0]
+        assert call["N"] == 31
+        assert call["t_final"] == 10.0
+
+    @pytest.mark.slow
+    def test_classical_e4_end_to_end(self):
+        """Drive the real shoccs binary on a tiny Brady-Livescu run."""
+        if not SHOCCS_BINARY.exists():
+            pytest.skip("shoccs binary not built")
+        out = layer8_cpp_simulation(
+            "E4", "classical", {"alpha": self.CLASSICAL_ALPHA},
+            N=21, t_final=1.0,
+        )
+        assert out["stable"] is True, (
+            f"classical E4u short run unexpectedly unstable: {out}"
+        )
+        assert 0.0 < out["final_linf"] < L8_FINAL_LINF_TOL
+        br = out["bridge_result"]
+        assert br.exit_code == 0
+        assert br.linf_trace.size > 0
+
+
+class TestLayer8Dispatch:
+    """Plan 42.7a: (scheme, kernel) → Lua scheme.type dispatch for spline families.
+
+    The tension, gaussian, and multiquadric E4u kernels all share the same
+    dispatch plumbing as the classical branch; these tests assert that each
+    kernel maps to the correct Lua type string and forwards params unchanged.
+    """
+
+    def _patch_bridge(self, monkeypatch, result: BridgeResult) -> list[dict]:
+        calls: list[dict] = []
+
+        def fake(scheme_type, params, **kwargs):
+            calls.append({"scheme_type": scheme_type, "params": params, **kwargs})
+            return result
+
+        monkeypatch.setattr(
+            "stencil_gen.brady2d_stability.run_cpp_brady2d", fake,
+        )
+        return calls
+
+    @pytest.mark.parametrize(
+        "kernel, params, expected_type",
+        [
+            ("tension", {"sigma": 3.0}, "tension_E4u"),
+            ("gaussian", {"epsilon": 0.9}, "gaussian_E4u"),
+            ("multiquadric", {"epsilon": 1.0}, "multiquadric_E4u"),
+        ],
+    )
+    def test_spline_kernel_dispatch(self, monkeypatch, kernel, params, expected_type):
+        stub = BridgeResult(final_linf=1e-3, stable=True, wall_time_s=0.5, exit_code=0)
+        calls = self._patch_bridge(monkeypatch, stub)
+
+        out = layer8_cpp_simulation("E4", kernel, params, N=31, t_final=10.0)
+
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["scheme_type"] == expected_type
+        assert call["params"] == params
+        assert call["N"] == 31
+        assert call["t_final"] == 10.0
+        assert out["stable"] is True
+        assert out["bridge_result"] is stub
+
+    def test_classical_still_dispatches(self, monkeypatch):
+        """Regression: 42.7a must not break the classical branch."""
+        stub = BridgeResult(final_linf=1e-3, stable=True, wall_time_s=0.5, exit_code=0)
+        calls = self._patch_bridge(monkeypatch, stub)
+
+        layer8_cpp_simulation(
+            "E4", "classical",
+            {"alpha": [-0.7733323791884821, 0.1623961700641681]},
+        )
+        assert calls[0]["scheme_type"] == "E4u"
+
+
+class TestStabilityScoreL8:
+    """brady2d_stability_score with max_layer=8 (plan 42.3b)."""
+
+    CLASSICAL_ALPHA = [-0.7733323791884821, 0.1623961700641681]
+
+    def _patch_l8(self, monkeypatch, result_dict: dict) -> list[dict]:
+        """Replace layer8_cpp_simulation with a stub. Returns call records."""
+        calls: list[dict] = []
+
+        def fake(scheme, kernel, params, **kwargs):
+            calls.append(
+                {"scheme": scheme, "kernel": kernel, "params": params, **kwargs},
+            )
+            return result_dict
+
+        monkeypatch.setattr(
+            "stencil_gen.brady2d_stability.layer8_cpp_simulation", fake,
+        )
+        return calls
+
+    def test_max_layer_8_runs_layer8_on_pass(self, monkeypatch):
+        """When L1–L7 pass, max_layer=8 invokes layer8_cpp_simulation."""
+        stub = {
+            "final_linf": 1.75e-3,
+            "stable": True,
+            "wall_time_s": 0.42,
+            "bridge_result": BridgeResult(
+                final_linf=1.75e-3, stable=True, wall_time_s=0.42, exit_code=0,
+            ),
+        }
+        calls = self._patch_l8(monkeypatch, stub)
+
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": self.CLASSICAL_ALPHA},
+            max_layer=8,
+        )
+        assert report.overall_verdict == "pass"
+        assert report.failed_layer is None
+        assert report.layer8 is stub
+        assert len(calls) == 1
+        assert calls[0]["scheme"] == "E4"
+        assert calls[0]["kernel"] == "classical"
+        assert calls[0]["N"] == 31
+        assert calls[0]["t_final"] == 10.0
+
+    def test_max_layer_8_forwards_N_and_t_final(self, monkeypatch):
+        stub = {
+            "final_linf": 1e-3, "stable": True, "wall_time_s": 0.1,
+            "bridge_result": BridgeResult(final_linf=1e-3, stable=True),
+        }
+        calls = self._patch_l8(monkeypatch, stub)
+        brady2d_stability_score(
+            "E4", "classical", {"alpha": self.CLASSICAL_ALPHA},
+            max_layer=8, layer8_N=21, layer8_t_final=1.0,
+        )
+        assert calls[0]["N"] == 21
+        assert calls[0]["t_final"] == 1.0
+
+    def test_max_layer_8_records_failure_on_unstable(self, monkeypatch):
+        """A failing L8 sets failed_layer=8 and verdict=fail."""
+        stub = {
+            "final_linf": float("nan"),
+            "stable": False,
+            "wall_time_s": 0.1,
+            "bridge_result": BridgeResult(
+                final_linf=float("nan"), stable=False,
+                exit_code=1, stderr="boom",
+            ),
+        }
+        self._patch_l8(monkeypatch, stub)
+
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": self.CLASSICAL_ALPHA},
+            max_layer=8,
+        )
+        assert report.overall_verdict == "fail"
+        assert report.failed_layer == 8
+        assert "unstable" in report.failed_reason.lower()
+        assert report.layer8 is stub
+
+    def test_max_layer_8_records_failure_on_linf_over_tol(self, monkeypatch):
+        """A stable run with final_linf > L8_FINAL_LINF_TOL still fails L8."""
+        stub = {
+            "final_linf": 5.0,
+            "stable": True,
+            "wall_time_s": 0.3,
+            "bridge_result": BridgeResult(
+                final_linf=5.0, stable=True, exit_code=0,
+            ),
+        }
+        self._patch_l8(monkeypatch, stub)
+
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": self.CLASSICAL_ALPHA},
+            max_layer=8,
+        )
+        assert report.overall_verdict == "fail"
+        assert report.failed_layer == 8
+        assert "L8_FINAL_LINF_TOL" in report.failed_reason
+
+    def test_max_layer_8_skips_l8_when_earlier_layer_fails(self, monkeypatch):
+        """When an earlier layer fails and short_circuit=True, L8 is not run."""
+        kv = _load_known_values()
+        unstable = kv["E4_1"]["known_unstable"][0]
+        assert unstable["kernel"] == "gaussian"
+        eps = unstable["epsilon"]
+
+        calls = self._patch_l8(monkeypatch, {
+            "final_linf": 0.0, "stable": True, "wall_time_s": 0.0,
+            "bridge_result": BridgeResult(),
+        })
+
+        report = brady2d_stability_score(
+            "E4", "gaussian", {"epsilon": eps}, max_layer=8,
+        )
+        assert report.overall_verdict == "fail"
+        assert report.failed_layer == 3  # original failure layer
+        assert report.layer8 is None
+        assert len(calls) == 0  # L8 never invoked
+
+    def test_max_layer_7_does_not_run_layer8(self, monkeypatch):
+        """At max_layer=7, layer8 field stays None and the stub is untouched."""
+        calls = self._patch_l8(monkeypatch, {
+            "final_linf": 0.0, "stable": True, "wall_time_s": 0.0,
+            "bridge_result": BridgeResult(),
+        })
+        report = brady2d_stability_score(
+            "E4", "tension", {"sigma": 3.0}, max_layer=7,
+        )
+        assert report.layer8 is None
+        assert len(calls) == 0
+
+    def test_str_with_layer8_populated_pass(self):
+        """The __str__ output contains an L8 line when layer8 is populated."""
+        report = StabilityReport(
+            layer8={"final_linf": 1.75e-3, "stable": True, "wall_time_s": 0.42},
+            overall_verdict="pass",
+        )
+        s = str(report)
+        assert "L8" in s
+        assert "C++ simulation" in s
+        assert "PASS" in s
+
+    def test_str_with_layer8_populated_fail(self):
+        """The __str__ output shows FAIL when the layer8 block failed."""
+        report = StabilityReport(
+            layer8={"final_linf": 42.0, "stable": False, "wall_time_s": 1.0},
+            overall_verdict="fail",
+            failed_layer=8,
+            failed_reason="C++ simulation unstable",
+        )
+        s = str(report)
+        assert "L8" in s
+        assert "FAIL" in s
+
+
+class TestBrady2DL8ClassicalE4:
+    """End-to-end orchestrator test including L8 (plan 42.3c)."""
+
+    CLASSICAL_ALPHA = [-0.7733323791884821, 0.1623961700641681]
+
+    @pytest.mark.slow
+    def test_classical_e4_passes_all_layers(self):
+        if not SHOCCS_BINARY.exists():
+            pytest.skip("shoccs binary not built")
+        report = brady2d_stability_score(
+            "E4", "classical", {"alpha": self.CLASSICAL_ALPHA},
+            max_layer=8, layer8_N=21, layer8_t_final=1.0,
+        )
+        assert report.overall_verdict == "pass", (
+            f"expected pass for classical E4 end-to-end; failed at layer "
+            f"{report.failed_layer}: {report.failed_reason}"
+        )
+        assert report.failed_layer is None
+        assert report.layer8 is not None
+        assert report.layer8["stable"] is True
+        assert 0.0 < report.layer8["final_linf"] < L8_FINAL_LINF_TOL
+
+
+class TestLayer8EndToEndSpline:
+    """End-to-end L1–L8 consistency for spline families (plan 42.7c).
+
+    For each (scheme, kernel, params) in the spline-family table, compare
+    the plan-42 empirical verdict (L8 C++ simulation) against the stored
+    plan-41 analytical calibration in ``brady2d_calibration``.  This is
+    the closed-loop consistency check: analytical L1–L7 should predict
+    the same overall outcome as the compiled shoccs run at L8.
+
+    Gracefully skipped when ``brady2d_calibration`` is absent (plan
+    41.11e not yet populated) or when the shoccs binary is missing.
+    """
+
+    # (scheme, kernel, params, calibration_label)
+    SPLINE_FAMILIES = [
+        ("E4", "tension", {"sigma": 3.0}, "E4_tension_3"),
+        ("E4", "gaussian", {"epsilon": 0.9}, "E4_gaussian_09"),
+        ("E4", "multiquadric", {"epsilon": 1.0}, "E4_multiquadric_1"),
+    ]
+
+    def _load_calibration(self):
+        if not KNOWN_VALUES_PATH.exists():
+            pytest.skip("known_values.json not present")
+        data = _load_known_values()
+        cal = data.get("brady2d_calibration")
+        if cal is None:
+            pytest.skip(
+                "brady2d_calibration not populated — run plan 41.11e manually",
+            )
+        return cal
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(
+        "scheme, kernel, params, label",
+        SPLINE_FAMILIES,
+        ids=[f[3] for f in SPLINE_FAMILIES],
+    )
+    def test_spline_family_l8_matches_calibration(
+        self, scheme, kernel, params, label,
+    ):
+        if not SHOCCS_BINARY.exists():
+            pytest.skip("shoccs binary not built")
+        cal = self._load_calibration()
+        if label not in cal:
+            pytest.skip(f"{label} not in brady2d_calibration")
+
+        stored_verdict = cal[label]["overall_verdict"]
+        report = brady2d_stability_score(
+            scheme, kernel, params,
+            max_layer=8, layer8_N=21, layer8_t_final=1.0,
+        )
+
+        if stored_verdict == "pass":
+            assert report.overall_verdict == "pass", (
+                f"{label}: plan-41 calibration says pass, plan-42 end-to-end "
+                f"got {report.overall_verdict} (failed_layer="
+                f"{report.failed_layer}, reason={report.failed_reason})"
+            )
+            assert report.failed_layer is None
+            assert report.layer8 is not None
+            assert report.layer8["stable"] is True
+            assert 0.0 < report.layer8["final_linf"] < L8_FINAL_LINF_TOL
+        else:
+            assert report.overall_verdict == "fail", (
+                f"{label}: plan-41 calibration says fail, plan-42 end-to-end "
+                f"got {report.overall_verdict}"
+            )

--- a/scripts/stencil_gen/tests/test_cpp_bridge.py
+++ b/scripts/stencil_gen/tests/test_cpp_bridge.py
@@ -1,0 +1,383 @@
+"""Tests for scripts/stencil_gen/stencil_gen/cpp_bridge.py.
+
+Plan 42.2a scope: make_brady2d_lua marker substitution and scheme-table
+emission. Plan 42.2b scope: run_cpp_brady2d subprocess driver, verified with
+a fake shoccs binary so the tests stay fast and hermetic.
+"""
+
+from __future__ import annotations
+
+import re
+import stat
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from stencil_gen.cpp_bridge import (
+    BRADY_LIVESCU_TEMPLATE,
+    LUA_TEMPLATE_DIR,
+    REPO_ROOT,
+    SHOCCS_BINARY,
+    BridgeResult,
+    make_brady2d_lua,
+    run_cpp_brady2d,
+)
+
+
+class TestBridgePaths:
+    def test_repo_root_contains_expected_markers(self):
+        assert (REPO_ROOT / "CMakeLists.txt").exists()
+        assert (REPO_ROOT / "lua-configs").is_dir()
+
+    def test_lua_template_dir_matches_repo_root(self):
+        assert LUA_TEMPLATE_DIR == REPO_ROOT / "lua-configs"
+
+    def test_brady_livescu_template_exists(self):
+        assert BRADY_LIVESCU_TEMPLATE.exists()
+        text = BRADY_LIVESCU_TEMPLATE.read_text()
+        for marker in ("--{{N}}--", "--{{T_FINAL}}--", "--{{SCHEME_TABLE}}--"):
+            assert marker in text, f"template missing marker {marker!r}"
+
+    def test_shoccs_binary_path_matches_plan(self):
+        assert SHOCCS_BINARY == REPO_ROOT / "build" / "src" / "app" / "shoccs"
+
+
+class TestMakeBrady2DLua:
+    CLASSICAL_ALPHA = [-0.7733323791884821, 0.1623961700641681]
+
+    def _render_classical(self, **overrides) -> str:
+        kwargs = dict(
+            scheme_type="E4u",
+            params={"alpha": self.CLASSICAL_ALPHA},
+            N=31,
+            t_final=10.0,
+        )
+        kwargs.update(overrides)
+        return make_brady2d_lua(**kwargs)
+
+    def test_all_markers_replaced(self):
+        rendered = self._render_classical()
+        for marker in ("--{{N}}--", "--{{T_FINAL}}--", "--{{SCHEME_TABLE}}--"):
+            assert marker not in rendered, f"marker {marker!r} survived substitution"
+
+    def test_n_substituted_as_integer(self):
+        rendered = self._render_classical(N=41)
+        # index_extents = {41, 41}
+        assert re.search(r"index_extents\s*=\s*\{41,\s*41\}", rendered)
+
+    def test_t_final_substituted(self):
+        rendered = self._render_classical(t_final=5.5)
+        assert re.search(r"max_time\s*=\s*5\.5", rendered)
+
+    def test_scheme_table_contains_type_and_alpha(self):
+        rendered = self._render_classical()
+        # Expect scheme = { order = 1, type = "E4u", alpha = {-0.77..., 0.16...} }
+        assert re.search(r'type\s*=\s*"E4u"', rendered)
+        for val in self.CLASSICAL_ALPHA:
+            assert repr(val) in rendered, f"alpha coefficient {val!r} missing"
+        assert re.search(r"alpha\s*=\s*\{", rendered)
+
+    def test_scheme_table_with_sigma(self):
+        rendered = make_brady2d_lua(
+            scheme_type="tension_E4u",
+            params={"sigma": 3.0},
+            N=31,
+            t_final=10.0,
+        )
+        assert re.search(r'type\s*=\s*"tension_E4u"', rendered)
+        assert re.search(r"sigma\s*=\s*3\.0", rendered)
+        assert "alpha" not in rendered.split("scheme")[1].split("system")[0]
+
+    def test_scheme_table_with_epsilon(self):
+        rendered = make_brady2d_lua(
+            scheme_type="gaussian_E4u",
+            params={"epsilon": 0.9},
+            N=31,
+            t_final=10.0,
+        )
+        assert re.search(r'type\s*=\s*"gaussian_E4u"', rendered)
+        assert re.search(r"epsilon\s*=\s*0\.9", rendered)
+
+    def test_rendered_output_is_lua_like(self):
+        """Basic sanity: every Lua brace must be balanced after substitution."""
+        rendered = self._render_classical()
+        assert rendered.count("{") == rendered.count("}")
+        assert "simulation" in rendered
+        assert "mesh" in rendered
+        assert "system" in rendered
+
+    def test_int_like_float_for_t_final(self):
+        # 10.0 should appear with a decimal point so Lua parses it as number
+        rendered = self._render_classical(t_final=10.0)
+        assert re.search(r"max_time\s*=\s*10\.0", rendered)
+
+
+class TestMakeBrady2DLuaSpline:
+    """Plan 42.7b — spline-family scheme-table emission.
+
+    The three runtime-parameterized families registered in 42.5e/42.6c/42.6g
+    each take a single scalar parameter (`sigma` for tension, `epsilon` for
+    gaussian and multiquadric) and must round-trip cleanly through the Lua
+    template.
+    """
+
+    @pytest.mark.parametrize(
+        "scheme_type,params,expected_kv",
+        [
+            ("tension_E4u", {"sigma": 3.0}, ("sigma", 3.0)),
+            ("tension_E4u", {"sigma": 7.5}, ("sigma", 7.5)),
+            ("gaussian_E4u", {"epsilon": 0.9}, ("epsilon", 0.9)),
+            ("gaussian_E4u", {"epsilon": 1.25}, ("epsilon", 1.25)),
+            ("multiquadric_E4u", {"epsilon": 1.0}, ("epsilon", 1.0)),
+            ("multiquadric_E4u", {"epsilon": 0.4}, ("epsilon", 0.4)),
+        ],
+    )
+    def test_emits_spline_scheme_table(self, scheme_type, params, expected_kv):
+        rendered = make_brady2d_lua(
+            scheme_type=scheme_type, params=params, N=31, t_final=10.0
+        )
+        key, value = expected_kv
+        # type must match verbatim
+        assert re.search(rf'type\s*=\s*"{re.escape(scheme_type)}"', rendered)
+        # parameter must be present with its repr (preserves full precision)
+        assert re.search(rf"{key}\s*=\s*{re.escape(repr(float(value)))}", rendered)
+        # the other scalar is never emitted
+        other = "epsilon" if key == "sigma" else "sigma"
+        scheme_slice = rendered.split("scheme")[1].split("system")[0]
+        assert f"{other} =" not in scheme_slice
+        assert "alpha" not in scheme_slice
+        # all markers are replaced
+        for marker in ("--{{N}}--", "--{{T_FINAL}}--", "--{{SCHEME_TABLE}}--"):
+            assert marker not in rendered
+        # order = 1 is present in the scheme table
+        assert "order = 1" in scheme_slice
+
+    def test_spline_rendered_output_has_balanced_braces(self):
+        for scheme_type, params in [
+            ("tension_E4u", {"sigma": 3.0}),
+            ("gaussian_E4u", {"epsilon": 0.9}),
+            ("multiquadric_E4u", {"epsilon": 1.0}),
+        ]:
+            rendered = make_brady2d_lua(
+                scheme_type=scheme_type, params=params, N=31, t_final=10.0
+            )
+            assert rendered.count("{") == rendered.count("}"), scheme_type
+
+    def test_spline_param_precision_preserved(self):
+        """Sigma/epsilon are emitted via repr() so round-tripping is exact."""
+        sigma = 0.1 + 0.2  # classic float that shows extra digits in repr
+        rendered = make_brady2d_lua(
+            scheme_type="tension_E4u",
+            params={"sigma": sigma},
+            N=31,
+            t_final=10.0,
+        )
+        assert repr(sigma) in rendered
+
+
+def _make_fake_shoccs(
+    tmp_path: Path,
+    *,
+    csv_body: str | None = None,
+    exit_code: int = 0,
+    sleep_s: float = 0.0,
+) -> Path:
+    """Write a POSIX shell script that mimics the shoccs binary contract.
+
+    The script writes the requested CSV body (stored alongside as a sibling
+    file and copied into cwd) to `logs/system.csv` in its cwd, optionally
+    sleeps, then exits with `exit_code`. Keeping the CSV in a separate file
+    avoids all shell-quoting hazards.
+    """
+    csv_src = tmp_path / "fake_shoccs.csv"
+    csv_src.write_text(csv_body if csv_body is not None else "")
+    script = tmp_path / "fake_shoccs.sh"
+    lines = [
+        "#!/bin/sh",
+        "mkdir -p logs",
+        f"cp {csv_src} logs/system.csv",
+    ]
+    if sleep_s > 0.0:
+        lines.append(f"sleep {sleep_s}")
+    lines.append(f"exit {exit_code}")
+    script.write_text("\n".join(lines) + "\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+    return script
+
+
+_HEADER = "Timestamp,Time,Step,Linf,Min,Max,Domain_Linf,Domain_ic,Rx_Linf,Rx_ic,Ry_Linf,Ry_ic,Rz_Linf,Rz_ic,Wall_ms"
+
+
+def _good_csv(final_linf: float, n_rows: int = 5) -> str:
+    rows = [_HEADER]
+    ts = "2026-04-13 19:51:40.000000"
+    for step in range(n_rows):
+        t = 0.1 * step
+        linf = final_linf if step == n_rows - 1 else 0.001 * (step + 1)
+        rows.append(f"{ts},{t},{step},{linf},-1.0,1.0,{linf},0,0,0,0,0,0,0,0.1")
+    return "\n".join(rows)
+
+
+class TestRunCppBrady2D:
+    def test_success_parses_final_linf(self, tmp_path: Path):
+        fake = _make_fake_shoccs(tmp_path, csv_body=_good_csv(0.01234))
+        result = run_cpp_brady2d(
+            scheme_type="E4u",
+            params={"alpha": [-0.77, 0.16]},
+            N=21,
+            t_final=1.0,
+            binary=fake,
+        )
+        assert result.exit_code == 0
+        assert result.stable is True
+        assert result.final_linf == pytest.approx(0.01234)
+        assert result.linf_trace.shape == (5,)
+        assert result.t_trace.shape == (5,)
+        assert result.wall_time_s > 0.0
+
+    def test_nonzero_exit_returns_nan_and_captures_stderr(self, tmp_path: Path):
+        # Script that writes nothing useful and exits 2; also emits stderr.
+        script = tmp_path / "failing_shoccs.sh"
+        script.write_text("#!/bin/sh\necho boom >&2\nexit 2\n")
+        script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+        result = run_cpp_brady2d(
+            scheme_type="E4u",
+            params={"alpha": [-0.77, 0.16]},
+            N=21,
+            t_final=1.0,
+            binary=script,
+        )
+        assert result.exit_code == 2
+        assert result.stable is False
+        assert np.isnan(result.final_linf)
+        assert "boom" in result.stderr
+
+    def test_unstable_when_final_linf_large(self, tmp_path: Path):
+        fake = _make_fake_shoccs(tmp_path, csv_body=_good_csv(123.4))
+        result = run_cpp_brady2d(
+            scheme_type="E4u",
+            params={"alpha": [-0.77, 0.16]},
+            N=21,
+            t_final=1.0,
+            binary=fake,
+        )
+        assert result.exit_code == 0
+        assert result.stable is False
+        assert result.final_linf == pytest.approx(123.4)
+
+    def test_missing_csv_returns_failure(self, tmp_path: Path):
+        # Script that exits 0 but never writes logs/system.csv.
+        script = tmp_path / "silent_shoccs.sh"
+        script.write_text("#!/bin/sh\nexit 0\n")
+        script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+        result = run_cpp_brady2d(
+            scheme_type="E4u",
+            params={"alpha": [-0.77, 0.16]},
+            N=21,
+            t_final=1.0,
+            binary=script,
+        )
+        assert result.stable is False
+        assert np.isnan(result.final_linf)
+        assert "system.csv" in result.stderr
+
+    def test_empty_csv_returns_failure(self, tmp_path: Path):
+        fake = _make_fake_shoccs(tmp_path, csv_body=_HEADER)
+        result = run_cpp_brady2d(
+            scheme_type="E4u",
+            params={"alpha": [-0.77, 0.16]},
+            N=21,
+            t_final=1.0,
+            binary=fake,
+        )
+        assert result.stable is False
+        assert np.isnan(result.final_linf)
+        assert "no data rows" in result.stderr
+
+    def test_timeout_is_graceful(self, tmp_path: Path):
+        fake = _make_fake_shoccs(tmp_path, csv_body=_good_csv(0.1), sleep_s=2.0)
+        result = run_cpp_brady2d(
+            scheme_type="E4u",
+            params={"alpha": [-0.77, 0.16]},
+            N=21,
+            t_final=1.0,
+            timeout=0.2,
+            binary=fake,
+        )
+        assert result.stable is False
+        assert result.exit_code == -1
+        assert "timeout" in result.stderr.lower()
+
+    def test_run_is_isolated_to_tempdir(self, tmp_path: Path):
+        """run_cpp_brady2d must not clobber REPO_ROOT/logs/system.csv."""
+        fake = _make_fake_shoccs(tmp_path, csv_body=_good_csv(0.5))
+        repo_logs = REPO_ROOT / "logs" / "system.csv"
+        before = repo_logs.read_bytes() if repo_logs.exists() else None
+        result = run_cpp_brady2d(
+            scheme_type="E4u",
+            params={"alpha": [-0.77, 0.16]},
+            N=21,
+            t_final=1.0,
+            binary=fake,
+        )
+        assert result.stable is True
+        after = repo_logs.read_bytes() if repo_logs.exists() else None
+        assert before == after, "run_cpp_brady2d must not touch REPO_ROOT/logs/"
+
+
+class TestCppBridgeSmoke:
+    """End-to-end smoke test against the real shoccs binary.
+
+    Marked @pytest.mark.slow — deselected unless --run-slow is passed.
+    Skipped entirely if the binary hasn't been built.
+    """
+
+    @pytest.mark.slow
+    def test_classical_e4u_short_run(self):
+        if not SHOCCS_BINARY.exists():
+            pytest.skip("shoccs binary not built")
+        result = run_cpp_brady2d(
+            scheme_type="E4u",
+            params={"alpha": [-0.7733323791884821, 0.1623961700641681]},
+            N=21,
+            t_final=1.0,
+        )
+        assert result.exit_code == 0, f"shoccs failed: {result.stderr}"
+        assert result.stable is True
+        assert 0.0 < result.final_linf < 1.0, (
+            f"final_linf out of expected band: {result.final_linf}"
+        )
+        assert result.linf_trace.size > 0
+        assert result.t_trace.size == result.linf_trace.size
+
+
+class TestBridgeResultDefaults:
+    def test_default_construction(self):
+        r = BridgeResult(final_linf=0.0)
+        assert r.stable is False
+        assert r.wall_time_s == 0.0
+        assert r.exit_code == 0
+        assert r.stderr == ""
+        assert r.linf_trace.shape == (0,)
+        assert r.t_trace.shape == (0,)
+
+    def test_final_linf_defaults_to_nan(self):
+        r = BridgeResult()
+        assert np.isnan(r.final_linf)
+
+    def test_explicit_fields(self):
+        import numpy as np
+
+        r = BridgeResult(
+            final_linf=0.123,
+            linf_trace=np.array([0.0, 0.1, 0.123]),
+            t_trace=np.array([0.0, 0.5, 1.0]),
+            stable=True,
+            wall_time_s=4.2,
+            exit_code=0,
+            stderr="",
+        )
+        assert r.stable is True
+        assert r.final_linf == pytest.approx(0.123)
+        assert r.linf_trace.shape == (3,)

--- a/scripts/stencil_gen/tests/test_gks_kreiss.py
+++ b/scripts/stencil_gen/tests/test_gks_kreiss.py
@@ -1,0 +1,800 @@
+"""Tests for the rigorous GKS Kreiss determinant stability module."""
+
+import numpy as np
+import pytest
+
+from stencil_gen.gks_kreiss import (
+    KreissResult,
+    DefectiveKappaError,
+    _classify_imag_axis,
+    _kappa_roots_from_poly,
+    _refine_witness,
+    _sweep_grid,
+    kappa_roots,
+    kreiss_matrix,
+    kreiss_stability_check,
+    make_s_grid,
+    min_singular_value,
+)
+
+
+class TestKappaRoots:
+    """Tests for kappa_roots (41.3b)."""
+
+    def test_first_order_upwind(self):
+        """First-order upwind: u_t = -(u_n - u_{n-1}) has one admissible root.
+
+        Interior stencil: weights=[-1, 1], offsets=[-1, 0].
+        Characteristic eqn: s + (-1)*kappa^{-1} + 1*kappa^0 = 0
+        Multiply by kappa (L_left=1): -1 + kappa + s*kappa = 0
+        => kappa*(1 + s) = 1 => kappa = 1/(1+s)
+
+        At s=1: kappa = 1/2 (admissible, |kappa| < 1).
+        The polynomial is degree 1 so there's exactly one root total.
+        """
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        s = 1.0
+
+        all_roots, admissible, is_defective = kappa_roots(
+            interior_weights, interior_offsets, s
+        )
+
+        # Degree-1 polynomial => exactly one root
+        assert len(all_roots) == 1
+        # The root should be 1/(1+s) = 0.5
+        assert abs(all_roots[0] - 0.5) < 1e-12
+
+        # One admissible root
+        assert len(admissible) == 1
+        assert abs(admissible[0] - 0.5) < 1e-12
+        assert abs(admissible[0]) < 1.0
+
+        # Not defective (only one root)
+        assert is_defective is False
+
+    def test_second_order_centered(self):
+        """Second-order centered: u_t = -(u_{n+1} - u_{n-1})/2.
+
+        Interior stencil: weights=[-0.5, 0.5], offsets=[-1, 1].
+        Char eqn: s + (-0.5)*kappa^{-1} + 0.5*kappa = 0
+        Multiply by kappa: -0.5 + s*kappa + 0.5*kappa^2 = 0
+
+        Degree-2 polynomial => 2 roots total.
+        """
+        interior_weights = np.array([-0.5, 0.5])
+        interior_offsets = np.array([-1, 1])
+        s = 0.5 + 0.3j
+
+        all_roots, admissible, is_defective = kappa_roots(
+            interior_weights, interior_offsets, s
+        )
+
+        # Degree-2 polynomial
+        assert len(all_roots) == 2
+
+        # Verify all roots satisfy the polynomial
+        # Q(kappa) = -0.5 + s*kappa + 0.5*kappa^2
+        for k in all_roots:
+            val = -0.5 + s * k + 0.5 * k**2
+            assert abs(val) < 1e-10, f"Root {k} doesn't satisfy polynomial: Q={val}"
+
+    def test_defective_kappa_detected_from_poly(self):
+        """Deliberately-coalescing case: double root at kappa=0.5.
+
+        Construct polynomial with known double root at 0.5 and a root at 2.0:
+        Q(kappa) = (kappa - 0.5)^2 * (kappa - 2.0)
+        """
+        # np.poly([0.5, 0.5, 2.0]) gives coefficients [1, -3, 2.25, -0.5]
+        poly_coeffs = np.poly([0.5, 0.5, 2.0])
+
+        all_roots, admissible, is_defective = _kappa_roots_from_poly(poly_coeffs)
+
+        # Should have 3 roots total
+        assert len(all_roots) == 3
+
+        # Two admissible roots (both near 0.5), one outside (near 2.0)
+        assert len(admissible) == 2
+        for k in admissible:
+            assert abs(k - 0.5) < 1e-6
+
+        # Defective because the two admissible roots are very close
+        assert is_defective is True
+
+    def test_no_admissible_roots(self):
+        """All roots outside the unit disk."""
+        # Q(kappa) = (kappa - 2)(kappa - 3) = kappa^2 - 5*kappa + 6
+        poly_coeffs = np.poly([2.0, 3.0])
+
+        all_roots, admissible, is_defective = _kappa_roots_from_poly(poly_coeffs)
+
+        assert len(all_roots) == 2
+        assert len(admissible) == 0
+        assert is_defective is False
+
+    def test_upwind_various_s_values(self):
+        """For upwind, kappa = 1/(1+s); admissible iff Re(s) > 0 or |1+s|>1."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+
+        # s=0.1: kappa = 1/1.1 ≈ 0.909, still admissible
+        _, adm, _ = kappa_roots(interior_weights, interior_offsets, 0.1)
+        assert len(adm) == 1
+        assert abs(adm[0] - 1.0 / 1.1) < 1e-12
+
+        # s with large Re: kappa small, definitely admissible
+        _, adm, _ = kappa_roots(interior_weights, interior_offsets, 10.0)
+        assert len(adm) == 1
+        assert abs(adm[0]) < 0.1
+
+    def test_purely_imaginary_s(self):
+        """Upwind at s = 2j: kappa = 1/(1+2j) = (1-2j)/5."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        s = 2j
+
+        all_roots, admissible, _ = kappa_roots(interior_weights, interior_offsets, s)
+        expected = 1.0 / (1.0 + 2j)
+        assert abs(all_roots[0] - expected) < 1e-12
+        # |kappa| = 1/sqrt(5) ≈ 0.447 < 1
+        assert len(admissible) == 1
+
+
+class TestKreissMatrix:
+    """Tests for kreiss_matrix and min_singular_value (41.3c)."""
+
+    def test_1x1_upwind(self):
+        """First-order upwind with one boundary row gives a 1x1 Kreiss matrix.
+
+        Interior: offsets=[-1, 0], weights=[-1, 1].
+        At s=1: kappa = 1/2.
+        Boundary row 0: weights=[2, -1], offsets=[0, 1] (grid points 0 and 1).
+        M[0,0] = s*kappa^0 + 2*kappa^0 + (-1)*kappa^1
+               = 1 + 2 - 0.5 = 2.5
+        """
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([2.0, -1.0]), np.array([0, 1]))]
+        s = 1.0
+
+        M = kreiss_matrix(interior_weights, interior_offsets, boundary_rows, s)
+
+        assert M.shape == (1, 1)
+        assert abs(M[0, 0] - 2.5) < 1e-12
+
+    def test_2x2_hand_computed(self):
+        """Explicit 2x2 case with hand-computed M(s=1).
+
+        Interior: offsets=[-2, -1, 0], weights=[0.1, 0.5, -0.4].
+        At s=1, polynomial 0.6*kappa^2 + 0.5*kappa + 0.1 = 0.
+        Roots: kappa_a = -1/3, kappa_b = -1/2 (both admissible).
+
+        Boundary row 0: weights=[3, -2], offsets=[0, 1].
+        Boundary row 1: weights=[1, 0.5, -0.5], offsets=[0, 1, 2].
+
+        For kappa in {-1/3, -1/2} (order from np.roots may vary):
+          M[0, l] = s*kappa^0 + 3*kappa^0 + (-2)*kappa^1
+                  = 1 + 3 - 2*kappa = 4 - 2*kappa
+          M[1, l] = s*kappa^1 + 1*kappa^0 + 0.5*kappa^1 + (-0.5)*kappa^2
+                  = kappa + 1 + 0.5*kappa - 0.5*kappa^2
+                  = 1 + 1.5*kappa - 0.5*kappa^2
+        """
+        interior_weights = np.array([0.1, 0.5, -0.4])
+        interior_offsets = np.array([-2, -1, 0])
+        boundary_rows = [
+            (np.array([3.0, -2.0]), np.array([0, 1])),
+            (np.array([1.0, 0.5, -0.5]), np.array([0, 1, 2])),
+        ]
+        s = 1.0
+
+        M = kreiss_matrix(interior_weights, interior_offsets, boundary_rows, s)
+
+        assert M.shape == (2, 2)
+
+        # Get the admissible roots to know the column ordering
+        _, admissible, _ = kappa_roots(interior_weights, interior_offsets, s)
+        assert len(admissible) == 2
+
+        # Verify each entry against the formula
+        for ell, kappa in enumerate(admissible):
+            # Row 0: M[0, l] = 4 - 2*kappa
+            expected_0 = 4.0 - 2.0 * kappa
+            assert abs(M[0, ell] - expected_0) < 1e-12, (
+                f"M[0,{ell}]: got {M[0,ell]}, expected {expected_0}"
+            )
+            # Row 1: M[1, l] = 1 + 1.5*kappa - 0.5*kappa^2
+            expected_1 = 1.0 + 1.5 * kappa - 0.5 * kappa**2
+            assert abs(M[1, ell] - expected_1) < 1e-12, (
+                f"M[1,{ell}]: got {M[1,ell]}, expected {expected_1}"
+            )
+
+    def test_2x2_exact_values(self):
+        """Verify M entries for kappa = -1/3, -1/2 (same setup as above).
+
+        For kappa = -1/3: M[0] = 4 + 2/3 = 14/3, M[1] = 1 - 1/2 - 1/18 = 4/9
+        For kappa = -1/2: M[0] = 4 + 1 = 5,       M[1] = 1 - 3/4 - 1/8 = 1/8
+
+        The exact matrix (up to column reordering) is:
+            [[14/3, 5], [4/9, 1/8]]  or  [[5, 14/3], [1/8, 4/9]]
+        """
+        interior_weights = np.array([0.1, 0.5, -0.4])
+        interior_offsets = np.array([-2, -1, 0])
+        boundary_rows = [
+            (np.array([3.0, -2.0]), np.array([0, 1])),
+            (np.array([1.0, 0.5, -0.5]), np.array([0, 1, 2])),
+        ]
+        s = 1.0
+
+        M = kreiss_matrix(interior_weights, interior_offsets, boundary_rows, s)
+        _, admissible, _ = kappa_roots(interior_weights, interior_offsets, s)
+
+        # Map kappa values to expected M columns
+        for ell, kappa in enumerate(admissible):
+            if abs(kappa - (-1.0 / 3.0)) < 1e-10:
+                assert abs(M[0, ell] - 14.0 / 3.0) < 1e-12
+                assert abs(M[1, ell] - 4.0 / 9.0) < 1e-12
+            elif abs(kappa - (-1.0 / 2.0)) < 1e-10:
+                assert abs(M[0, ell] - 5.0) < 1e-12
+                assert abs(M[1, ell] - 1.0 / 8.0) < 1e-12
+            else:
+                pytest.fail(f"Unexpected admissible root: {kappa}")
+
+    def test_shape_mismatch_raises(self):
+        """ValueError when admissible root count != boundary row count."""
+        # Upwind has 1 admissible root at s=1, but we provide 2 boundary rows
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [
+            (np.array([1.0]), np.array([0])),
+            (np.array([1.0]), np.array([0])),
+        ]
+        with pytest.raises(ValueError, match="admissible roots"):
+            kreiss_matrix(interior_weights, interior_offsets, boundary_rows, s=1.0)
+
+    def test_defective_raises(self):
+        """DefectiveKappaError when admissible roots coalesce.
+
+        Reverse-engineer a stencil whose characteristic polynomial is
+        (kappa - 0.3)^2 * (kappa - 5) at s = 0.4, giving a double admissible
+        root at kappa = 0.3.
+
+        For offsets [-2, -1, 0, 1] with L_left=2, shifted=[0,1,2,3]:
+          Q(kappa) = w_{-2} + w_{-1}*k + (w_0 + s)*k^2 + w_1*k^3
+        Target:    -0.45   + 3.09*k    - 5.6*k^2       + k^3
+        So w_{-2}=-0.45, w_{-1}=3.09, w_0=-6.0 (since w_0+s=-5.6), w_1=1.0.
+        """
+        interior_weights = np.array([-0.45, 3.09, -6.0, 1.0])
+        interior_offsets = np.array([-2, -1, 0, 1])
+        s = 0.4
+
+        # Confirm kappa_roots detects defective roots
+        _, admissible, is_defective = kappa_roots(
+            interior_weights, interior_offsets, s
+        )
+        assert len(admissible) == 2
+        assert is_defective is True
+
+        # kreiss_matrix must raise DefectiveKappaError
+        boundary_rows = [
+            (np.array([1.0]), np.array([0])),
+            (np.array([1.0]), np.array([0])),
+        ]
+        with pytest.raises(DefectiveKappaError):
+            kreiss_matrix(interior_weights, interior_offsets, boundary_rows, s)
+
+    def test_min_singular_value_1x1(self):
+        """min_singular_value returns |M[0,0]| for a 1x1 matrix."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([2.0, -1.0]), np.array([0, 1]))]
+        s = 1.0
+
+        sv = min_singular_value(interior_weights, interior_offsets, boundary_rows, s)
+        assert abs(sv - 2.5) < 1e-12
+
+    def test_min_singular_value_2x2(self):
+        """min_singular_value matches numpy SVD on the 2x2 hand-computed M."""
+        interior_weights = np.array([0.1, 0.5, -0.4])
+        interior_offsets = np.array([-2, -1, 0])
+        boundary_rows = [
+            (np.array([3.0, -2.0]), np.array([0, 1])),
+            (np.array([1.0, 0.5, -0.5]), np.array([0, 1, 2])),
+        ]
+        s = 1.0
+
+        sv = min_singular_value(interior_weights, interior_offsets, boundary_rows, s)
+
+        # Cross-check: build M manually and compute SVD
+        M = kreiss_matrix(interior_weights, interior_offsets, boundary_rows, s)
+        expected_sv = float(np.linalg.svd(M, compute_uv=False)[-1])
+        assert abs(sv - expected_sv) < 1e-12
+
+    def test_min_singular_value_shape_mismatch_returns_inf(self):
+        """min_singular_value returns inf when root count != boundary row count."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [
+            (np.array([1.0]), np.array([0])),
+            (np.array([1.0]), np.array([0])),
+        ]
+        sv = min_singular_value(interior_weights, interior_offsets, boundary_rows, s=1.0)
+        assert sv == np.inf
+
+    def test_min_singular_value_defective_returns_inf(self):
+        """min_singular_value returns inf on the DefectiveKappaError path.
+
+        Uses the same engineered stencil as test_defective_raises:
+        Q(kappa) = (kappa - 0.3)^2 * (kappa - 5) at s = 0.4.
+        """
+        interior_weights = np.array([-0.45, 3.09, -6.0, 1.0])
+        interior_offsets = np.array([-2, -1, 0, 1])
+        boundary_rows = [
+            (np.array([1.0]), np.array([0])),
+            (np.array([1.0]), np.array([0])),
+        ]
+        sv = min_singular_value(
+            interior_weights, interior_offsets, boundary_rows, s=0.4
+        )
+        assert sv == np.inf
+
+
+class TestSGridSweep:
+    """Tests for make_s_grid and _sweep_grid (41.3d)."""
+
+    def test_grid_shape_default(self):
+        """Default grid shape is (n_imag, n_radial + 1) = (120, 41)."""
+        grid = make_s_grid()
+        assert grid.shape == (120, 41)
+        assert grid.dtype == complex
+
+    def test_grid_shape_custom(self):
+        """Custom parameters produce the expected shape."""
+        grid = make_s_grid(n_radial=10, n_imag=30)
+        assert grid.shape == (30, 11)
+
+    def test_grid_real_parts_positive(self):
+        """All grid points have Re(s) > 0 (right half-plane)."""
+        grid = make_s_grid()
+        assert np.all(grid.real > 0)
+
+    def test_grid_imaginary_axis_strip(self):
+        """Column 0 is the imaginary-axis strip at Re(s) = eps_imag."""
+        eps = 1e-6
+        grid = make_s_grid(eps_imag=eps, n_radial=10, n_imag=20)
+        np.testing.assert_allclose(grid[:, 0].real, eps)
+
+    def test_grid_imaginary_range(self):
+        """Imaginary parts span [-imag_max, imag_max]."""
+        grid = make_s_grid(imag_max=15.0, n_imag=50, n_radial=5)
+        assert grid.imag.min() == pytest.approx(-15.0)
+        assert grid.imag.max() == pytest.approx(15.0)
+
+    def test_grid_real_log_spacing(self):
+        """Re(s) values in columns 1..n_radial are logarithmically spaced."""
+        grid = make_s_grid(s_max=10.0, n_radial=20, n_imag=5)
+        # All rows share the same Re values; check row 0
+        re_vals = grid[0, 1:].real  # skip imaginary-axis strip column
+        assert re_vals[0] == pytest.approx(1e-4)
+        assert re_vals[-1] == pytest.approx(10.0)
+        # Log-spacing means ratios between consecutive values are approximately constant
+        ratios = re_vals[1:] / re_vals[:-1]
+        np.testing.assert_allclose(ratios, ratios[0], rtol=1e-10)
+
+    def test_sweep_grid_upwind_stable(self):
+        """First-order upwind with natural boundary is stable: min(sigma) > 0.01.
+
+        Interior: weights=[-1, 1], offsets=[-1, 0] (first-order upwind).
+        Boundary row 0: weights=[1], offsets=[0] (identity = Dirichlet at left).
+        This is GKS-stable, so sigma_min should be bounded away from zero.
+        """
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        # Dirichlet boundary: u_0 = prescribed → the boundary equation
+        # is simply u_0(t) = g(t), which in the homogeneous stability problem
+        # becomes u_0 = 0. Row: [1]*[kappa^0] = kappa^0 = 1.
+        boundary_rows = [(np.array([1.0]), np.array([0]))]
+
+        # Small grid for speed
+        grid = make_s_grid(s_max=5.0, n_radial=10, n_imag=20, imag_max=10.0)
+        sigma_field, argmin_idx = _sweep_grid(
+            interior_weights, interior_offsets, boundary_rows, grid
+        )
+
+        assert sigma_field.shape == grid.shape
+        assert np.all(np.isfinite(sigma_field))
+        assert sigma_field.min() > 0.01, (
+            f"Expected stable scheme, got min(sigma) = {sigma_field.min()}"
+        )
+
+    def test_sweep_grid_argmin_consistent(self):
+        """argmin_idx points to the actual minimum of sigma_field."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([1.0]), np.array([0]))]
+
+        grid = make_s_grid(s_max=3.0, n_radial=5, n_imag=10, imag_max=5.0)
+        sigma_field, argmin_idx = _sweep_grid(
+            interior_weights, interior_offsets, boundary_rows, grid
+        )
+
+        flat = sigma_field.ravel()
+        assert flat[argmin_idx] == flat.min()
+
+
+class TestRefineWitness:
+    """Tests for _refine_witness (41.3e)."""
+
+    def test_converges_to_known_zero(self):
+        """Perturbed start near s=1+0j on a known-unstable scheme converges to sigma_min < 1e-6.
+
+        Construct an unstable scheme: first-order upwind interior with boundary
+        weights=[0, -2], offsets=[0, 1]. The Kreiss matrix is 1x1:
+            M(s) = s + 0*kappa^0 + (-2)*kappa^1 = s - 2/(1+s) = (s^2 + s - 2)/(1+s)
+        which has a zero at s=1 (Re>0), making this scheme GKS-unstable.
+        """
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([0.0, -2.0]), np.array([0, 1]))]
+
+        # Start from a perturbed point
+        s_start = 1.5 + 0.5j
+        s_refined = _refine_witness(
+            interior_weights, interior_offsets, boundary_rows, s_start
+        )
+
+        # Verify convergence: sigma_min at refined s should be < 1e-6
+        sv = min_singular_value(
+            interior_weights, interior_offsets, boundary_rows, s_refined
+        )
+        assert sv < 1e-6, f"Expected sigma_min < 1e-6, got {sv} at s={s_refined}"
+
+        # The refined s should be near s=1+0j
+        assert abs(s_refined - 1.0) < 0.1, (
+            f"Expected refined s near 1+0j, got {s_refined}"
+        )
+
+    def test_stays_in_right_half_plane(self):
+        """Refined witness has Re(s) >= 0 even when starting near the imaginary axis.
+
+        Same unstable scheme as above, starting from s_start = 0.1 + 0.1j.
+        """
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([0.0, -2.0]), np.array([0, 1]))]
+
+        s_start = 0.1 + 0.1j
+        s_refined = _refine_witness(
+            interior_weights, interior_offsets, boundary_rows, s_start
+        )
+
+        assert s_refined.real >= 0, f"Re(s) = {s_refined.real} < 0"
+
+    def test_stable_scheme_stays_bounded(self):
+        """On a stable scheme, _refine_witness still returns a valid s with sigma_min > 0."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        # Dirichlet boundary: identity at grid point 0
+        boundary_rows = [(np.array([1.0]), np.array([0]))]
+
+        s_start = 1.5 + 0.5j
+        s_refined = _refine_witness(
+            interior_weights, interior_offsets, boundary_rows, s_start
+        )
+
+        sv = min_singular_value(
+            interior_weights, interior_offsets, boundary_rows, s_refined
+        )
+        # Stable scheme: sigma_min should be bounded away from zero
+        assert sv > 0.01, f"Expected sigma_min > 0.01 on stable scheme, got {sv}"
+
+
+class TestClassifyImagAxis:
+    """Tests for _classify_imag_axis (41.3f)."""
+
+    def test_inward_perturbation_violation(self):
+        """Case A: root at kappa=1 moves inward under Re(s) perturbation → GKS violation.
+
+        Construct Q(kappa; s=0) = (kappa - 1)(kappa - 0.5) via stencil with
+        offsets [-1, 0, 1], weights [0.5, -1.5, 1.0]. At s=0, roots are
+        kappa=1 and kappa=0.5. For small positive delta, d(kappa)/ds = -2
+        at kappa=1 (computed from implicit differentiation), so the root
+        moves inward → outgoing_mode_detected (a GKS violation).
+        """
+        interior_weights = np.array([0.5, -1.5, 1.0])
+        interior_offsets = np.array([-1, 0, 1])
+
+        result = _classify_imag_axis(
+            interior_weights, interior_offsets, s_candidate=0.0 + 0j, delta=1e-4
+        )
+        assert result == "outgoing_mode_detected"
+
+    def test_outward_perturbation_non_violation(self):
+        """Case B: root at kappa=1 moves outward under Re(s) perturbation → non-violation.
+
+        Construct Q(kappa; s=0) = (kappa - 1)(kappa - 2) via stencil with
+        offsets [-1, 0, 1], weights [2.0, -3.0, 1.0]. At s=0, roots are
+        kappa=1 and kappa=2. For small positive delta, d(kappa)/ds = +1
+        at kappa=1, so the root moves outward → all_incoming (non-violation).
+        """
+        interior_weights = np.array([2.0, -3.0, 1.0])
+        interior_offsets = np.array([-1, 0, 1])
+
+        result = _classify_imag_axis(
+            interior_weights, interior_offsets, s_candidate=0.0 + 0j, delta=1e-4
+        )
+        assert result == "all_incoming"
+
+    def test_no_near_unit_roots_returns_no_candidates(self):
+        """When no roots are near the unit circle, return 'no_candidates'."""
+        # Upwind at s=5: kappa = 1/6 ≈ 0.167, far from unit circle
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+
+        result = _classify_imag_axis(
+            interior_weights, interior_offsets, s_candidate=5.0 + 0j
+        )
+        assert result == "no_candidates"
+
+    def test_defective_roots_far_from_unit_circle_returns_no_candidates(self):
+        """When defective roots are far from unit circle, return 'no_candidates'.
+
+        The engineered defective stencil has a double root at |kappa|=0.3,
+        which is far from the unit circle. The defective check should only
+        fire for near-unit-circle roots, so this returns 'no_candidates'.
+        """
+        # Same engineered defective stencil from TestKreissMatrix:
+        # double root at kappa=0.3 (|kappa|=0.3, far from unit circle)
+        interior_weights = np.array([-0.45, 3.09, -6.0, 1.0])
+        interior_offsets = np.array([-2, -1, 0, 1])
+
+        result = _classify_imag_axis(
+            interior_weights, interior_offsets, s_candidate=0.4 + 0j
+        )
+        assert result == "no_candidates"
+
+    def test_defective_roots_near_unit_circle_returns_defective(self):
+        """When defective roots are near the unit circle, return 'defective'.
+
+        Engineer a stencil whose characteristic polynomial has a double root
+        at kappa=0.99995 (|kappa| - 1 = -5e-5, within unit_tol=1e-4) and a
+        third root at kappa=5 (outside the unit disk).
+
+        Target polynomial: (kappa - 0.99995)^2 (kappa - 5.0)
+        With offsets [-2, -1, 0, 1], L_left=2, the polynomial is:
+            Q(kappa) = w_0 + w_1*kappa + (w_2 + s)*kappa^2 + w_3*kappa^3
+        Set s=0 and match coefficients.
+        """
+        r = 0.99995
+        a = 5.0
+        # (kappa - r)^2 (kappa - a) = kappa^3 - (2r+a)*kappa^2
+        #                            + (r^2 + 2*r*a)*kappa - r^2*a
+        w_3 = 1.0
+        s_val = 0.0 + 0j
+        w_2 = -(2 * r + a) - s_val  # coeff of kappa^2 minus s
+        w_1 = r**2 + 2 * r * a
+        w_0 = -(r**2 * a)
+
+        interior_weights = np.array([w_0, w_1, w_2, w_3])
+        interior_offsets = np.array([-2, -1, 0, 1])
+
+        result = _classify_imag_axis(
+            interior_weights, interior_offsets, s_candidate=s_val
+        )
+        assert result == "defective"
+
+
+class TestKreissStabilityCheck:
+    """Tests for kreiss_stability_check orchestrator (41.3g)."""
+
+    def test_stable_upwind_dirichlet(self):
+        """First-order upwind with Dirichlet BC is GKS-stable."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([1.0]), np.array([0]))]
+
+        result = kreiss_stability_check(
+            interior_weights, interior_offsets, boundary_rows,
+            s_grid_params={"s_max": 5.0, "n_radial": 10, "n_imag": 20,
+                           "imag_max": 10.0},
+        )
+
+        assert isinstance(result, KreissResult)
+        assert result.is_stable is True
+        assert result.compute_time > 0
+        assert result.s_grid_shape == (20, 11)
+
+    def test_unstable_scheme_detected(self):
+        """Known-unstable scheme: upwind with boundary weights [0, -2] has zero at s=1."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([0.0, -2.0]), np.array([0, 1]))]
+
+        # Dense grid near s=1+0j: need fine imaginary spacing so a grid point
+        # lands close enough for the sweep to trigger refinement.
+        result = kreiss_stability_check(
+            interior_weights, interior_offsets, boundary_rows,
+            s_grid_params={"s_max": 5.0, "n_radial": 30, "n_imag": 81,
+                           "imag_max": 5.0},
+        )
+
+        assert result.is_stable is False
+        assert result.witness_sigma_min < 1e-6
+        assert result.witness_s is not None
+
+    def test_compute_time_positive(self):
+        """compute_time is always positive."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([1.0]), np.array([0]))]
+
+        result = kreiss_stability_check(
+            interior_weights, interior_offsets, boundary_rows,
+            s_grid_params={"s_max": 3.0, "n_radial": 5, "n_imag": 10,
+                           "imag_max": 5.0},
+            refine=False,
+        )
+
+        assert result.compute_time > 0
+
+    def test_no_refine_option(self):
+        """With refine=False, result depends on grid resolution only."""
+        interior_weights = np.array([-1.0, 1.0])
+        interior_offsets = np.array([-1, 0])
+        boundary_rows = [(np.array([1.0]), np.array([0]))]
+
+        result = kreiss_stability_check(
+            interior_weights, interior_offsets, boundary_rows,
+            s_grid_params={"s_max": 3.0, "n_radial": 5, "n_imag": 10,
+                           "imag_max": 5.0},
+            refine=False,
+        )
+
+        # Stable scheme stays stable even without refinement
+        assert result.is_stable is True
+        assert result.witness_s is not None
+        assert result.witness_sigma_min > 0
+
+
+def _extract_stencil_data_from_D(D, p):
+    """Extract interior weights/offsets and boundary rows from a D matrix.
+
+    Uses the first p rows as boundary rows (matching the number of admissible
+    kappa roots for a 2p+1-point centered stencil in the GKS framework).
+
+    Parameters
+    ----------
+    D : np.ndarray
+        Full N×N differentiation matrix.
+    p : int
+        Interior half-bandwidth.
+
+    Returns
+    -------
+    interior_weights, interior_offsets, boundary_rows
+    """
+    n = D.shape[0]
+    mid = n // 2
+    io = np.arange(-p, p + 1)
+    interior_weights = D[mid, mid + io]
+
+    boundary_rows = []
+    for i in range(p):
+        brow = D[i, :]
+        bcols = np.nonzero(np.abs(brow) > 1e-15)[0]
+        boundary_rows.append((brow[bcols], bcols))
+
+    return interior_weights, io, boundary_rows
+
+
+class TestKreissIntegration:
+    """Integration tests using real E4 stencils (41.3h).
+
+    Note on GKS vs eigenvalue instability: the Kreiss determinant test
+    assesses boundary-closure stability on a SEMI-INFINITE domain (one
+    boundary only). A scheme can be GKS-stable at each boundary
+    individually but eigenvalue-unstable on the finite domain (due to
+    left-right boundary interaction). The Gaussian eps=0.1 is one such
+    case: it passes the GKS Kreiss test but has max Re(eigenvalue(-D_bc)) > 0.
+    Its instability is caught at Layer 3 (eigenvalue check), not Layer 2.
+    """
+
+    def test_classical_e4_passes(self):
+        """E4 classical closure is GKS-stable (Kreiss test passes)."""
+        from stencil_gen.phs import build_diff_matrix_rbf
+
+        # Use tension sigma=3.0 as the stable reference (RBF path, known stable)
+        D = build_diff_matrix_rbf(n=20, p=2, q=3, epsilon=3.0,
+                                   kernel="tension", nu=1, nextra=0)
+        interior_weights, interior_offsets, boundary_rows = (
+            _extract_stencil_data_from_D(D, p=2)
+        )
+
+        result = kreiss_stability_check(
+            interior_weights, interior_offsets, boundary_rows,
+            s_grid_params={"s_max": 10.0, "n_radial": 30, "n_imag": 80,
+                           "imag_max": 15.0},
+        )
+
+        assert result.is_stable is True
+
+    def test_gaussian_known_unstable_passes_gks(self):
+        """E4 Gaussian epsilon=0.1 is eigenvalue-unstable but GKS-stable.
+
+        The Gaussian eps=0.1 passes the Kreiss test because its instability
+        arises from left-right boundary interaction (caught at Layer 3),
+        not from a single-boundary GKS violation. This test documents this
+        important distinction.
+        """
+        from stencil_gen.phs import build_diff_matrix_rbf
+
+        D = build_diff_matrix_rbf(n=20, p=2, q=3, epsilon=0.1,
+                                   kernel="gaussian", nu=1, nextra=0)
+        interior_weights, interior_offsets, boundary_rows = (
+            _extract_stencil_data_from_D(D, p=2)
+        )
+
+        result = kreiss_stability_check(
+            interior_weights, interior_offsets, boundary_rows,
+            s_grid_params={"s_max": 10.0, "n_radial": 30, "n_imag": 80,
+                           "imag_max": 15.0},
+        )
+
+        # GKS-stable — the instability is NOT a boundary-closure issue
+        assert result.is_stable is True
+
+        # But eigenvalue check catches the actual instability
+        from stencil_gen.phs import stability_eigenvalue_from_matrix
+        max_re = stability_eigenvalue_from_matrix(D)
+        assert max_re > 0, "Expected eigenvalue instability for Gaussian eps=0.1"
+
+    def test_consistency_with_heuristic(self):
+        """GKS heuristic and Kreiss test are complementary diagnostics.
+
+        The heuristic detects eigenmodes with outgoing group velocity (which
+        may have negative real part — damped but outgoing). The Kreiss test
+        checks for modes with Re(s) >= 0 that violate the boundary condition.
+        They test different aspects and need not be strictly consistent.
+
+        This test verifies that both complete without error on the Gaussian
+        eps=0.1 case and documents their relationship.
+        """
+        from stencil_gen.phs import build_diff_matrix_rbf
+        from stencil_gen.group_velocity import gks_group_velocity_check
+
+        n = 20
+        D = build_diff_matrix_rbf(n=n, p=2, q=3, epsilon=0.1,
+                                   kernel="gaussian", nu=1, nextra=0)
+        xi_array = np.linspace(0, np.pi, 1000)
+        modes = gks_group_velocity_check(D, xi_array)
+        outgoing = [m for m in modes if m.is_outgoing]
+
+        # Heuristic detects an outgoing mode (with negative Re(eigenvalue))
+        assert len(outgoing) > 0, "Expected heuristic to find outgoing modes"
+        # The outgoing mode has Re(eigenvalue) < 0 (damped), so not a GKS violation
+        for m in outgoing:
+            assert m.eigenvalue.real < 0, (
+                f"Outgoing mode has Re(eigenvalue)={m.eigenvalue.real} >= 0"
+            )
+
+    def test_s_equals_zero_godunov_ryabenkii_reduction(self):
+        """At s=0, min_singular_value returns inf (no admissible roots ≠ n_boundary).
+
+        For the E4 centered stencil at s=0, one root is at kappa=1 (exactly
+        on the unit circle, not strictly inside), giving only 1 admissible root.
+        With 2 boundary rows, this is a shape mismatch → min_singular_value
+        returns inf. This is the Godunov-Ryabenkii condition: the boundary
+        closure does not support the trivial (constant) mode, which is correct.
+        """
+        from stencil_gen.phs import build_diff_matrix_rbf
+
+        D = build_diff_matrix_rbf(n=20, p=2, q=3, epsilon=3.0,
+                                   kernel="tension", nu=1, nextra=0)
+        interior_weights, interior_offsets, boundary_rows = (
+            _extract_stencil_data_from_D(D, p=2)
+        )
+
+        sv = min_singular_value(
+            interior_weights, interior_offsets, boundary_rows, s=0.0
+        )
+        # At s=0, only 1 admissible root vs 2 boundary rows → inf (shape mismatch)
+        assert sv == np.inf, f"sigma_min(M(0)) = {sv}, expected inf"

--- a/scripts/stencil_gen/tests/test_group_velocity.py
+++ b/scripts/stencil_gen/tests/test_group_velocity.py
@@ -1,0 +1,1973 @@
+"""Tests for group velocity analysis module."""
+
+import numpy as np
+import pytest
+
+from stencil_gen.group_velocity import (
+    AnisotropyResult,
+    GKSModeInfo,
+    GroupVelocity2DResult,
+    GroupVelocityProfile,
+    PsiSweepResult,
+    anisotropy_profile,
+    boundary_group_velocity,
+    boundary_group_velocity_2d,
+    boundary_group_velocity_classical,
+    cut_cell_group_velocity,
+    gks_group_velocity_check,
+    group_velocity_numerical,
+    group_velocity_2d,
+    group_velocity_error,
+    group_velocity_exact,
+    group_velocity_exact_nonuniform,
+    interior_group_velocity,
+    local_group_velocity,
+    anisotropy_over_coefficient_field,
+    local_group_velocity_2d_varying,
+    max_local_gv_error_2d,
+    modified_wavenumber,
+    modified_wavenumber_nonuniform,
+    phase_velocity,
+    psi_sweep_group_velocity,
+    ray_trace_group_velocity,
+)
+
+
+class TestCoreGroupVelocity:
+    """Core group velocity computation tests (34.1b)."""
+
+    N_XI = 500
+
+    def test_exact_scheme_unity_group_velocity(self):
+        """For exact differentiation (central difference of delta), C(xi) = 1."""
+        # For D1 approximating d/dx, kappa*(xi) has Im(kappa*) approximating xi.
+        # Group velocity: C(xi) = d(Im(kappa*))/d(xi).
+        # For exact differentiation, Im(kappa*) = xi, so C = 1.
+        #
+        # No finite stencil gives kappa* = i*xi exactly, so we test the
+        # "spectral" limit: use a high-order scheme (E8) and verify C ≈ 1
+        # at low wavenumbers where the truncation error is negligible.
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        p = 4  # E8 scheme
+        coeffs = derive_interior(0, p, 1)
+        w = [float(c) for c in full_gamma_array(coeffs)]
+        nodes = list(range(-p, p + 1))
+        xi = np.linspace(0.01, 0.5, self.N_XI)  # well-resolved wavenumbers
+
+        C = group_velocity_exact(w, 0, nodes, xi)
+        # At low xi, C should be very close to 1 for high-order scheme
+        assert np.allclose(C, 1.0, atol=1e-4), (
+            f"E8 group velocity should be ~1 at low xi, got max error "
+            f"{np.max(np.abs(C - 1.0)):.2e}"
+        )
+
+    def test_numerical_vs_analytical_gradient(self):
+        """group_velocity_numerical() and group_velocity_exact() agree within numerical tolerance."""
+        # Use E2 interior stencil: weights [-1/2, 0, 1/2]
+        weights = [-0.5, 0.0, 0.5]
+        nodes = [-1, 0, 1]
+        xi = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+
+        kstar = modified_wavenumber(weights, 0, nodes, xi)
+        C_numerical = group_velocity_numerical(kstar, xi)
+        C_analytical = group_velocity_exact(weights, 0, nodes, xi)
+
+        # Numerical differentiation (2nd-order central diff) agrees to ~O(h^2)
+        assert np.allclose(C_numerical, C_analytical, atol=1e-4), (
+            f"Numerical vs analytical group velocity max diff: "
+            f"{np.max(np.abs(C_numerical - C_analytical)):.2e}"
+        )
+
+    def test_phase_velocity_low_xi_limit(self):
+        """Phase velocity c(xi) -> 1 as xi -> 0 for any consistent scheme."""
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        for p in [1, 2, 3]:
+            coeffs = derive_interior(0, p, 1)
+            w = [float(c) for c in full_gamma_array(coeffs)]
+            nodes = list(range(-p, p + 1))
+            xi = np.linspace(0.01, 0.1, 50)
+
+            kstar = modified_wavenumber(w, 0, nodes, xi)
+            c = phase_velocity(kstar, xi)
+
+            # At small xi, phase velocity should be close to 1
+            assert abs(c[0] - 1.0) < 1e-3, (
+                f"p={p}: phase velocity at xi={xi[0]:.3f} is {c[0]:.6f}, "
+                f"expected ~1.0"
+            )
+
+    def test_second_order_known_values(self):
+        """For E2 interior stencil [-1/2, 0, 1/2], C(xi) = cos(xi)."""
+        weights = [-0.5, 0.0, 0.5]
+        nodes = [-1, 0, 1]
+        xi = np.linspace(0, np.pi, self.N_XI)
+
+        # Analytical group velocity
+        C = group_velocity_exact(weights, 0, nodes, xi)
+        expected = np.cos(xi)
+
+        assert np.allclose(C, expected, atol=1e-14), (
+            f"E2 group velocity should be cos(xi), max error: "
+            f"{np.max(np.abs(C - expected)):.2e}"
+        )
+
+        # Also verify via modified wavenumber
+        kstar = modified_wavenumber(weights, 0, nodes, xi)
+        # kappa* = i*sin(xi), so Im(kappa*) = sin(xi)
+        assert np.allclose(np.imag(kstar), np.sin(xi), atol=1e-14)
+        assert np.allclose(np.real(kstar), 0.0, atol=1e-14)
+
+    def test_interior_group_velocity_e2(self):
+        """Smoke test for interior_group_velocity(): E2 (p=1) returns correct profile."""
+        xi = np.linspace(0, np.pi, self.N_XI)
+        profile = interior_group_velocity(p=1, nu=1, xi_array=xi)
+
+        # Correct type and order
+        assert isinstance(profile, GroupVelocityProfile)
+        assert profile.order == 2
+
+        # E2 group velocity is cos(xi)
+        assert np.allclose(profile.group_velocity, np.cos(xi), atol=1e-14)
+
+        # Cutoff where C first goes to zero: cos(xi)=0 at xi=pi/2
+        assert abs(profile.cutoff_xi - np.pi / 2) < 2 * np.pi / self.N_XI
+
+
+class TestInteriorGroupVelocity:
+    """Interior scheme group velocity analysis (34.2b)."""
+
+    N_XI = 2000
+
+    def test_error_amplification_factor(self):
+        """Group velocity error is (2p+1) times phase velocity error at leading order.
+
+        For a 2p-th order scheme, Im(kappa*) = xi - a*xi^(2p+1) + ..., so:
+          phase velocity error:  c - 1 = -a*xi^(2p) + ...
+          group velocity error:  C - 1 = -(2p+1)*a*xi^(2p) + ...
+        The leading-order ratio is (2p+1).
+
+        Note: the original plan stated (2p-1), but the correct factor from
+        the Taylor expansion is (2p+1).  Verified numerically below.
+        """
+        xi = np.linspace(0.01, 0.15, 500)
+        for p in [1, 2, 3, 4]:
+            profile = interior_group_velocity(p=p, nu=1, xi_array=xi)
+            gv_err = profile.group_velocity - 1.0
+            pv_err = profile.phase_velocity - 1.0
+            # Use a point near the middle where errors are small but nonzero
+            idx = len(xi) // 2
+            ratio = gv_err[idx] / pv_err[idx]
+            expected = 2 * p + 1
+            assert abs(ratio - expected) < 0.1, (
+                f"E{2*p}: gv_err/pv_err ratio = {ratio:.2f}, expected {expected}"
+            )
+
+    def test_cutoff_wavenumber(self):
+        """Cutoff xi (where C = 0) increases with order.
+
+        Higher-order schemes resolve more wavenumbers before group velocity
+        reversal, so cutoff_xi moves to higher values.
+        """
+        xi = np.linspace(0, np.pi, self.N_XI)
+        cutoffs = []
+        for p in [1, 2, 3, 4]:
+            profile = interior_group_velocity(p=p, nu=1, xi_array=xi)
+            cutoffs.append(profile.cutoff_xi)
+
+        # Cutoffs should be strictly increasing
+        for i in range(len(cutoffs) - 1):
+            assert cutoffs[i] < cutoffs[i + 1], (
+                f"E{2*(i+1)} cutoff {cutoffs[i]:.4f} >= "
+                f"E{2*(i+2)} cutoff {cutoffs[i+1]:.4f}"
+            )
+
+        # E2 cutoff should be pi/2
+        assert abs(cutoffs[0] - np.pi / 2) < 2 * np.pi / self.N_XI
+
+    def test_group_velocity_sign_reversal(self):
+        """C(xi) < 0 for all xi beyond cutoff (parasitic regime)."""
+        xi = np.linspace(0, np.pi, self.N_XI)
+        for p in [1, 2, 3, 4]:
+            profile = interior_group_velocity(p=p, nu=1, xi_array=xi)
+            beyond = xi > profile.cutoff_xi
+            assert np.any(beyond), f"E{2*p}: no points beyond cutoff"
+            C_beyond = profile.group_velocity[beyond]
+            assert np.all(C_beyond <= 0), (
+                f"E{2*p}: found positive C beyond cutoff, "
+                f"max = {np.max(C_beyond):.4e}"
+            )
+
+class TestBoundaryGroupVelocity:
+    """Boundary closure group velocity analysis (34.3)."""
+
+    N_XI = 1000
+
+    def test_boundary_gv_returns_all_rows(self):
+        """boundary_group_velocity returns a profile for each boundary row."""
+        xi = np.linspace(0, np.pi, self.N_XI)
+        # E2, q=1, nextra=0, tension kernel with small sigma
+        profiles = boundary_group_velocity(
+            p=1, q=1, nextra=0, nu=1, sigma=0.1, kernel="tension", xi_array=xi,
+        )
+        # For E2 nu=1: r = q+1+nextra = 2
+        assert len(profiles) == 2
+        for i in range(2):
+            assert i in profiles
+            assert isinstance(profiles[i], GroupVelocityProfile)
+            assert len(profiles[i].xi) == self.N_XI
+            assert profiles[i].order == 1  # boundary accuracy order = q
+
+    def test_boundary_gv_bounded(self):
+        """For E2/E4 at small sigma, |C(xi)| is bounded (no blow-up)."""
+        xi = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+        configs = [
+            (1, 1, 0, 0.1),  # E2, q=1
+            (2, 3, 0, 0.1),  # E4, q=3
+        ]
+        for p, q, nextra, sigma in configs:
+            profiles = boundary_group_velocity(
+                p=p, q=q, nextra=nextra, nu=1, sigma=sigma,
+                kernel="tension", xi_array=xi,
+            )
+            for i, prof in profiles.items():
+                C = prof.group_velocity
+                assert np.all(np.isfinite(C)), (
+                    f"p={p}, row {i}: non-finite group velocity"
+                )
+                assert np.max(np.abs(C)) < 100, (
+                    f"p={p}, row {i}: |C| blow-up, max={np.max(np.abs(C)):.2e}"
+                )
+
+    def test_boundary_row0_low_xi_near_unity(self):
+        """Boundary row 0 group velocity should approach 1 at low xi (consistent scheme)."""
+        xi = np.linspace(0.01, 0.3, self.N_XI)
+        profiles = boundary_group_velocity(
+            p=2, q=3, nextra=0, nu=1, sigma=0.1, kernel="tension", xi_array=xi,
+        )
+        # Row 0 evaluates derivative at grid point 0 using a one-sided stencil.
+        # At low xi, if the scheme is consistent, C should be near 1.
+        C = profiles[0].group_velocity
+        assert abs(C[0] - 1.0) < 0.5, (
+            f"Boundary row 0 C at xi={xi[0]:.3f} = {C[0]:.4f}, expected ~1"
+        )
+
+    def test_cutoff_handles_oscillating_c(self):
+        """cutoff_xi reflects persistent (not transient) sign reversal.
+
+        Boundary stencils can have C(xi) that dips below zero briefly
+        then recovers positive.  The cutoff should mark where C goes
+        *permanently* non-positive, not the first transient dip.
+        """
+        from stencil_gen.group_velocity import _build_profile
+
+        # Synthetic one-sided stencil (i_eval=0, nodes=[0..4]) whose
+        # group velocity oscillates: C = 3cos(xi) - 6cos(2xi) + 6cos(3xi) - 2cos(4xi).
+        # C(0) = 1, dips negative near xi~0.7, recovers strongly positive
+        # around xi~pi/2, then goes permanently negative near xi~2.7.
+        weights = [0.0, 3.0, -3.0, 2.0, -0.5]
+        nodes = [0, 1, 2, 3, 4]
+        xi = np.linspace(0, np.pi, 2000)
+
+        profile = _build_profile(weights, np.asarray(nodes), xi, order=1)
+        C = profile.group_velocity
+
+        # Verify oscillation: C has a transient dip below zero AND
+        # later recovery to positive values before the final descent.
+        first_neg = None
+        for idx in range(1, len(xi)):
+            if C[idx] <= 0.0:
+                first_neg = float(xi[idx])
+                break
+        recovery = False
+        if first_neg is not None:
+            for idx in range(1, len(xi)):
+                if xi[idx] > first_neg and C[idx] > 0.0:
+                    recovery = True
+                    break
+        assert first_neg is not None, "expected a transient negative dip"
+        assert recovery, "expected C to recover positive after first dip"
+
+        # Cutoff must be beyond the transient dip (at the persistent crossing)
+        assert profile.cutoff_xi > first_neg + 0.5, (
+            f"cutoff_xi={profile.cutoff_xi:.3f} is too close to first "
+            f"transient dip at xi={first_neg:.3f}"
+        )
+
+        # Beyond cutoff, C stays non-positive
+        beyond = xi > profile.cutoff_xi
+        if np.any(beyond):
+            assert np.all(C[beyond] <= 0.0), (
+                f"C has positive values beyond cutoff_xi={profile.cutoff_xi:.3f}"
+            )
+
+    def test_boundary_vs_interior_gv_error(self):
+        """Boundary row 0 has larger GV error than interior; no sign reversal at low xi.
+
+        Row 0 (fully one-sided) should have larger error than the symmetric
+        interior stencil.  Rows closer to the interior may have smaller error
+        because they use a wider stencil.
+
+        At well-resolved wavenumbers (xi < pi/4), no boundary row should
+        reverse the sign of C (which would mean energy propagating backwards).
+        """
+        xi = np.linspace(0.01, np.pi, self.N_XI)
+        for p, q, nextra, sigma in [(2, 3, 0, 0.1), (3, 5, 0, 0.1)]:
+            interior = interior_group_velocity(p=p, nu=1, xi_array=xi)
+            boundary = boundary_group_velocity(
+                p=p, q=q, nextra=nextra, nu=1, sigma=sigma,
+                kernel="tension", xi_array=xi,
+            )
+            resolved = xi < np.pi / 4
+            # Row 0 (fully one-sided) should have the largest error
+            C_row0 = boundary[0].group_velocity[resolved]
+            C_int = interior.group_velocity[resolved]
+            row0_err = np.max(np.abs(C_row0 - 1.0))
+            int_err = np.max(np.abs(C_int - 1.0))
+            assert row0_err >= int_err, (
+                f"p={p}: row 0 error ({row0_err:.4e}) smaller than "
+                f"interior ({int_err:.4e})"
+            )
+            # No sign reversal at well-resolved wavenumbers for any row
+            for i, prof in boundary.items():
+                C_bnd = prof.group_velocity[resolved]
+                assert np.all(C_bnd > 0), (
+                    f"p={p}, row {i}: C < 0 at resolved xi<pi/4 "
+                    f"(min={np.min(C_bnd):.4e})"
+                )
+
+    def test_parasitic_direction_at_boundary(self):
+        """Check for parasitic outgoing modes at the boundary.
+
+        For u_t + u_x = 0 on a left boundary, physical waves propagate rightward
+        (C > 0).  If a boundary stencil creates a mode with C < 0 at a wavenumber
+        where the interior has C > 0, that's a parasitic mode propagating energy
+        out through the boundary — the hallmark of GKS instability.
+
+        Here we check the complementary concern for an inflow boundary: modes
+        with C > 0 (into the domain) at wavenumbers where the interior has C < 0
+        (energy should be propagating outward).  Such modes create spontaneous
+        radiation of energy into the domain.
+        """
+        xi = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+        for p, q, nextra, sigma in [(1, 1, 0, 0.1), (2, 3, 0, 0.1)]:
+            interior = interior_group_velocity(p=p, nu=1, xi_array=xi)
+            boundary = boundary_group_velocity(
+                p=p, q=q, nextra=nextra, nu=1, sigma=sigma,
+                kernel="tension", xi_array=xi,
+            )
+            # In the parasitic regime (beyond interior cutoff), check if
+            # boundary rows create C > 0 where interior has C < 0.
+            parasitic = xi > interior.cutoff_xi
+            if not np.any(parasitic):
+                continue
+            for i, prof in boundary.items():
+                C_bnd_parasitic = prof.group_velocity[parasitic]
+                # Flag if boundary creates strongly positive C in parasitic regime.
+                # Small positive values are tolerable; large positive means energy
+                # radiation into the domain.
+                max_positive = np.max(C_bnd_parasitic) if len(C_bnd_parasitic) > 0 else 0
+                # This is a diagnostic — we record but don't fail on small positives.
+                # A strongly positive boundary C in the parasitic regime is suspicious.
+                assert max_positive < 5.0, (
+                    f"p={p}, row {i}: boundary C strongly positive ({max_positive:.2f}) "
+                    f"in parasitic regime — potential GKS instability source"
+                )
+
+
+class TestBoundaryClassical:
+    """Classical (non-RBF) boundary stencil group velocity analysis (34.3b)."""
+
+    N_XI = 1000
+
+    @pytest.fixture(scope="class")
+    def e4_classical(self):
+        """Derive E4 boundary rows with conservation and known-good alpha values."""
+        from sympy import symbols
+
+        from stencil_gen.boundary import derive_boundary
+        from stencil_gen.conservation import build_conservation_system, solve_conservation
+
+        result = derive_boundary(p=2, nu=1, s=0)
+        equations, w_syms, last_free = build_conservation_system(
+            result.r, result.t, 2, result.rows, result.interior_coeffs,
+        )
+        _, updated_rows = solve_conservation(
+            equations, w_syms, last_free, result.all_free_params, result.rows,
+        )
+        # Known-good alpha values from E4u_1.t.cpp (same as test_boundary.py)
+        a0, a1 = symbols("alpha_0 alpha_1")
+        alpha_values = {a0: -0.7733323791884821, a1: 0.1623961700641681}
+        return updated_rows, alpha_values
+
+    def test_classical_returns_all_rows(self, e4_classical):
+        """boundary_group_velocity_classical returns a profile for each boundary row."""
+        updated_rows, alpha_values = e4_classical
+        xi = np.linspace(0, np.pi, self.N_XI)
+        profiles = boundary_group_velocity_classical(
+            updated_rows, alpha_values, order=3, xi_array=xi,
+        )
+        # E4 (p=2): r = 3 boundary rows
+        assert len(profiles) == 3
+        for i in range(3):
+            assert i in profiles
+            assert isinstance(profiles[i], GroupVelocityProfile)
+            assert profiles[i].order == 3
+
+    def test_classical_coefficients_finite(self, e4_classical):
+        """All evaluated coefficients are finite (no unresolved symbols)."""
+        updated_rows, alpha_values = e4_classical
+        xi = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+        profiles = boundary_group_velocity_classical(
+            updated_rows, alpha_values, order=3, xi_array=xi,
+        )
+        for i, prof in profiles.items():
+            assert np.all(np.isfinite(prof.group_velocity)), (
+                f"Row {i}: non-finite group velocity"
+            )
+            assert np.all(np.isfinite(prof.kappa_star)), (
+                f"Row {i}: non-finite modified wavenumber"
+            )
+
+    def test_classical_row0_low_xi(self, e4_classical):
+        """Classical E4 row 0 group velocity near unity at low xi."""
+        updated_rows, alpha_values = e4_classical
+        xi = np.linspace(0.01, 0.3, self.N_XI)
+        profiles = boundary_group_velocity_classical(
+            updated_rows, alpha_values, order=3, xi_array=xi,
+        )
+        C = profiles[0].group_velocity
+        assert abs(C[0] - 1.0) < 0.5, (
+            f"Classical E4 row 0 C at xi={xi[0]:.3f} = {C[0]:.4f}, expected ~1"
+        )
+
+    def test_classical_bounded(self, e4_classical):
+        """Group velocity is bounded (no blow-up) for all boundary rows."""
+        updated_rows, alpha_values = e4_classical
+        xi = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+        profiles = boundary_group_velocity_classical(
+            updated_rows, alpha_values, order=3, xi_array=xi,
+        )
+        for i, prof in profiles.items():
+            assert np.max(np.abs(prof.group_velocity)) < 100, (
+                f"Row {i}: |C| blow-up, max={np.max(np.abs(prof.group_velocity)):.2e}"
+            )
+
+    def test_classical_e4_boundary_gv(self, e4_classical):
+        """Classical E4 boundary stencils: no sign reversal at resolved wavenumbers.
+
+        Uses the known-good alpha values from E4u_1.t.cpp.  At well-resolved
+        wavenumbers (xi < pi/2), all boundary rows should have C > 0, meaning
+        no parasitic energy reversal in the resolved regime.
+        """
+        updated_rows, alpha_values = e4_classical
+        xi = np.linspace(0.01, np.pi, self.N_XI)
+        profiles = boundary_group_velocity_classical(
+            updated_rows, alpha_values, order=3, xi_array=xi,
+        )
+        resolved = xi < np.pi / 2
+        for i, prof in profiles.items():
+            C_resolved = prof.group_velocity[resolved]
+            assert np.all(C_resolved > 0), (
+                f"Classical E4 row {i}: C < 0 at resolved xi "
+                f"(min={np.min(C_resolved):.4e}), parasitic sign reversal"
+            )
+
+
+class TestGKSDiagnostic:
+    """GKS group velocity diagnostic tests (34.3e).
+
+    Tests for :func:`gks_group_velocity_check`, which bridges per-stencil
+    group velocity analysis with full-operator eigenvalue analysis by
+    identifying boundary-localized, nearly-neutral eigenmodes whose group
+    velocity radiates energy into the domain (GKS instability signature).
+    """
+
+    N_XI = 1000
+
+    def test_stable_scheme_no_outgoing_modes(self):
+        """Stable E2 scheme: no boundary modes radiate energy into the domain.
+
+        E2 with tension kernel (universally stable for all sigma) produces no
+        boundary-localized nearly-neutral eigenmodes at sigma=10, confirming
+        the diagnostic returns clean results for a well-behaved scheme.
+        """
+        from stencil_gen.phs import build_diff_matrix_rbf
+
+        n = 40
+        xi = np.linspace(0, np.pi, self.N_XI)
+        D = build_diff_matrix_rbf(
+            n, p=1, q=1, epsilon=10.0, kernel="tension", nu=1, nextra=0,
+        )
+        modes = gks_group_velocity_check(D, xi)
+
+        outgoing = [m for m in modes if m.is_outgoing]
+        assert len(outgoing) == 0, (
+            f"Stable E2 has {len(outgoing)} outgoing modes: "
+            + "; ".join(
+                f"lam={m.eigenvalue:.4f}, xi={m.boundary_wavenumber:.3f}, "
+                f"C={m.group_velocity:.3f}"
+                for m in outgoing
+            )
+        )
+
+    def test_known_unstable_extrapolation(self):
+        """GKS diagnostic detects parasitic boundary mode in E4 PHS.
+
+        The original plan aimed to test with extrapolation outflow BC (known
+        GKS-unstable for leapfrog, Trefethen 1983).  However, the leapfrog
+        instability is time-discrete: the fully-discrete dispersion relation
+        differs from the semi-discrete one, and the semi-discrete eigenvalue
+        framework used here cannot capture that effect.  A time-discrete
+        extension using the leapfrog dispersion relation is future work.
+
+        Instead, we test with E4 PHS (sigma=0), which reliably produces a
+        boundary-localized, nearly-neutral eigenmode whose dominant wavenumber
+        is in the parasitic regime (xi near pi).  The interior group velocity
+        at that wavenumber is strongly negative (C ~ -1.7), meaning energy
+        flows from the right boundary into the domain.  The mode is slightly
+        damped (Re ~ -0.007), so it doesn't cause exponential growth, but the
+        diagnostic correctly flags the suspicious group velocity direction.
+        """
+        from stencil_gen.phs import build_diff_matrix_rbf
+
+        n = 40
+        xi = np.linspace(0, np.pi, self.N_XI)
+        D = build_diff_matrix_rbf(
+            n, p=2, q=3, epsilon=0.0, kernel="tension", nu=1, nextra=0,
+        )
+        modes = gks_group_velocity_check(D, xi)
+
+        # E4 PHS produces at least one outgoing boundary mode
+        outgoing = [m for m in modes if m.is_outgoing]
+        assert len(outgoing) >= 1, (
+            f"Expected at least 1 outgoing mode for E4 PHS, got {len(modes)} "
+            f"total modes with 0 outgoing"
+        )
+
+        # The outgoing mode should be in the parasitic regime (high xi)
+        # where interior group velocity is negative
+        mode = outgoing[0]
+        assert isinstance(mode, GKSModeInfo)
+        assert mode.boundary_wavenumber > np.pi / 2, (
+            f"Outgoing mode wavenumber {mode.boundary_wavenumber:.3f} should be "
+            f"in parasitic regime (> pi/2)"
+        )
+        assert mode.group_velocity < 0, (
+            f"Outgoing mode group velocity {mode.group_velocity:.3f} should be "
+            f"negative (energy flowing into domain from right boundary)"
+        )
+        # Mode is nearly-neutral (slightly damped, not growing)
+        assert mode.eigenvalue.real < 0, (
+            f"Mode Re(lambda) = {mode.eigenvalue.real:.6e} should be negative "
+            f"(damped, not growing)"
+        )
+
+
+class TestGKSSideParameter:
+    """Tests for the ``side`` parameter of :func:`gks_group_velocity_check` (41.4b)."""
+
+    N_XI = 1000
+
+    def _build_e4_phs_matrix(self, n: int = 40) -> np.ndarray:
+        """Build E4 PHS differentiation matrix (known to have boundary modes)."""
+        from stencil_gen.phs import build_diff_matrix_rbf
+
+        return build_diff_matrix_rbf(
+            n, p=2, q=3, epsilon=0.0, kernel="tension", nu=1, nextra=0,
+        )
+
+    def test_left_default_unchanged(self):
+        """Explicit side='left' produces the same results as the default (no side arg).
+
+        Verifies backwards compatibility: adding the side parameter does not
+        change existing behavior for the left boundary.
+        """
+        xi = np.linspace(0, np.pi, self.N_XI)
+        D = self._build_e4_phs_matrix()
+
+        modes_default = gks_group_velocity_check(D, xi)
+        modes_left = gks_group_velocity_check(D, xi, side="left")
+
+        assert len(modes_default) == len(modes_left)
+        for m_def, m_left in zip(modes_default, modes_left):
+            np.testing.assert_allclose(
+                m_def.eigenvalue, m_left.eigenvalue, atol=1e-12,
+            )
+            np.testing.assert_allclose(
+                m_def.boundary_wavenumber, m_left.boundary_wavenumber, atol=1e-12,
+            )
+            np.testing.assert_allclose(
+                m_def.group_velocity, m_left.group_velocity, atol=1e-12,
+            )
+            assert m_def.is_outgoing == m_left.is_outgoing
+
+    def test_right_mirrors_left(self):
+        """side='right' on D has the same eigenvalue spectrum as side='left' on P@D@P.
+
+        Under index reversal, ``D_rev = P @ D @ P`` (where ``P`` is the
+        reversal permutation) satisfies ``D_rev[1:, 1:] = P' @ D[:-1, :-1] @ P'``
+        (a similarity transform), so ``eig(-D_rev[1:, 1:]) == eig(-D[:-1, :-1])``.
+        This means ``side="left"`` on ``D_rev`` produces the same eigenvalues as
+        ``side="right"`` on the original ``D``.
+
+        The outgoing classification is not compared because it depends on the
+        eigenvector spatial structure, which the FFT-based wavenumber estimator
+        resolves differently on the reversed vs original matrix.
+        """
+        xi = np.linspace(0, np.pi, self.N_XI)
+        D = self._build_e4_phs_matrix()
+        n = D.shape[0]
+
+        # Index reversal: D_rev = P @ D @ P (no negation — preserves eig(-D_bc))
+        P = np.eye(n)[::-1]
+        D_rev = P @ D @ P
+
+        modes_right = gks_group_velocity_check(D, xi, side="right")
+        modes_left_rev = gks_group_velocity_check(D_rev, xi, side="left")
+
+        # Both analyses should find the same number of modes
+        assert len(modes_right) == len(modes_left_rev), (
+            f"side='right' found {len(modes_right)} modes, "
+            f"side='left' on reflected D found {len(modes_left_rev)}"
+        )
+
+        # Sort by eigenvalue imaginary part for stable comparison
+        modes_right_sorted = sorted(modes_right, key=lambda m: m.eigenvalue.imag)
+        modes_left_sorted = sorted(modes_left_rev, key=lambda m: m.eigenvalue.imag)
+
+        for m_right, m_left in zip(modes_right_sorted, modes_left_sorted):
+            # Eigenvalues should match (similarity transform preserves spectrum)
+            np.testing.assert_allclose(
+                m_right.eigenvalue, m_left.eigenvalue, atol=1e-8,
+                err_msg="Eigenvalues should match between right and reflected-left",
+            )
+
+    def test_bottom_raises(self):
+        """side='bottom' raises NotImplementedError (requires 2D D, deferred to 41.6)."""
+        xi = np.linspace(0, np.pi, self.N_XI)
+        D = self._build_e4_phs_matrix()
+
+        with pytest.raises(NotImplementedError, match="2D differentiation matrix"):
+            gks_group_velocity_check(D, xi, side="bottom")
+
+    def test_top_raises(self):
+        """side='top' raises NotImplementedError."""
+        xi = np.linspace(0, np.pi, self.N_XI)
+        D = self._build_e4_phs_matrix()
+
+        with pytest.raises(NotImplementedError, match="2D differentiation matrix"):
+            gks_group_velocity_check(D, xi, side="top")
+
+    def test_invalid_side_raises(self):
+        """Invalid side value raises ValueError."""
+        xi = np.linspace(0, np.pi, self.N_XI)
+        D = self._build_e4_phs_matrix()
+
+        with pytest.raises(ValueError, match="side must be one of"):
+            gks_group_velocity_check(D, xi, side="invalid")
+
+
+class TestNonuniformModWavenumber:
+    """Tests for modified_wavenumber_nonuniform and group_velocity_exact_nonuniform (35.1b)."""
+
+    N_XI = 500
+
+    def test_nonuniform_mod_wavenumber(self):
+        """With integer offsets, nonuniform version matches uniform version exactly."""
+        weights = [-0.5, 0.0, 0.5]
+        nodes = [-1, 0, 1]
+        i_eval = 0
+        offsets = [n - i_eval for n in nodes]  # [-1, 0, 1]
+        xi = np.linspace(0, np.pi, self.N_XI)
+
+        kstar_uniform = modified_wavenumber(weights, i_eval, nodes, xi)
+        kstar_nonuniform = modified_wavenumber_nonuniform(weights, offsets, xi)
+
+        assert np.allclose(kstar_uniform, kstar_nonuniform, atol=1e-14), (
+            f"Nonuniform should match uniform for integer offsets, "
+            f"max diff = {np.max(np.abs(kstar_uniform - kstar_nonuniform)):.2e}"
+        )
+
+    def test_nonuniform_gv_matches_uniform(self):
+        """With integer offsets, nonuniform GV matches uniform GV exactly."""
+        weights = [-0.5, 0.0, 0.5]
+        nodes = [-1, 0, 1]
+        i_eval = 0
+        offsets = [n - i_eval for n in nodes]
+        xi = np.linspace(0, np.pi, self.N_XI)
+
+        C_uniform = group_velocity_exact(weights, i_eval, nodes, xi)
+        C_nonuniform = group_velocity_exact_nonuniform(weights, offsets, xi)
+
+        assert np.allclose(C_uniform, C_nonuniform, atol=1e-14), (
+            f"Nonuniform GV should match uniform for integer offsets, "
+            f"max diff = {np.max(np.abs(C_uniform - C_nonuniform)):.2e}"
+        )
+
+    def test_nonuniform_fractional_offset_bounded(self):
+        """Nonuniform with fractional offsets produces bounded, finite results."""
+        # Simulate a cut-cell-like stencil with wall at -0.3
+        weights = [-0.3, 0.7, 0.1, -0.5]
+        offsets = [-0.3, 0.0, 1.0, 2.0]
+        xi = np.linspace(0.01, np.pi, self.N_XI)
+
+        kstar = modified_wavenumber_nonuniform(weights, offsets, xi)
+        C = group_velocity_exact_nonuniform(weights, offsets, xi)
+
+        assert np.all(np.isfinite(kstar)), "kappa* should be finite"
+        assert np.all(np.isfinite(C)), "Group velocity should be finite"
+        assert np.max(np.abs(C)) < 100, f"|C| blow-up: max={np.max(np.abs(C)):.2e}"
+
+
+class TestCutCellGroupVelocity:
+    """Cut-cell group velocity analysis (35.1c)."""
+
+    N_XI = 1000
+
+    @pytest.fixture(scope="class")
+    def e2_1_cut_cell(self):
+        """Derive E2_1 cut-cell stencil (symbolic in psi and alpha)."""
+        from sympy import Symbol
+
+        from stencil_gen.temo import E2_1, derive_cut_cell_scheme
+
+        psi = Symbol("psi")
+        result = derive_cut_cell_scheme(E2_1, psi)
+        return result, psi
+
+    def test_psi_1_matches_uniform(self, e2_1_cut_cell):
+        """At psi=1, cut-cell group velocity matches uniform boundary GV.
+
+        By TEMO construction, B(psi=1) = B_u (the uniform boundary stencil).
+        At psi=1 the wall is at position -1 (uniform spacing), so the cut-cell
+        stencil effectively reduces to a uniform-grid boundary stencil.
+
+        We compare by evaluating the TEMO's own B_u at alpha=0 and verifying
+        the group velocity profiles agree at resolved wavenumbers.
+        """
+        from stencil_gen.group_velocity import _build_profile
+        from stencil_gen.temo import E2_1 as scheme, derive_uniform_boundary_for_temo
+
+        result, psi = e2_1_cut_cell
+        xi = np.linspace(0.01, np.pi, self.N_XI)
+        alpha_vals = {s: 0 for s in result.alpha_symbols}
+
+        cc_profiles = cut_cell_group_velocity(
+            result, psi, psi_val=1.0, alpha_values=alpha_vals, xi_array=xi,
+        )
+
+        # At psi=1, all rows should give well-behaved GV
+        for i, prof in cc_profiles.items():
+            assert np.all(np.isfinite(prof.group_velocity)), (
+                f"Row {i}: non-finite GV at psi=1"
+            )
+            # At low xi, C should be near 1 (consistent scheme)
+            low_xi = xi < 0.3
+            C_low = prof.group_velocity[low_xi]
+            assert abs(C_low[0] - 1.0) < 0.5, (
+                f"Row {i}: C at low xi = {C_low[0]:.4f}, expected ~1"
+            )
+
+        # Get the TEMO uniform boundary B_u and compute its GV.
+        # At psi=1, the wall column coefficient is zero for rows 0..r-1,
+        # so the cut-cell stencil exactly matches the uniform one.
+        ur = derive_uniform_boundary_for_temo(scheme)
+        B_u = ur.B_u
+        u_alpha_vals = {s: 0 for s in ur.alpha_symbols}
+        t = B_u.cols
+        nodes = np.arange(t)
+
+        for i in range(B_u.rows):
+            w_uni = [float(B_u[i, j].xreplace(u_alpha_vals))
+                     if hasattr(B_u[i, j], 'xreplace') else float(B_u[i, j])
+                     for j in range(t)]
+            uni_prof = _build_profile(w_uni, nodes - i, xi, order=scheme.q)
+            max_diff = np.max(np.abs(
+                cc_profiles[i].group_velocity - uni_prof.group_velocity
+            ))
+            assert max_diff < 1e-10, (
+                f"Row {i}: psi=1 cut-cell GV should match TEMO uniform "
+                f"exactly (wall coeff=0), diff = {max_diff:.2e}"
+            )
+
+    def test_psi_0_degenerate_bounded(self, e2_1_cut_cell):
+        """At psi=0 (degenerate mesh), group velocity is bounded and finite.
+
+        The degenerate point collocates the wall with grid point 0, so the
+        stencil degenerates gracefully (by TEMO design principle).
+        """
+        result, psi = e2_1_cut_cell
+        xi = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+        alpha_vals = {s: 0 for s in result.alpha_symbols}
+
+        profiles = cut_cell_group_velocity(
+            result, psi, psi_val=0.0, alpha_values=alpha_vals, xi_array=xi,
+        )
+
+        for i, prof in profiles.items():
+            C = prof.group_velocity
+            assert np.all(np.isfinite(C)), (
+                f"Row {i}: non-finite GV at psi=0"
+            )
+            assert np.max(np.abs(C)) < 100, (
+                f"Row {i}: |C| blow-up at psi=0, max={np.max(np.abs(C)):.2e}"
+            )
+
+    def test_e2_1_cut_cell_gv_smooth_in_psi(self, e2_1_cut_cell):
+        """E2_1 group velocity varies smoothly with psi (no discontinuous jumps).
+
+        Compute C(xi) at 11 evenly spaced psi values in [0, 1] and verify
+        that the group velocity profile at resolved wavenumbers changes
+        smoothly between adjacent values (bounded derivative dC/dpsi).
+        """
+        result, psi = e2_1_cut_cell
+        xi = np.linspace(0.01, np.pi / 2, self.N_XI)
+        alpha_vals = {s: 0 for s in result.alpha_symbols}
+
+        psi_values = np.linspace(0.0, 1.0, 11)
+        all_profiles = {}
+        for pv in psi_values:
+            all_profiles[pv] = cut_cell_group_velocity(
+                result, psi, psi_val=float(pv), alpha_values=alpha_vals,
+                xi_array=xi,
+            )
+
+        # For each row, check that adjacent psi values give bounded dC/dpsi
+        R = result.floating.rows
+        for i in range(R):
+            for k in range(len(psi_values) - 1):
+                pv0, pv1 = float(psi_values[k]), float(psi_values[k + 1])
+                C0 = all_profiles[pv0][i].group_velocity
+                C1 = all_profiles[pv1][i].group_velocity
+                dpsi = pv1 - pv0
+                max_deriv = np.max(np.abs(C1 - C0)) / dpsi
+                # dC/dpsi should be finite (no discontinuity).  A smooth
+                # rational function in psi can have large but bounded
+                # derivatives, especially near psi=0 where the stencil
+                # degenerates.  Threshold of 200 catches genuine
+                # discontinuities while allowing smooth variation.
+                assert max_deriv < 200, (
+                    f"Row {i}: dC/dpsi too large between psi={pv0:.2f} and "
+                    f"psi={pv1:.2f}, max|dC/dpsi| = {max_deriv:.1f}"
+                )
+
+
+class TestPsiSweepGroupVelocity:
+    """Psi sweep group velocity analysis (35.2b)."""
+
+    N_XI = 500
+
+    def test_e2_1_psi_sweep(self):
+        """Sweep psi in [0, 1] for E2_1; verify result structure and diagnostics.
+
+        Computes group velocity at 11 psi values and verifies:
+        - PsiSweepResult is well-formed with all expected fields.
+        - All profiles are finite and bounded.
+        - No parasitic sign reversal at well-resolved wavenumbers (xi < pi/2)
+          for non-degenerate psi values (psi >= 0.1).
+        """
+        from stencil_gen.temo import E2_1
+
+        xi = np.linspace(0.01, np.pi, self.N_XI)
+        psi_values = np.linspace(0.0, 1.0, 11)
+
+        result = psi_sweep_group_velocity(
+            E2_1, psi_values, alpha_values={}, xi_array=xi,
+        )
+
+        assert isinstance(result, PsiSweepResult)
+        assert len(result.profiles) == len(psi_values)
+        assert result.min_C < float("inf")
+
+        # All profiles should be finite and bounded
+        for pv, profs in result.profiles.items():
+            for row_idx, prof in profs.items():
+                assert np.all(np.isfinite(prof.group_velocity)), (
+                    f"psi={pv}, row {row_idx}: non-finite GV"
+                )
+                assert np.max(np.abs(prof.group_velocity)) < 100, (
+                    f"psi={pv}, row {row_idx}: |C| blow-up"
+                )
+
+        # At non-degenerate psi (>= 0.1), boundary rows should not have
+        # strongly negative C at resolved wavenumbers.  The degenerate
+        # psi=0 point collocates the wall with a grid point and some rows
+        # naturally produce negative C there.
+        resolved = xi < np.pi / 2
+        interior = interior_group_velocity(p=E2_1.p, nu=1, xi_array=xi)
+        C_int = interior.group_velocity
+        for pv, profs in result.profiles.items():
+            if pv < 0.1:
+                continue
+            for row_idx, prof in profs.items():
+                C_res = prof.group_velocity[resolved]
+                # No parasitic sign reversal: boundary C > 0 where interior C < 0
+                reversal = (C_res > 0) & (C_int[resolved] < 0)
+                assert not np.any(reversal), (
+                    f"psi={pv}, row {row_idx}: parasitic sign reversal "
+                    f"at resolved xi"
+                )
+
+    def test_e2_1_no_cfl_penalty(self):
+        """TEMO cut-cell stencil does not dramatically increase max|omega(xi)|.
+
+        The TEMO construction avoids the CFL stiffness penalty: the maximum
+        |omega| = max|Im(kappa*(xi))| should not blow up as psi -> 0.
+        We verify that the ratio max|omega(psi)| / max|omega(psi=1)| stays
+        bounded (< 10x) across all psi values.
+        """
+        from stencil_gen.temo import E2_1
+
+        xi = np.linspace(0.01, np.pi, self.N_XI)
+        psi_values = np.linspace(0.0, 1.0, 11)
+
+        result = psi_sweep_group_velocity(
+            E2_1, psi_values, alpha_values={}, xi_array=xi,
+        )
+
+        # Compute max|omega| at psi=1 as reference
+        ref_profs = result.profiles[1.0]
+        ref_max_omega = max(
+            float(np.max(np.abs(np.imag(prof.kappa_star))))
+            for prof in ref_profs.values()
+        )
+
+        # At each psi, max|omega| should not blow up
+        for pv, profs in result.profiles.items():
+            psi_max_omega = max(
+                float(np.max(np.abs(np.imag(prof.kappa_star))))
+                for prof in profs.values()
+            )
+            ratio = psi_max_omega / max(ref_max_omega, 1e-15)
+            assert ratio < 10.0, (
+                f"psi={pv}: max|omega| = {psi_max_omega:.4f} is "
+                f"{ratio:.1f}x the psi=1 reference ({ref_max_omega:.4f}), "
+                f"indicating CFL penalty"
+            )
+
+    @pytest.mark.slow
+    def test_e4_1_psi_sweep(self):
+        """Sweep psi in [0, 1] for E4_1 (stricter scheme).
+
+        E4_1 has tighter constraints (only 2 stable schemes in the paper).
+        Verify the psi sweep completes without blow-up and profiles are bounded.
+        """
+        from stencil_gen.temo import E4_1
+
+        xi = np.linspace(0.01, np.pi, self.N_XI)
+        psi_values = np.linspace(0.0, 1.0, 11)
+
+        result = psi_sweep_group_velocity(
+            E4_1, psi_values, alpha_values={}, xi_array=xi,
+        )
+
+        assert isinstance(result, PsiSweepResult)
+        assert len(result.profiles) == len(psi_values)
+
+        # All profiles should be finite and bounded
+        for pv, profs in result.profiles.items():
+            for row_idx, prof in profs.items():
+                assert np.all(np.isfinite(prof.group_velocity)), (
+                    f"psi={pv}, row {row_idx}: non-finite GV"
+                )
+                # E4_1 has a wider stencil (7 points) with non-uniform
+                # offsets, so |C| can be larger at high xi than for E2.
+                assert np.max(np.abs(prof.group_velocity)) < 500, (
+                    f"psi={pv}, row {row_idx}: |C| blow-up, "
+                    f"max={np.max(np.abs(prof.group_velocity)):.2e}"
+                )
+
+
+class TestCutCellGVvsEigenvalue:
+    """Comparison of GV diagnostic with eigenvalue analysis (35.3a).
+
+    Verifies that the per-stencil group velocity diagnostic agrees with
+    full-operator eigenvalue stability for cut-cell configurations, and
+    demonstrates the O(1)-vs-O(N^3) cost advantage of the GV approach.
+    """
+
+    N_XI = 500
+
+    @staticmethod
+    def _build_cut_cell_diff_matrix(cc_result, psi_sym, psi_val, alpha_values,
+                                    scheme_params, n):
+        """Build N×N diff matrix with cut-cell left boundary.
+
+        Left boundary rows use the Dirichlet cut-cell stencil evaluated at
+        *psi_val*.  Interior uses the standard centered stencil.  Right
+        boundary uses the uniform RBF/tension stencil (sigma=10, stable).
+
+        Parameters
+        ----------
+        cc_result : CutCellResult
+            Pre-derived symbolic cut-cell stencil.
+        psi_sym : Symbol
+            SymPy psi symbol.
+        psi_val : float
+            Numeric psi value.
+        alpha_values : dict
+            Alpha symbol → value mapping.
+        scheme_params : SchemeParams
+            Scheme parameters (for p, q, nu, nextra).
+        n : int
+            Grid size.
+
+        Returns
+        -------
+        np.ndarray
+            N×N differentiation matrix.
+        """
+        from stencil_gen.interior import derive_interior, full_gamma_array
+        from stencil_gen.phs import uniform_boundary_weights_rbf
+
+        dims = cc_result.dims
+        r, t, T = dims.r, dims.t, dims.T
+        p, nu = scheme_params.p, scheme_params.nu
+
+        subs = {psi_sym: psi_val, **alpha_values}
+
+        # Interior stencil
+        interior_coeffs = derive_interior(0, p, nu)
+        interior_w = [float(c) for c in full_gamma_array(interior_coeffs)]
+
+        D = np.zeros((n, n))
+
+        # Left boundary: cut-cell Dirichlet stencil.
+        # dirichlet has (R-1) = r rows, T columns.
+        # Column 0 is the wall (u_wall = 0 for Dirichlet), columns 1..T-1
+        # are grid points 0..T-2 = 0..t-1.
+        F_dir = cc_result.dirichlet
+        for i in range(F_dir.rows):
+            for j in range(1, T):
+                D[i, j - 1] = float(F_dir[i, j].xreplace(subs))
+
+        # Interior rows: centered 2p+1 stencil
+        for i in range(r, n - r):
+            for k_idx, j in enumerate(range(i - p, i + p + 1)):
+                D[i, j] = interior_w[k_idx]
+
+        # Right boundary: reflected uniform stencil (sigma=0 tension =
+        # polynomial-only, matching the TEMO polynomial design).
+        sign = (-1.0) ** nu
+        for i in range(r):
+            w = uniform_boundary_weights_rbf(
+                i, t, nu, scheme_params.q, 0.0, kernel="tension",
+            )
+            row = n - 1 - i
+            for j in range(t):
+                col = n - 1 - j
+                D[row, col] = sign * float(w[j])
+
+        return D
+
+    def test_gv_predicts_eigenvalue_stability(self):
+        """GV diagnostic and eigenvalue stability agree for E2_1 cut-cell.
+
+        For E2_1 at psi = 0.1, 0.3, 0.5, 0.7, 1.0:
+        - Compute GV profiles via cut_cell_group_velocity.
+        - Build the N×N diff matrix and compute eigenvalues of -D.
+        - Check: if no parasitic sign reversal in GV → eigenvalues stable
+          (Re(lambda) <= small positive tolerance).
+        """
+        from sympy import Symbol
+
+        from stencil_gen.temo import E2_1, derive_cut_cell_scheme
+
+        psi_sym = Symbol("psi")
+        cc = derive_cut_cell_scheme(E2_1, psi_sym)
+        alpha_vals = {s: 0 for s in cc.alpha_symbols}
+
+        xi = np.linspace(0.01, np.pi, self.N_XI)
+        n = 40
+        psi_test = [0.1, 0.3, 0.5, 0.7, 1.0]
+
+        # Interior GV for sign-reversal detection
+        interior = interior_group_velocity(p=E2_1.p, nu=1, xi_array=xi)
+        C_int = interior.group_velocity
+
+        for pv in psi_test:
+            # --- Group velocity diagnostic ---
+            profiles = cut_cell_group_velocity(
+                cc, psi_sym, pv, alpha_vals, xi, order=E2_1.q,
+            )
+            # Check for parasitic sign reversal at resolved wavenumbers
+            resolved = xi < np.pi / 2
+            gv_has_reversal = False
+            for row_idx, prof in profiles.items():
+                C = prof.group_velocity
+                reversal = (C[resolved] > 0) & (C_int[resolved] < 0)
+                if np.any(reversal):
+                    gv_has_reversal = True
+                    break
+
+            # --- Eigenvalue stability ---
+            D = self._build_cut_cell_diff_matrix(
+                cc, psi_sym, pv, alpha_vals, E2_1, n,
+            )
+            eigenvalues = np.linalg.eigvals(-D)
+            max_real = float(np.max(eigenvalues.real))
+
+            # Consistency: no GV reversal → eigenvalues stable.
+            # Tolerance 1e-4: the polynomial-only right boundary produces
+            # O(1e-6) positive Re at finite N — these vanish as N → ∞ and
+            # are not related to the cut-cell left boundary under test.
+            if not gv_has_reversal:
+                assert max_real < 1e-4, (
+                    f"psi={pv}: GV says no parasitic reversal but "
+                    f"eigenvalue Re(lambda)_max = {max_real:.2e} > 0 "
+                    f"(unstable)"
+                )
+            # Note: GV reversal does NOT guarantee instability (it's a
+            # necessary condition from GKS theory, not sufficient), so we
+            # don't assert the converse.
+
+class Test2DGroupVelocity:
+    """2D tensor-product group velocity tests (36.1)."""
+
+    N_XI = 500
+
+    @staticmethod
+    def _e2_kappa_star(xi: np.ndarray) -> np.ndarray:
+        """E2 (2nd-order central) modified wavenumber: kappa* = i*sin(xi)."""
+        weights = [-0.5, 0.0, 0.5]
+        nodes = [-1, 0, 1]
+        return modified_wavenumber(weights, 0, nodes, xi)
+
+    def test_2d_basic(self):
+        """group_velocity_2d returns correct result structure and values for E2."""
+        xi = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+        eta = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+
+        kx = self._e2_kappa_star(xi)
+        ky = self._e2_kappa_star(eta)
+
+        result = group_velocity_2d(kx, ky, xi, eta, a=1.0, b=1.0)
+
+        # Check return type and field shapes
+        assert isinstance(result, GroupVelocity2DResult)
+        assert result.C_x.shape == (len(xi), len(eta))
+        assert result.C_y.shape == (len(xi), len(eta))
+        assert result.speed.shape == (len(xi), len(eta))
+        assert result.angle.shape == (len(xi), len(eta))
+        assert result.angle_error.shape == (len(xi), len(eta))
+
+        # For E2, Im(kappa*) = sin(xi), so C_1d = cos(xi).
+        # C_x should equal cos(xi) broadcast over eta.
+        C_x_expected = np.cos(xi)
+        np.testing.assert_allclose(
+            result.C_x[:, len(eta) // 2], C_x_expected, atol=1e-3,
+            err_msg="C_x should match cos(xi) for E2 stencil",
+        )
+
+        # C_y should equal cos(eta) broadcast over xi.
+        C_y_expected = np.cos(eta)
+        np.testing.assert_allclose(
+            result.C_y[len(xi) // 2, :], C_y_expected, atol=1e-3,
+            err_msg="C_y should match cos(eta) for E2 stencil",
+        )
+
+        # Speed at (xi, eta) = sqrt(cos^2(xi) + cos^2(eta))
+        xi_2d, eta_2d = np.meshgrid(xi, eta, indexing="ij")
+        speed_expected = np.sqrt(np.cos(xi_2d)**2 + np.cos(eta_2d)**2)
+        np.testing.assert_allclose(
+            result.speed, speed_expected, atol=1e-3,
+            err_msg="Speed should be sqrt(C_x^2 + C_y^2)",
+        )
+
+    def test_2d_wave_speed_scaling(self):
+        """group_velocity_2d correctly scales by wave speed coefficients a, b."""
+        xi = np.linspace(0.1, 2.0, 200)
+        eta = np.linspace(0.1, 2.0, 200)
+
+        kx = self._e2_kappa_star(xi)
+        ky = self._e2_kappa_star(eta)
+
+        a, b = 2.0, 0.5
+        result = group_velocity_2d(kx, ky, xi, eta, a=a, b=b)
+
+        # C_x should be a*cos(xi), C_y should be b*cos(eta).
+        # Exclude endpoints where np.gradient has reduced accuracy.
+        s = slice(1, -1)
+        np.testing.assert_allclose(
+            result.C_x[s, 0], a * np.cos(xi[s]), atol=1e-3,
+            err_msg="C_x should scale with wave speed a",
+        )
+        np.testing.assert_allclose(
+            result.C_y[0, s], b * np.cos(eta[s]), atol=1e-3,
+            err_msg="C_y should scale with wave speed b",
+        )
+
+    def test_anisotropy_basic(self):
+        """anisotropy_profile returns correct structure and basic properties."""
+        theta = np.linspace(0.01, np.pi / 2 - 0.01, 200)
+        xi_mag = 1.0
+
+        result = anisotropy_profile(p=1, nu=1, theta_array=theta, xi_mag=xi_mag)
+
+        # Check return type and shapes
+        assert isinstance(result, AnisotropyResult)
+        assert result.C_x.shape == theta.shape
+        assert result.C_y.shape == theta.shape
+        assert result.speed.shape == theta.shape
+        assert result.angle.shape == theta.shape
+        assert result.angle_error.shape == theta.shape
+
+        # For E2 (p=1), the 1D group velocity is cos(xi).
+        # At theta=0: C_x = cos(xi_mag), C_y = 0, speed = cos(xi_mag)
+        # At theta=pi/2: C_x = 0, C_y = cos(xi_mag), speed = cos(xi_mag)
+        # At theta=pi/4: speed = cos(xi_mag/sqrt(2))
+        # Since cos(xi_mag/sqrt(2)) > cos(xi_mag), diagonal is faster.
+
+        # Verify speed is in (0, 1] for moderate xi_mag
+        assert np.all(result.speed > 0), "Speed should be positive"
+        assert np.all(result.speed <= 1.0 + 1e-10), "Speed should not exceed 1"
+
+        # Angle should roughly track theta (anisotropy causes deviation,
+        # up to ~0.18 rad for E2 at xi_mag=1.0 -- that's the physical effect)
+        assert np.max(np.abs(result.angle_error)) < 0.25, (
+            "Angle error should be bounded for moderate xi_mag"
+        )
+
+    def test_anisotropy_axis_vs_diagonal(self):
+        """For E2, diagonal propagation is faster than axis-aligned (Trefethen)."""
+        theta = np.array([0.01, np.pi / 4])  # near-axis and diagonal
+        xi_mag = 1.0
+
+        result = anisotropy_profile(p=1, nu=1, theta_array=theta, xi_mag=xi_mag)
+
+        speed_axis = result.speed[0]      # theta ~ 0
+        speed_diag = result.speed[1]      # theta = pi/4
+
+        assert speed_diag > speed_axis, (
+            f"E2 diagonal speed ({speed_diag:.6f}) should exceed "
+            f"axis speed ({speed_axis:.6f})"
+        )
+
+    def test_anisotropy_small_xi_near_exact(self):
+        """At small wavenumber, all schemes approach exact group velocity."""
+        theta = np.linspace(0.1, np.pi / 2 - 0.1, 100)
+        xi_mag = 0.1  # very resolved wave
+
+        # Error is O(xi^(2p)) for order-2p scheme.  At xi=0.1:
+        #   E2 (p=1): ~5e-3, E4 (p=2): ~5e-5, E6 (p=3): ~5e-7
+        tols = {1: 1e-2, 2: 1e-4, 3: 1e-6}
+        for p in [1, 2, 3]:  # E2, E4, E6
+            result = anisotropy_profile(p=p, nu=1, theta_array=theta, xi_mag=xi_mag)
+            np.testing.assert_allclose(
+                result.speed, 1.0, atol=tols[p],
+                err_msg=f"E{2*p} speed should be ~1 at xi_mag=0.1",
+            )
+            np.testing.assert_allclose(
+                result.angle_error, 0.0, atol=tols[p],
+                err_msg=f"E{2*p} angle error should be ~0 at xi_mag=0.1",
+            )
+
+    def test_axis_aligned_reduces_to_1d(self):
+        """For theta=0 (wave along x-axis), 2D group velocity reduces to 1D."""
+        xi = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+        eta = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+
+        kx = self._e2_kappa_star(xi)
+        ky = self._e2_kappa_star(eta)
+
+        # Advection purely in x: a=1, b=0
+        result = group_velocity_2d(kx, ky, xi, eta, a=1.0, b=0.0)
+
+        # C_x should match 1D group velocity cos(xi) for E2
+        C_x_expected = np.cos(xi)
+        np.testing.assert_allclose(
+            result.C_x[:, len(eta) // 2], C_x_expected, atol=1e-3,
+            err_msg="C_x should match 1D group velocity when b=0",
+        )
+
+        # C_y should be 0 everywhere since b=0
+        np.testing.assert_allclose(
+            result.C_y, 0.0, atol=1e-15,
+            err_msg="C_y should be 0 for axis-aligned propagation (b=0)",
+        )
+
+        # Speed should equal |C_x| = |cos(xi)|
+        np.testing.assert_allclose(
+            result.speed[:, len(eta) // 2], np.abs(C_x_expected), atol=1e-3,
+            err_msg="Speed should reduce to |C_x| = 1D speed when b=0",
+        )
+
+    def test_diagonal_propagation(self):
+        """For theta=pi/4 (diagonal), C_x = C_y by symmetry."""
+        # Use the anisotropy_profile which parameterizes by propagation angle
+        theta = np.array([np.pi / 4])
+        xi_mag = 1.0
+
+        result = anisotropy_profile(p=1, nu=1, theta_array=theta, xi_mag=xi_mag)
+
+        # At theta = pi/4: cos(theta) = sin(theta), and the 1D wavenumber
+        # components are equal, so C_x == C_y
+        np.testing.assert_allclose(
+            result.C_x, result.C_y, atol=1e-14,
+            err_msg="C_x should equal C_y at theta=pi/4 by symmetry",
+        )
+
+        # Group propagation angle should be exactly pi/4
+        np.testing.assert_allclose(
+            result.angle, np.pi / 4, atol=1e-14,
+            err_msg="Group angle should be pi/4 for diagonal propagation",
+        )
+
+    def test_anisotropy_e4_reduced(self):
+        """E4 has less grid anisotropy than E2 at the same wavenumber."""
+        theta = np.linspace(0.01, np.pi / 2 - 0.01, 200)
+        xi_mag = 1.0
+
+        result_e2 = anisotropy_profile(p=1, nu=1, theta_array=theta, xi_mag=xi_mag)
+        result_e4 = anisotropy_profile(p=2, nu=1, theta_array=theta, xi_mag=xi_mag)
+
+        # Measure anisotropy as max-min speed variation over theta
+        aniso_e2 = np.max(result_e2.speed) - np.min(result_e2.speed)
+        aniso_e4 = np.max(result_e4.speed) - np.min(result_e4.speed)
+
+        assert aniso_e4 < aniso_e2, (
+            f"E4 anisotropy ({aniso_e4:.6f}) should be less than "
+            f"E2 anisotropy ({aniso_e2:.6f})"
+        )
+
+        # Also check angle deviation is reduced
+        max_angle_err_e2 = np.max(np.abs(result_e2.angle_error))
+        max_angle_err_e4 = np.max(np.abs(result_e4.angle_error))
+
+        assert max_angle_err_e4 < max_angle_err_e2, (
+            f"E4 angle error ({max_angle_err_e4:.6f}) should be less than "
+            f"E2 angle error ({max_angle_err_e2:.6f})"
+        )
+
+    def test_angle_deviation_bounded(self):
+        """Group propagation angle deviation < 5 degrees for well-resolved waves.
+
+        At xi_mag = 0.7 (~9 points per wavelength), E2 has ~4 deg deviation
+        while E4 and E6 have much less.  All are bounded below 5 degrees.
+        """
+        theta = np.linspace(0.05, np.pi / 2 - 0.05, 200)
+        xi_mag = 0.7  # ~9 points per wavelength
+
+        for p in [1, 2, 3]:  # E2, E4, E6
+            result = anisotropy_profile(
+                p=p, nu=1, theta_array=theta, xi_mag=xi_mag,
+            )
+
+            max_deviation_rad = np.max(np.abs(result.angle_error))
+            max_deviation_deg = np.degrees(max_deviation_rad)
+
+            assert max_deviation_deg < 5.0, (
+                f"E{2*p} angle deviation ({max_deviation_deg:.2f} deg) "
+                f"exceeds 5 deg bound at xi_mag={xi_mag}"
+            )
+
+    def test_trefethen_eq_4_8a(self):
+        """For E2, group speed matches the leading-order expansion.
+
+        The tensor-product E2 group speed in 2D satisfies:
+            |C| ~ 1 - |xi|^2 * (3 + cos(4*theta)) / 8
+        to leading order in |xi|.  This is verified by Taylor-expanding
+        cos(|xi|*cos(theta)) and cos(|xi|*sin(theta)) through the
+        group velocity formula.
+        """
+        theta = np.linspace(0.05, np.pi / 2 - 0.05, 200)
+        xi_mag = 0.15  # small enough for leading-order accuracy
+
+        result = anisotropy_profile(p=1, nu=1, theta_array=theta, xi_mag=xi_mag)
+
+        # Analytical prediction: |C| ~ 1 - xi^2*(3+cos(4*theta))/8
+        predicted = 1 - xi_mag**2 * (3 + np.cos(4 * theta)) / 8
+
+        # At xi=0.15, the next-order term is O(xi^4) ~ 5e-5.
+        # The leading-order formula should match to ~1e-4.
+        np.testing.assert_allclose(
+            result.speed, predicted, atol=1e-4,
+            err_msg="E2 group speed should match leading-order expansion",
+        )
+
+    def test_2d_boundary_basic(self):
+        """boundary_group_velocity_2d returns per-row AnisotropyResult dicts."""
+        xi = np.linspace(0, np.pi, self.N_XI)
+        theta = np.linspace(0.05, np.pi / 2 - 0.05, 200)
+        xi_mag = 0.7
+
+        # Boundary stencils in x-direction (E2, q=1)
+        bdy_x = boundary_group_velocity(
+            p=1, q=1, nextra=0, nu=1, sigma=0.1,
+            kernel="tension", xi_array=xi,
+        )
+        # Interior stencil in y-direction
+        int_y = interior_group_velocity(p=1, nu=1, xi_array=xi)
+
+        result = boundary_group_velocity_2d(bdy_x, int_y, theta, xi_mag)
+
+        # Should return one AnisotropyResult per boundary row
+        assert len(result) == len(bdy_x)
+        for row_idx in bdy_x:
+            assert row_idx in result
+            r = result[row_idx]
+            assert isinstance(r, AnisotropyResult)
+            assert r.C_x.shape == theta.shape
+            assert r.C_y.shape == theta.shape
+            assert r.speed.shape == theta.shape
+
+        # At moderate xi_mag, speed should be bounded and finite
+        for row_idx, r in result.items():
+            assert np.all(np.isfinite(r.speed)), (
+                f"Row {row_idx}: non-finite speed"
+            )
+            assert np.all(r.speed < 10), (
+                f"Row {row_idx}: speed blow-up, max={np.max(r.speed):.2f}"
+            )
+
+    def test_2d_boundary_interior_matches_anisotropy(self):
+        """Far from boundary, 2D boundary GV should approach interior anisotropy."""
+        xi = np.linspace(0, np.pi, 1000)
+        theta = np.linspace(0.1, np.pi / 2 - 0.1, 100)
+        xi_mag = 0.5
+
+        # E4 boundary stencils -- the last (highest-index) boundary row
+        # transitions toward the interior behavior
+        bdy_x = boundary_group_velocity(
+            p=2, q=3, nextra=0, nu=1, sigma=0.1,
+            kernel="tension", xi_array=xi,
+        )
+        int_y = interior_group_velocity(p=2, nu=1, xi_array=xi)
+
+        result_bdy = boundary_group_velocity_2d(bdy_x, int_y, theta, xi_mag)
+        result_int = anisotropy_profile(p=2, nu=1, theta_array=theta, xi_mag=xi_mag)
+
+        # The y-component should match interior exactly (same stencil)
+        last_row = max(bdy_x.keys())
+        np.testing.assert_allclose(
+            result_bdy[last_row].C_y, result_int.C_y, atol=1e-3,
+            err_msg="C_y should match interior (same y-direction stencil)",
+        )
+
+
+class Test2DBoundaryGroupVelocity:
+    """2D boundary group velocity tests (36.2b)."""
+
+    N_XI = 500
+
+    def test_boundary_angle_distortion(self):
+        """Boundary stencils distort group velocity angle relative to interior."""
+        xi = np.linspace(0, np.pi, self.N_XI)
+        theta = np.linspace(0.1, np.pi / 2 - 0.1, 200)
+        xi_mag = 0.7
+
+        for p, q, label in [(1, 1, "E2"), (2, 3, "E4")]:
+            bdy_x = boundary_group_velocity(
+                p=p, q=q, nextra=0, nu=1, sigma=0.1,
+                kernel="tension", xi_array=xi,
+            )
+            int_y = interior_group_velocity(p=p, nu=1, xi_array=xi)
+
+            result_bdy = boundary_group_velocity_2d(bdy_x, int_y, theta, xi_mag)
+            result_int = anisotropy_profile(p=p, nu=1, theta_array=theta, xi_mag=xi_mag)
+
+            # Every boundary row should have finite angle error
+            for row_idx, r in result_bdy.items():
+                assert np.all(np.isfinite(r.angle_error)), (
+                    f"{label} row {row_idx}: non-finite angle error"
+                )
+
+            # Row 0 (closest to boundary) should have larger angle distortion
+            # than the last row (furthest from boundary, closest to interior)
+            row_0 = result_bdy[0]
+            last_row = max(result_bdy.keys())
+            row_last = result_bdy[last_row]
+
+            distortion_0 = np.max(np.abs(row_0.angle_error - result_int.angle_error))
+            distortion_last = np.max(np.abs(row_last.angle_error - result_int.angle_error))
+
+            assert distortion_0 > distortion_last, (
+                f"{label}: row 0 distortion ({distortion_0:.4f}) should exceed "
+                f"last row distortion ({distortion_last:.4f})"
+            )
+
+            # Distortion at row 0 should be non-trivial (> 0.01 radians ~ 0.6 deg)
+            assert distortion_0 > 0.01, (
+                f"{label}: boundary distortion at row 0 too small ({distortion_0:.4f} rad)"
+            )
+
+    def test_corner_region(self):
+        """At a corner, both directions use boundary stencils.
+
+        Compute 2D group velocity by using boundary profiles for both x and y.
+        The result should remain finite and bounded -- no blow-up from combining
+        two boundary stencils.
+        """
+        xi = np.linspace(0, np.pi, self.N_XI)
+        theta = np.linspace(0.1, np.pi / 2 - 0.1, 200)
+        xi_mag = 0.5
+
+        # E2 boundary stencils for both directions
+        bdy = boundary_group_velocity(
+            p=1, q=1, nextra=0, nu=1, sigma=0.1,
+            kernel="tension", xi_array=xi,
+        )
+
+        # For a corner: use boundary profiles for BOTH x and y.
+        # boundary_group_velocity_2d takes boundary x-profiles and an interior
+        # y-profile. To simulate a corner, pass a boundary y-profile (row 0)
+        # as the "interior_y" argument.
+        corner_y = bdy[0]
+
+        result_corner = boundary_group_velocity_2d(bdy, corner_y, theta, xi_mag)
+
+        for row_idx, r in result_corner.items():
+            # All values must be finite
+            assert np.all(np.isfinite(r.speed)), (
+                f"Corner row {row_idx}: non-finite speed"
+            )
+            assert np.all(np.isfinite(r.angle)), (
+                f"Corner row {row_idx}: non-finite angle"
+            )
+            # Speed should not blow up (bounded by a generous factor)
+            assert np.all(r.speed < 10), (
+                f"Corner row {row_idx}: speed blow-up, max={np.max(r.speed):.2f}"
+            )
+
+        # Compare corner vs boundary-only-in-x: corner should be slower
+        # because the y-direction also suffers boundary degradation
+        int_y = interior_group_velocity(p=1, nu=1, xi_array=xi)
+        result_bdy = boundary_group_velocity_2d(bdy, int_y, theta, xi_mag)
+
+        row_0_corner_speed = np.mean(result_corner[0].speed)
+        row_0_bdy_speed = np.mean(result_bdy[0].speed)
+
+        # Corner degrades in both directions, so typically speed differs
+        # (it could be either direction depending on stencil, but the results
+        # should at least be finite and comparable in magnitude)
+        assert abs(row_0_corner_speed - row_0_bdy_speed) < 5, (
+            f"Corner vs boundary speed difference unreasonable: "
+            f"corner={row_0_corner_speed:.3f}, bdy={row_0_bdy_speed:.3f}"
+        )
+
+    def test_no_outgoing_2d(self):
+        """No 2D boundary modes have group velocity pointing into the domain
+        at wavenumbers where the interior mode doesn't.
+
+        At a left boundary (outward normal n = (-1, 0)), "into the domain"
+        means C_x > 0. We check that wherever the interior C_x is <= 0
+        (i.e., the interior mode does NOT propagate rightward), the boundary
+        C_x is also not anomalously positive.
+        """
+        xi = np.linspace(0, np.pi, self.N_XI)
+        # Use theta near 0 (wave mostly in x) to focus on x-component
+        theta = np.linspace(0.05, np.pi / 4, 200)
+        xi_mag = 0.7
+
+        for p, q, label in [(1, 1, "E2"), (2, 3, "E4")]:
+            bdy_x = boundary_group_velocity(
+                p=p, q=q, nextra=0, nu=1, sigma=0.1,
+                kernel="tension", xi_array=xi,
+            )
+            int_y = interior_group_velocity(p=p, nu=1, xi_array=xi)
+
+            result_bdy = boundary_group_velocity_2d(bdy_x, int_y, theta, xi_mag)
+            result_int = anisotropy_profile(
+                p=p, nu=1, theta_array=theta, xi_mag=xi_mag,
+            )
+
+            # Interior C_x: where it's non-positive, boundary should not be
+            # strongly positive (allow small tolerance for interpolation noise)
+            int_nonpositive = result_int.C_x <= 0
+
+            for row_idx, r in result_bdy.items():
+                if not np.any(int_nonpositive):
+                    continue
+                # Where interior is non-positive, boundary C_x should not
+                # exceed a small tolerance
+                bdy_cx_at_nonpositive = r.C_x[int_nonpositive]
+                max_outgoing = np.max(bdy_cx_at_nonpositive)
+                assert max_outgoing < 0.1, (
+                    f"{label} row {row_idx}: anomalous outgoing C_x = {max_outgoing:.4f} "
+                    f"where interior C_x <= 0"
+                )
+
+
+class TestVaryingCoefficientGroupVelocity:
+    """Tests for varying-coefficient group velocity analysis (36.3)."""
+
+    N_XI = 200
+
+    def test_varying_basic(self):
+        """With constant a(x)=1, local GV matches interior GV everywhere."""
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        p = 1  # E2
+        coeffs = derive_interior(0, p, 1)
+        w = [float(c) for c in full_gamma_array(coeffs)]
+        nodes = list(range(-p, p + 1))
+
+        xi_array = np.linspace(0, np.pi, self.N_XI)
+        x = np.linspace(0, 1, 10)
+
+        def weights_func(x_val):
+            return w, nodes
+
+        C = local_group_velocity(weights_func, x, xi_array)
+
+        # Shape check
+        assert C.shape == (len(x), len(xi_array))
+
+        # All rows identical (constant coefficient)
+        for i in range(1, len(x)):
+            np.testing.assert_allclose(C[i], C[0], atol=1e-14)
+
+        # Matches interior group velocity from exact formula
+        C_interior = group_velocity_exact(w, 0, nodes, xi_array)
+        np.testing.assert_allclose(C[0], C_interior, atol=1e-14)
+
+    def test_constant_coefficient_uniform_gv(self):
+        """With a(x) = 1 everywhere, local GV equals interior GV at all x."""
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        for p in [1, 2, 3]:  # E2, E4, E6
+            coeffs = derive_interior(0, p, 1)
+            w = [float(c) for c in full_gamma_array(coeffs)]
+            nodes = list(range(-p, p + 1))
+
+            xi_array = np.linspace(0, np.pi, self.N_XI)
+            x = np.linspace(0, 1, 20)
+
+            def weights_func(x_val, _w=w, _n=nodes):
+                return _w, _n
+
+            C = local_group_velocity(weights_func, x, xi_array)
+            C_int = group_velocity_exact(w, 0, nodes, xi_array)
+
+            for i in range(len(x)):
+                np.testing.assert_allclose(
+                    C[i], C_int, atol=1e-14,
+                    err_msg=f"E{2*p} at x={x[i]:.2f}",
+                )
+
+    def test_linear_coefficient_gv_variation(self):
+        """With a(x) = 1 + 0.5*x, local GV varies smoothly with x."""
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        p = 1  # E2
+        coeffs = derive_interior(0, p, 1)
+        w_base = np.array([float(c) for c in full_gamma_array(coeffs)])
+        nodes = list(range(-p, p + 1))
+
+        xi_array = np.linspace(0, np.pi, self.N_XI)
+        x = np.linspace(0, 1, 30)
+
+        def weights_func(x_val):
+            # a(x) = 1 + 0.5*x scales the stencil weights
+            a_x = 1.0 + 0.5 * x_val
+            return (a_x * w_base).tolist(), nodes
+
+        C = local_group_velocity(weights_func, x, xi_array)
+
+        # C should scale linearly with a(x): C(x, xi) = a(x) * g(xi)
+        # where g(xi) is the interior group velocity for unit coefficient
+        g = group_velocity_exact(w_base.tolist(), 0, nodes, xi_array)
+        for i in range(len(x)):
+            a_x = 1.0 + 0.5 * x[i]
+            np.testing.assert_allclose(
+                C[i], a_x * g, atol=1e-13,
+                err_msg=f"x={x[i]:.3f}, a(x)={a_x:.3f}",
+            )
+
+        # Verify smooth variation: max difference between adjacent x-points
+        # should be bounded by the coefficient variation * max|g|
+        dC = np.diff(C, axis=0)
+        dx = np.diff(x)
+        # dC/dx ≈ 0.5 * g(xi) for a(x) = 1 + 0.5*x
+        for i in range(len(dx)):
+            np.testing.assert_allclose(
+                dC[i] / dx[i], 0.5 * g, atol=1e-10,
+            )
+
+    def test_sign_change_interface(self):
+        """With a(x) changing sign, verify GV reversal at the interface.
+
+        When a(x) < 0, the wave propagates in the -x direction, so the group
+        velocity should be negative.  Trefethen (1983, Theorem 5) shows that
+        interfaces where a(x) changes sign always have outgoing modes --
+        energy radiates away from the sign change in both directions.
+        """
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        p = 1  # E2
+        coeffs = derive_interior(0, p, 1)
+        w_base = np.array([float(c) for c in full_gamma_array(coeffs)])
+        nodes = list(range(-p, p + 1))
+
+        xi_array = np.linspace(0.01, np.pi - 0.01, self.N_XI)
+        x = np.linspace(-1, 1, 40)
+
+        def weights_func(x_val):
+            # a(x) = x: changes sign at x = 0
+            a_x = x_val
+            return (a_x * w_base).tolist(), nodes
+
+        C = local_group_velocity(weights_func, x, xi_array)
+
+        # At low wavenumbers where g(xi) > 0 (resolved waves):
+        # C(x, xi) = a(x) * g(xi), so sign(C) = sign(a(x))
+        g = group_velocity_exact(w_base.tolist(), 0, nodes, xi_array)
+        low_xi_mask = xi_array < 1.0  # well-resolved waves
+        assert np.any(low_xi_mask)
+
+        # For x > 0 (a > 0): C should be positive at low xi
+        pos_x = x > 0.2
+        assert np.all(C[pos_x][:, low_xi_mask] > 0), "C should be positive for a(x) > 0"
+
+        # For x < 0 (a < 0): C should be negative at low xi
+        neg_x = x < -0.2
+        assert np.all(C[neg_x][:, low_xi_mask] < 0), "C should be negative for a(x) < 0"
+
+        # At x ≈ 0 (interface): C ≈ 0 (energy stalls at the interface)
+        interface = np.abs(x) < 0.05
+        if np.any(interface):
+            assert np.all(np.abs(C[interface][:, low_xi_mask]) < 0.1)
+
+    def test_ray_trace_uniform(self):
+        """In a uniform medium, rays are straight lines at constant xi.
+
+        Verifies to numerical precision that the RK4 integrator produces
+        exact straight-line trajectories when dC/dx = 0.
+        """
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        p = 2  # E4
+        coeffs = derive_interior(0, p, 1)
+        w = [float(c) for c in full_gamma_array(coeffs)]
+        nodes = list(range(-p, p + 1))
+
+        xi_array = np.linspace(0.01, np.pi, self.N_XI)
+        x_grid = np.linspace(-2, 3, 80)
+
+        def weights_func(x_val):
+            return w, nodes
+
+        C_field = local_group_velocity(weights_func, x_grid, xi_array)
+
+        # Test at several initial wavenumbers
+        for xi_0 in [0.5, 1.0, 2.0]:
+            result = ray_trace_group_velocity(
+                C_field, x_grid, xi_array, xi_0, x_0=0.0, t_final=1.0, dt=0.01,
+            )
+
+            # xi constant
+            np.testing.assert_allclose(result.xi, xi_0, atol=1e-10,
+                                       err_msg=f"xi_0={xi_0}")
+
+            # x linear
+            C_val = float(np.interp(xi_0, xi_array,
+                                     group_velocity_exact(w, 0, nodes, xi_array)))
+            np.testing.assert_allclose(result.x, C_val * result.t, atol=1e-6,
+                                       err_msg=f"xi_0={xi_0}")
+
+    def test_ray_trace_refraction(self):
+        """In a medium with linearly varying a(x), rays bend (refraction).
+
+        For a(x) = 1 + epsilon*x with small epsilon, the ray equations are:
+          dx/dt = a(x) * g(xi)
+          dxi/dt = -epsilon * g(xi)  (since dC/dx = epsilon * g(xi))
+
+        At fixed xi (valid for short times), dxi/dt ≈ -epsilon * g(xi_0),
+        so xi decreases linearly.  Verify against this analytical prediction.
+        """
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        p = 1  # E2
+        coeffs = derive_interior(0, p, 1)
+        w_base = np.array([float(c) for c in full_gamma_array(coeffs)])
+        nodes = list(range(-p, p + 1))
+
+        xi_array = np.linspace(0.01, np.pi, 300)
+        eps = 0.3
+        x_grid = np.linspace(-2, 4, 100)
+
+        def weights_func(x_val):
+            a_x = 1.0 + eps * x_val
+            return (a_x * w_base).tolist(), nodes
+
+        C_field = local_group_velocity(weights_func, x_grid, xi_array)
+
+        xi_0 = 1.0
+        t_final = 0.5
+        dt = 0.005
+
+        result = ray_trace_group_velocity(
+            C_field, x_grid, xi_array, xi_0, x_0=0.0, t_final=t_final, dt=dt,
+        )
+
+        # Analytical prediction for short times:
+        # dxi/dt ≈ -eps * g(xi_0) where g is the interior 1D GV
+        g_xi0 = float(np.interp(xi_0, xi_array,
+                                 group_velocity_exact(w_base.tolist(), 0, nodes, xi_array)))
+        xi_analytical = xi_0 - eps * g_xi0 * result.t
+
+        # Should agree to O(eps * t_final) accuracy
+        np.testing.assert_allclose(
+            result.xi, xi_analytical, atol=0.05,
+            err_msg="Refraction: xi should decrease linearly for small eps*t",
+        )
+
+        # xi should be monotonically changing (refraction is one-way here)
+        dxi = np.diff(result.xi)
+        assert np.all(dxi < 0), "xi should decrease monotonically for eps > 0"
+
+
+class TestLocal2DVarying:
+    """Tests for local_group_velocity_2d_varying and max_local_gv_error_2d."""
+
+    @staticmethod
+    def _interior_stencil(p: int, nu: int = 1):
+        """Return (weights, offsets) for the interior scheme with half-bandwidth p."""
+        from stencil_gen.interior import derive_interior, full_gamma_array
+
+        coeffs = derive_interior(0, p, nu)
+        w = np.array([float(c) for c in full_gamma_array(coeffs)])
+        offsets = np.arange(-p, p + 1, dtype=float)
+        return (w, offsets)
+
+    def test_constant_coefficient_reduces_to_interior(self):
+        """With c_x == 1, c_y == 0, the result should match interior_group_velocity."""
+        p, nu = 2, 1  # E4
+        stencil = self._interior_stencil(p, nu)
+        xi = np.linspace(0.01, np.pi, 100)
+
+        Ny, Nx = 5, 7
+        c_x = np.ones((Ny, Nx))
+        c_y = np.zeros((Ny, Nx))
+
+        result = local_group_velocity_2d_varying(stencil, stencil, c_x, c_y, xi)
+
+        # Reference: 1D interior profile
+        ref_profile = interior_group_velocity(p, nu, xi)
+
+        # C_x_field should be C_x(xi) at every point (c_x == 1)
+        for i in range(Ny):
+            for j in range(Nx):
+                np.testing.assert_allclose(
+                    result["C_x_field"][i, j, :],
+                    ref_profile.group_velocity,
+                    atol=1e-14,
+                )
+        # gv_error_x_field should match gv_error (c_x == 1)
+        for i in range(Ny):
+            for j in range(Nx):
+                np.testing.assert_allclose(
+                    result["gv_error_x_field"][i, j, :],
+                    ref_profile.gv_error,
+                    atol=1e-14,
+                )
+        # C_y_field and gv_error_y_field should be zero (c_y == 0)
+        np.testing.assert_allclose(result["C_y_field"], 0.0, atol=1e-14)
+        np.testing.assert_allclose(result["gv_error_y_field"], 0.0, atol=1e-14)
+
+    def test_radial_flow_field(self):
+        """max_local_gv_error_2d on the Brady-Livescu field is finite and reasonable."""
+        from stencil_gen.benchmarks.brady_livescu_2d import make_coefficient_field
+
+        p, nu = 2, 1  # E4
+        stencil = self._interior_stencil(p, nu)
+        xi = np.linspace(0.01, np.pi, 100)
+
+        _, _, c_x, c_y = make_coefficient_field(31)
+        result = local_group_velocity_2d_varying(stencil, stencil, c_x, c_y, xi)
+
+        max_err = max_local_gv_error_2d(result)
+        assert np.isfinite(max_err), "max_local_gv_error_2d should be finite"
+        assert max_err > 0.0, "max_local_gv_error_2d should be positive"
+        # E4 interior has some dispersion error, and c_x, c_y are O(1).
+        # Near xi=pi the GV error is large (negative C), so the max over all
+        # wavenumbers can exceed 2. Bound is a loose sanity check.
+        assert max_err < 5.0, f"max_local_gv_error_2d unexpectedly large: {max_err}"
+
+    def test_scalar_reduction_finite_for_both_schemes(self):
+        """E2 and E4 both produce finite positive max_local_gv_error_2d on BL field."""
+        from stencil_gen.benchmarks.brady_livescu_2d import make_coefficient_field
+
+        xi = np.linspace(0.01, np.pi, 100)
+        _, _, c_x, c_y = make_coefficient_field(31)
+
+        for p in (1, 2):  # E2 (p=1), E4 (p=2)
+            stencil = self._interior_stencil(p, nu=1)
+            result = local_group_velocity_2d_varying(stencil, stencil, c_x, c_y, xi)
+            max_err = max_local_gv_error_2d(result)
+            assert np.isfinite(max_err), f"p={p}: max error should be finite"
+            assert max_err > 0.0, f"p={p}: max error should be positive"
+
+
+class TestAnisotropyOverField:
+    """Tests for anisotropy_over_coefficient_field (41.7a)."""
+
+    def test_constant_coefficient_uniform(self):
+        """Uniform (c_x, c_y) = (1, 0) gives error matching anisotropy at theta=0."""
+        N = 11
+        c_x = np.ones((N, N))
+        c_y = np.zeros((N, N))
+
+        theta = np.linspace(0.01, np.pi / 2 - 0.01, 100)
+        xi_mag = 1.0
+        result = anisotropy_over_coefficient_field("E4", c_x, c_y, theta, xi_mag)
+
+        # All local angles are 0.  The error at theta=0 should be the
+        # anisotropy profile error at theta=0.
+        ref = anisotropy_profile(2, 1, theta, xi_mag)
+        err_at_0 = np.sqrt(
+            (ref.C_x[0] - np.cos(theta[0])) ** 2
+            + (ref.C_y[0] - np.sin(theta[0])) ** 2
+        )
+        assert result["max_aligned_error"] == pytest.approx(err_at_0, abs=1e-10)
+
+    def test_radial_flow_field(self):
+        """BL radial flow field produces finite positive max_aligned_error."""
+        from stencil_gen.benchmarks.brady_livescu_2d import make_coefficient_field
+
+        _, _, c_x, c_y = make_coefficient_field(31)
+        theta = np.linspace(0.01, np.pi / 2 - 0.01, 200)
+        xi_mag = 1.0
+        result = anisotropy_over_coefficient_field("E4", c_x, c_y, theta, xi_mag)
+
+        assert np.isfinite(result["max_aligned_error"])
+        assert result["max_aligned_error"] > 0.0
+        # E4 at xi_mag=1 has small but nonzero anisotropy
+        assert result["max_aligned_error"] < 1.0
+        # worst_point should be a valid index
+        i, j = result["worst_point"]
+        assert 0 <= i < 31
+        assert 0 <= j < 31
+
+    def test_higher_xi_mag_increases_error(self):
+        """Anisotropy error grows with wavenumber magnitude."""
+        from stencil_gen.benchmarks.brady_livescu_2d import make_coefficient_field
+
+        _, _, c_x, c_y = make_coefficient_field(21)
+        theta = np.linspace(0.01, np.pi / 2 - 0.01, 100)
+
+        err_low = anisotropy_over_coefficient_field(
+            "E4", c_x, c_y, theta, xi_mag=0.5
+        )["max_aligned_error"]
+        err_high = anisotropy_over_coefficient_field(
+            "E4", c_x, c_y, theta, xi_mag=2.0
+        )["max_aligned_error"]
+        assert err_high > err_low
+
+    def test_e2_larger_error_than_e4(self):
+        """E2 has worse anisotropy than E4 at a given xi_mag."""
+        N = 21
+        c_x = np.ones((N, N)) * 0.7
+        c_y = np.ones((N, N)) * 0.7
+        theta = np.linspace(0.01, np.pi / 2 - 0.01, 100)
+        xi_mag = 1.5
+
+        err_e2 = anisotropy_over_coefficient_field(
+            "E2", c_x, c_y, theta, xi_mag
+        )["max_aligned_error"]
+        err_e4 = anisotropy_over_coefficient_field(
+            "E4", c_x, c_y, theta, xi_mag
+        )["max_aligned_error"]
+        assert err_e2 > err_e4

--- a/scripts/stencil_gen/tests/test_non_normality.py
+++ b/scripts/stencil_gen/tests/test_non_normality.py
@@ -1,0 +1,704 @@
+"""Tests for stencil_gen.non_normality module."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from stencil_gen.non_normality import (
+    spectral_abscissa_sparse,
+    numerical_abscissa_sparse,
+    henrici_departure,
+    eigenvector_condition,
+    _sigma_field,
+    pseudospectral_abscissa_estimate,
+    kreiss_constant_estimate,
+    compute_non_normality,
+    NonNormalityReport,
+)
+
+
+# ---------------------------------------------------------------------------
+# TestSpectralAbscissa (41.8b)
+# ---------------------------------------------------------------------------
+
+
+class TestSpectralAbscissa:
+    """Tests for spectral_abscissa_sparse."""
+
+    def test_diagonal_negative(self):
+        """Diagonal -diag(1..50) has spectral abscissa ≈ -1."""
+        diag_vals = -np.arange(1, 51, dtype=float)
+        L = sp.diags(diag_vals, format="csr")
+        max_re, evals = spectral_abscissa_sparse(L, k=10)
+        assert max_re == pytest.approx(-1.0, abs=1e-10)
+        # All eigenvalues should have negative real part
+        assert np.all(evals.real < 0)
+
+    def test_random_sparse_returns_finite(self):
+        """Random sparse matrix returns a finite spectral abscissa."""
+        rng = np.random.default_rng(42)
+        n = 100
+        # Random sparse with density ~5%
+        data = rng.standard_normal(500)
+        rows = rng.integers(0, n, 500)
+        cols = rng.integers(0, n, 500)
+        L = sp.coo_matrix((data, (rows, cols)), shape=(n, n)).tocsr()
+        max_re, evals = spectral_abscissa_sparse(L, k=10)
+        assert np.isfinite(max_re)
+        assert len(evals) > 0
+
+    def test_dense_fallback_small_n(self):
+        """Dense fallback path is exercised at N=20."""
+        rng = np.random.default_rng(123)
+        n = 20
+        A = rng.standard_normal((n, n))
+        # Make it stable: shift eigenvalues to left half-plane
+        A = A - 3.0 * np.eye(n)
+
+        # Pass as dense ndarray — should trigger dense fallback since n <= 900
+        # and n <= k+1 (k=20 by default, so 20 <= 21)
+        max_re, evals = spectral_abscissa_sparse(A, k=20)
+        assert np.isfinite(max_re)
+        # Should have all n eigenvalues from dense path
+        assert len(evals) == n
+
+        # Verify against direct numpy eigvals
+        expected = np.max(np.linalg.eigvals(A).real)
+        assert max_re == pytest.approx(expected, abs=1e-10)
+
+    def test_identity_spectral_abscissa(self):
+        """Identity matrix has spectral abscissa = 1."""
+        L = sp.eye(30, format="csr")
+        max_re, evals = spectral_abscissa_sparse(L, k=5)
+        assert max_re == pytest.approx(1.0, abs=1e-10)
+
+    def test_negative_identity(self):
+        """-I has spectral abscissa = -1."""
+        L = -sp.eye(30, format="csr")
+        max_re, evals = spectral_abscissa_sparse(L, k=5)
+        assert max_re == pytest.approx(-1.0, abs=1e-10)
+
+    def test_known_eigenvalues_tridiagonal(self):
+        """Tridiagonal matrix with known eigenvalues."""
+        # Symmetric tridiagonal: -2 on diagonal, 1 on off-diagonals
+        # Eigenvalues: -2 + 2*cos(k*pi/(n+1)) for k=1..n
+        n = 50
+        diag_main = -2.0 * np.ones(n)
+        diag_off = np.ones(n - 1)
+        L = sp.diags([diag_off, diag_main, diag_off], [-1, 0, 1], format="csr")
+
+        max_re, evals = spectral_abscissa_sparse(L, k=10)
+
+        # Largest eigenvalue is at k=1: -2 + 2*cos(pi/(n+1))
+        expected_max = -2.0 + 2.0 * np.cos(np.pi / (n + 1))
+        assert max_re == pytest.approx(expected_max, abs=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# TestSpectralAbscissaDeterminism (45.6b.1)
+# ---------------------------------------------------------------------------
+
+
+class TestSpectralAbscissaDeterminism:
+    """Tests that spectral_abscissa_sparse is cross-process deterministic.
+
+    scipy 1.17's eigs() draws a fresh OS-entropy Generator per call when
+    rng is None. For BL42-like operators whose eigenvalues cluster on the
+    imaginary axis, ARPACK convergence is highly sensitive to the starting
+    vector, so two calls with the same input can land on different
+    representative eigenvalues. Passing a fixed rng seed pins the starting
+    vector and eliminates that variance.
+    """
+
+    def _bl42_like_matrix(self, n: int = 100):
+        """Build a sparse matrix whose eigenvalues cluster on the imaginary axis.
+
+        This is the pathological regime where unpinned starting vectors
+        produce different ARPACK convergence paths across processes.
+        """
+        rng = np.random.default_rng(2026)
+        # Skew-symmetric matrices have purely imaginary eigenvalues, so this
+        # is a strong stand-in for the BL42 reflecting-hyperbolic operator.
+        A = rng.standard_normal((n, n))
+        L = 0.5 * (A - A.T)
+        return sp.csr_matrix(L)
+
+    def test_cross_process_deterministic(self):
+        """Two subprocess calls with the same rng_seed return byte-identical stdout."""
+        import subprocess
+        import sys
+
+        script = (
+            "import numpy as np, scipy.sparse as sp\n"
+            "from stencil_gen.non_normality import spectral_abscissa_sparse\n"
+            "rng = np.random.default_rng(2026)\n"
+            "n = 100\n"
+            "A = rng.standard_normal((n, n))\n"
+            "L = sp.csr_matrix(0.5 * (A - A.T))\n"
+            "max_re, _ = spectral_abscissa_sparse(L, k=10, rng_seed=0)\n"
+            "print(repr(max_re))\n"
+        )
+        out1 = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        out2 = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert out1 == out2, f"non-deterministic:\n  run1={out1!r}\n  run2={out2!r}"
+
+    def test_same_seed_same_result_in_process(self):
+        """Two calls with the same rng_seed return bit-identical max_re."""
+        L = self._bl42_like_matrix()
+        max_re_a, _ = spectral_abscissa_sparse(L, k=10, rng_seed=0)
+        max_re_b, _ = spectral_abscissa_sparse(L, k=10, rng_seed=0)
+        assert max_re_a == max_re_b
+
+    def test_rng_seed_override_quality_equivalent(self):
+        """Different seeds may trace different Arnoldi paths but agree in quality.
+
+        Both answers are within ARPACK's own tolerance of the true spectral
+        abscissa (0 for a skew-symmetric operator), so rng_seed is a path
+        selector, not a correctness knob.
+        """
+        L = self._bl42_like_matrix()
+        max_re_0, _ = spectral_abscissa_sparse(L, k=10, rng_seed=0)
+        max_re_1, _ = spectral_abscissa_sparse(L, k=10, rng_seed=1)
+        # Skew-symmetric ⇒ true spectral abscissa is 0.
+        assert abs(max_re_0) < 1e-8
+        assert abs(max_re_1) < 1e-8
+
+    def test_default_seed_is_zero(self):
+        """Omitting rng_seed uses the same path as rng_seed=0."""
+        L = self._bl42_like_matrix()
+        max_re_default, _ = spectral_abscissa_sparse(L, k=10)
+        max_re_explicit, _ = spectral_abscissa_sparse(L, k=10, rng_seed=0)
+        assert max_re_default == max_re_explicit
+
+
+# ---------------------------------------------------------------------------
+# TestNumericalAbscissaDeterminism (46.1b)
+# ---------------------------------------------------------------------------
+
+
+class TestNumericalAbscissaDeterminism:
+    """Tests that numerical_abscissa_sparse is cross-call deterministic via rng_seed.
+
+    Mirrors TestSpectralAbscissaDeterminism but for the eigsh (Hermitian-part)
+    path inside numerical_abscissa_sparse. Only triggers above the n > 900
+    sparse Arnoldi threshold.
+    """
+
+    @staticmethod
+    def _nonsymmetric_matrix(n: int = 1000):
+        """Build an n x n non-symmetric sparse matrix whose Hermitian part has non-trivial spectrum.
+
+        Do not use a skew-symmetric construction here: H = (L + L^T) / 2 = 0
+        causes eigsh(which='LA') to fail to converge, raising RuntimeError
+        before the determinism path is exercised.
+        """
+        rng = np.random.default_rng(2026)
+        A = rng.standard_normal((n, n)) - 5.0 * np.eye(n)
+        return sp.csr_matrix(A)
+
+    def test_numerical_abscissa_sparse_deterministic_across_calls(self):
+        """Two calls at the default seed return byte-identical results; rng_seed=42 differs at the ULP level."""
+        L = self._nonsymmetric_matrix(1000)
+
+        # Default seed (rng_seed=0): byte-identical across consecutive calls.
+        na_a = numerical_abscissa_sparse(L)
+        na_b = numerical_abscissa_sparse(L)
+        assert na_a == na_b, (
+            f"default-seed calls diverged: {na_a!r} vs {na_b!r}; "
+            "rng_seed not threaded through eigsh"
+        )
+
+        # Different seed traces a different Arnoldi path. Difference is at
+        # the ULP level (~1e-14 relative); use != not np.isclose, since
+        # equality would mean the seed isn't reaching ARPACK.
+        na_seed42 = numerical_abscissa_sparse(L, rng_seed=42)
+        assert na_seed42 != na_a, (
+            f"rng_seed=42 produced same result as default ({na_a!r}); "
+            "seed not actually being threaded through ARPACK"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestNormMetrics (41.8c)
+# ---------------------------------------------------------------------------
+
+
+class TestNormMetrics:
+    """Tests for numerical_abscissa_sparse, henrici_departure, eigenvector_condition."""
+
+    def test_diagonal_numerical_abscissa(self):
+        """Diagonal -diag(1..50): numerical abscissa = spectral abscissa = -1."""
+        diag_vals = -np.arange(1, 51, dtype=float)
+        L = sp.diags(diag_vals, format="csr")
+        na = numerical_abscissa_sparse(L)
+        # For a real diagonal (hence symmetric) matrix, numerical abscissa
+        # equals spectral abscissa: max eigenvalue of H = max eigenvalue of L.
+        assert na == pytest.approx(-1.0, abs=1e-10)
+
+    def test_diagonal_henrici_zero(self):
+        """Diagonal matrix is normal: Henrici departure = 0."""
+        diag_vals = -np.arange(1, 51, dtype=float)
+        L = sp.diags(diag_vals, format="csr")
+        h = henrici_departure(L)
+        assert h == pytest.approx(0.0, abs=1e-12)
+
+    def test_diagonal_eigenvector_condition_one(self):
+        """Diagonal matrix has eigenvector condition number ≈ 1."""
+        diag_vals = -np.arange(1, 51, dtype=float)
+        L = sp.diags(diag_vals, format="csr")
+        cond_v = eigenvector_condition(L)
+        # Eigenvectors of a diagonal matrix are the identity columns,
+        # so V = permutation of I, cond(V) = 1.
+        assert cond_v == pytest.approx(1.0, abs=1e-8)
+
+    def test_numerical_abscissa_dense_input(self):
+        """numerical_abscissa_sparse works with dense ndarray input."""
+        A = np.diag([-3.0, -2.0, -1.0])
+        na = numerical_abscissa_sparse(A)
+        assert na == pytest.approx(-1.0, abs=1e-10)
+
+    def test_henrici_dense_input(self):
+        """henrici_departure works with dense ndarray input."""
+        A = np.diag([1.0, 2.0, 3.0])
+        h = henrici_departure(A)
+        assert h == pytest.approx(0.0, abs=1e-12)
+
+    def test_eigenvector_condition_large_returns_nan(self):
+        """eigenvector_condition returns NaN when N exceeds threshold."""
+        L = sp.eye(1000, format="csr")
+        cond_v = eigenvector_condition(L, small_dense_threshold=500)
+        assert np.isnan(cond_v)
+
+    def test_non_normal_matrix_positive_henrici(self):
+        """A non-normal matrix (upper triangular shift) has Henrici > 0."""
+        n = 30
+        # Upper-shift matrix: L[i, i+1] = 1
+        L = sp.diags([np.ones(n - 1)], [1], shape=(n, n), format="csr")
+        h = henrici_departure(L)
+        assert h > 0.0
+
+    def test_non_normal_matrix_large_eigenvector_condition(self):
+        """A non-normal matrix has cond(V) >> 1."""
+        n = 30
+        # Jordan-like: -I + nilpotent shift
+        A = -np.eye(n) + n * np.diag(np.ones(n - 1), 1)
+        cond_v = eigenvector_condition(A)
+        assert cond_v > 10.0
+
+    def test_numerical_abscissa_ge_spectral_abscissa(self):
+        """Numerical abscissa >= spectral abscissa (fundamental inequality)."""
+        rng = np.random.default_rng(99)
+        A = rng.standard_normal((30, 30)) - 3.0 * np.eye(30)
+        na = numerical_abscissa_sparse(A)
+        sa, _ = spectral_abscissa_sparse(A)
+        assert na >= sa - 1e-9
+
+    def test_zero_matrix_henrici(self):
+        """Zero matrix: henrici_departure returns 0 (guard against div-by-zero)."""
+        L = sp.csr_matrix((10, 10))
+        h = henrici_departure(L)
+        assert h == pytest.approx(0.0, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# TestSigmaField (41.8d)
+# ---------------------------------------------------------------------------
+
+
+class TestSigmaField:
+    """Tests for _sigma_field: sigma_min(sI - L) over a complex grid."""
+
+    def test_diagonal_matches_brute_force(self):
+        """On a small diagonal matrix, compare _sigma_field to dense SVD."""
+        diag_vals = np.array([-3.0, -2.0, -1.0, 0.5, 1.5])
+        L = sp.diags(diag_vals, format="csr")
+        n = L.shape[0]
+
+        # Build a small grid
+        re_vals = np.linspace(-1, 3, 5)
+        im_vals = np.linspace(-2, 2, 5)
+        s_grid = re_vals[:, None] + 1j * im_vals[None, :]
+
+        result = _sigma_field(L, s_grid)
+        assert result.shape == s_grid.shape
+
+        # Brute-force reference
+        for i in range(s_grid.shape[0]):
+            for j in range(s_grid.shape[1]):
+                s = s_grid[i, j]
+                M = s * np.eye(n) - np.diag(diag_vals)
+                sv_ref = np.linalg.svd(M, compute_uv=False)[-1]
+                assert result[i, j] == pytest.approx(sv_ref, abs=1e-10)
+
+    def test_dense_input(self):
+        """_sigma_field works with a dense ndarray as L."""
+        A = np.diag([-2.0, -1.0, 0.0])
+        s_grid = np.array([0.0 + 0j, 1.0 + 0j, 0.0 + 1j])
+
+        result = _sigma_field(A, s_grid)
+        assert result.shape == s_grid.shape
+
+        # Check each point via brute-force
+        for idx, s in enumerate(s_grid):
+            M = s * np.eye(3) - A
+            sv_ref = np.linalg.svd(M, compute_uv=False)[-1]
+            assert result[idx] == pytest.approx(sv_ref, abs=1e-10)
+
+    def test_at_eigenvalue_sigma_min_near_zero(self):
+        """sigma_min(sI - L) ≈ 0 when s is an eigenvalue of L."""
+        diag_vals = np.array([-3.0, -1.0, 2.0])
+        L = sp.diags(diag_vals, format="csr")
+
+        # Evaluate exactly at each eigenvalue
+        s_grid = np.array([-3.0 + 0j, -1.0 + 0j, 2.0 + 0j])
+        result = _sigma_field(L, s_grid)
+
+        for val in result:
+            assert val == pytest.approx(0.0, abs=1e-10)
+
+    def test_identity_sigma_min(self):
+        """For L = I, sigma_min(sI - I) = |s - 1| (all singular values equal)."""
+        n = 10
+        L = sp.eye(n, format="csr")
+        s_grid = np.array([0.5 + 0j, 1.0 + 0j, 2.0 + 1j, -1.0 + 0.5j])
+
+        result = _sigma_field(L, s_grid)
+        for idx, s in enumerate(s_grid):
+            expected = abs(s - 1.0)
+            assert result[idx] == pytest.approx(expected, abs=1e-10)
+
+    def test_2d_grid_shape_preserved(self):
+        """Output shape matches a 2D input grid shape."""
+        L = sp.diags([-1.0, -2.0, -3.0], format="csr")
+        s_grid = np.zeros((4, 7), dtype=complex)
+        s_grid.real = np.linspace(-1, 1, 4)[:, None]
+        s_grid.imag = np.linspace(-3, 3, 7)[None, :]
+
+        result = _sigma_field(L, s_grid)
+        assert result.shape == (4, 7)
+
+    def test_dense_large_input(self):
+        """Dense ndarray with n > 900 does not crash (41.8d-followup).
+
+        Previously, _sigma_field would crash with NameError on I_sp/L_sp
+        when given a dense matrix with n > 900, because those variables
+        were only set in the sp.issparse(L) branch.
+        """
+        n = 901
+        # Diagonal matrix: eigenvalues are -1, -2, ..., -901
+        diag_vals = -np.arange(1, n + 1, dtype=float)
+        L_dense = np.diag(diag_vals)
+
+        # Avoid s values that coincide with eigenvalues (sigma_min = 0
+        # is poorly handled by sparse svds).  Use points away from the
+        # spectrum so sigma_min is comfortably positive.
+        s_grid = np.array([0.5 + 0j, 0.0 + 3j, -0.5 + 1j])
+        result = _sigma_field(L_dense, s_grid)
+
+        # Verify against brute-force dense SVD
+        for idx, s in enumerate(s_grid):
+            M = s * np.eye(n) - L_dense
+            sv_ref = np.linalg.svd(M, compute_uv=False)[-1]
+            assert result[idx] == pytest.approx(sv_ref, abs=1e-4)
+
+    def test_sparse_medium_size(self):
+        """Sparse path exercised for N > 200 (if we make L sparse and large)."""
+        n = 250
+        # Stable tridiagonal
+        diag_main = -2.0 * np.ones(n)
+        diag_off = np.ones(n - 1)
+        L = sp.diags([diag_off, diag_main, diag_off], [-1, 0, 1], format="csc")
+
+        # Small grid — just a few points to keep test fast
+        s_grid = np.array([0.0 + 0j, 0.0 + 1j, -1.0 + 0j])
+        result = _sigma_field(L, s_grid)
+
+        # Compare to dense
+        L_dense = L.toarray()
+        for idx, s in enumerate(s_grid):
+            M = s * np.eye(n) - L_dense
+            sv_ref = np.linalg.svd(M, compute_uv=False)[-1]
+            assert result[idx] == pytest.approx(sv_ref, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# TestPseudoAndKreiss (41.8e)
+# ---------------------------------------------------------------------------
+
+
+class TestPseudoAndKreiss:
+    """Tests for pseudospectral_abscissa_estimate and kreiss_constant_estimate.
+
+    Uses the Wilkinson bidiagonal matrix  L = -I + N*upper_shift  at N=30,
+    which is spectrally stable (spectral abscissa = -1) but highly non-normal
+    (numerical abscissa >> 0, Kreiss constant >> 1).
+    """
+
+    @staticmethod
+    def _wilkinson_bidiagonal(n: int = 30):
+        """Build L = -I + n * upper-shift (bidiagonal).
+
+        Returns a dense ndarray because this matrix is so non-normal that
+        Arnoldi (ARPACK) fails to converge to the true eigenvalues.  Dense
+        eigensolver handles it correctly.
+        """
+        return -np.eye(n) + float(n) * np.diag(np.ones(n - 1), 1)
+
+    @staticmethod
+    def _make_rhs_grid(re_max: float = 2.0, n_re: int = 30,
+                       im_max: float = 5.0, n_im: int = 40):
+        """Build a right-half-plane grid for resolvent sampling."""
+        re_vals = np.linspace(1e-3, re_max, n_re)
+        im_vals = np.linspace(-im_max, im_max, n_im)
+        return re_vals[:, None] + 1j * im_vals[None, :]
+
+    def test_wilkinson_spectral_abscissa_minus_one(self):
+        """Wilkinson bidiagonal has spectral abscissa ≈ -1."""
+        L = self._wilkinson_bidiagonal(30)
+        sa, _ = spectral_abscissa_sparse(L)
+        assert sa == pytest.approx(-1.0, abs=1e-8)
+
+    def test_wilkinson_numerical_abscissa_strongly_positive(self):
+        """Wilkinson bidiagonal has strongly positive numerical abscissa."""
+        L = self._wilkinson_bidiagonal(30)
+        na = numerical_abscissa_sparse(L)
+        assert na > 5.0  # much larger than spectral abscissa
+
+    def test_pseudospectral_abscissa_monotone_in_epsilon(self):
+        """alpha_eps is non-decreasing in epsilon (larger perturbation => larger pseudospectrum)."""
+        L = self._wilkinson_bidiagonal(30)
+        s_grid = self._make_rhs_grid()
+        epsilons = [1e-4, 1e-3, 1e-2, 1e-1]
+        result = pseudospectral_abscissa_estimate(L, epsilons, s_grid)
+
+        # Monotonicity: alpha_eps1 <= alpha_eps2 when eps1 < eps2
+        prev = float("-inf")
+        for eps in epsilons:
+            assert result[eps] >= prev - 1e-12
+            prev = result[eps]
+
+    def test_pseudospectral_abscissa_returns_neg_inf_for_tiny_epsilon(self):
+        """For extremely small epsilon, no grid point satisfies => -inf."""
+        L = self._wilkinson_bidiagonal(30)
+        # Grid far from spectrum: sigma_min is large at all points
+        s_grid = np.array([10.0 + 0j, 10.0 + 5j])
+        result = pseudospectral_abscissa_estimate(L, [1e-20], s_grid)
+        assert result[1e-20] == float("-inf")
+
+    def test_pseudospectral_abscissa_at_eigenvalue(self):
+        """alpha_eps includes the eigenvalue vicinity for large enough epsilon."""
+        # Diagonal L: eigenvalues at -1, -2, -3
+        L = sp.diags([-1.0, -2.0, -3.0], format="csr")
+        # Grid includes a point near eigenvalue -1
+        s_grid = np.array([-1.0 + 0j, -0.99 + 0j, -0.5 + 0j, 0.5 + 0j])
+        result = pseudospectral_abscissa_estimate(L, [0.1], s_grid)
+        # sigma_min(sI - L) at s = -0.99 is min(|0.01|, |1.01|, |2.01|) = 0.01 < 0.1
+        assert result[0.1] >= -1.0
+
+    def test_kreiss_constant_wilkinson_large(self):
+        """Wilkinson bidiagonal has Kreiss constant >> 1 (strong transient growth)."""
+        L = self._wilkinson_bidiagonal(30)
+        s_grid = self._make_rhs_grid()
+        K = kreiss_constant_estimate(L, s_grid)
+        assert K > 10.0  # highly non-normal => large Kreiss constant
+
+    def test_kreiss_constant_stable_diagonal(self):
+        """Stable normal matrix has Kreiss constant ≈ 1."""
+        # L = -I: all eigenvalues at -1, normal matrix
+        n = 30
+        L = -sp.eye(n, format="csr")
+        # Grid in right half-plane: Re(s) > 0
+        re_vals = np.linspace(0.01, 2.0, 20)
+        im_vals = np.linspace(-3.0, 3.0, 30)
+        s_grid = re_vals[:, None] + 1j * im_vals[None, :]
+        K = kreiss_constant_estimate(L, s_grid)
+        # For a normal matrix with spectral abscissa -1:
+        # sigma_min(sI - L) = min|s - lambda_i| = |s + 1| >= Re(s) + 1
+        # so Re(s) / sigma_min <= Re(s) / (Re(s) + 1) < 1
+        assert K < 1.0
+
+    def test_kreiss_constant_no_rhs_returns_zero(self):
+        """If no grid points have Re(s) > 0, Kreiss constant is 0."""
+        L = sp.eye(5, format="csr")
+        s_grid = np.array([-1.0 + 0j, -0.5 + 1j])  # all Re(s) <= 0
+        K = kreiss_constant_estimate(L, s_grid)
+        assert K == 0.0
+
+    def test_shared_sigma_field_consistency(self):
+        """Both functions produce results consistent with direct _sigma_field call."""
+        L = self._wilkinson_bidiagonal(30)
+        s_grid = self._make_rhs_grid(re_max=1.5, n_re=15, im_max=3.0, n_im=20)
+
+        sigma = _sigma_field(L, s_grid)
+        flat_sigma = sigma.ravel()
+        flat_re = s_grid.ravel().real
+
+        # Manual pseudospectral abscissa for eps=0.1
+        eps = 0.1
+        mask = flat_sigma <= eps
+        expected_alpha = float(np.max(flat_re[mask])) if np.any(mask) else float("-inf")
+        result = pseudospectral_abscissa_estimate(L, [eps], s_grid)
+        assert result[eps] == pytest.approx(expected_alpha, abs=1e-12)
+
+        # Manual Kreiss constant
+        rhs_mask = flat_re > 0
+        expected_K = float(np.max(flat_re[rhs_mask] / np.maximum(flat_sigma[rhs_mask], 1e-300)))
+        K = kreiss_constant_estimate(L, s_grid)
+        assert K == pytest.approx(expected_K, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# TestComputeNonNormality (41.8f)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeNonNormality:
+    """Tests for compute_non_normality orchestrator."""
+
+    def test_small_diagonal(self):
+        """Diagonal -diag(1..30): normal matrix, all diagnostics consistent."""
+        diag_vals = -np.arange(1, 31, dtype=float)
+        L = sp.diags(diag_vals, format="csr")
+
+        report = compute_non_normality(L)
+        assert isinstance(report, NonNormalityReport)
+        assert report.n == 30
+
+        # Spectral abscissa = max eigenvalue = -1
+        assert report.spectral_abscissa == pytest.approx(-1.0, abs=1e-8)
+
+        # For a normal matrix, numerical abscissa == spectral abscissa
+        assert report.numerical_abscissa == pytest.approx(-1.0, abs=1e-8)
+
+        # Henrici departure ≈ 0 for normal matrix
+        assert report.henrici_departure == pytest.approx(0.0, abs=1e-10)
+
+        # Eigenvector condition ≈ 1 for normal matrix
+        assert report.eigenvector_condition == pytest.approx(1.0, abs=1e-6)
+
+        # Kreiss constant should be < 1 for stable normal matrix
+        assert report.kreiss_constant < 1.0
+
+        # Transient growth bound = e * K
+        import math
+        assert report.transient_growth_bound == pytest.approx(
+            math.e * report.kreiss_constant, rel=1e-12
+        )
+
+        # compute_time recorded
+        assert report.compute_time > 0.0
+
+        # Cross-check: numerical_abscissa >= spectral_abscissa
+        assert report.numerical_abscissa >= report.spectral_abscissa - 1e-9
+
+    def test_non_normal_wilkinson(self):
+        """Wilkinson bidiagonal: non-normal, large Kreiss constant."""
+        n = 30
+        L = -np.eye(n) + float(n) * np.diag(np.ones(n - 1), 1)
+
+        report = compute_non_normality(L)
+
+        # Spectral abscissa ≈ -1 (all eigenvalues at -1)
+        assert report.spectral_abscissa == pytest.approx(-1.0, abs=1e-6)
+
+        # Numerical abscissa strongly positive (non-normal transient growth)
+        assert report.numerical_abscissa > 5.0
+
+        # Henrici departure > 0
+        assert report.henrici_departure > 0.0
+
+        # Kreiss constant >> 1
+        assert report.kreiss_constant > 10.0
+
+        # Transient growth bound >> 1
+        assert report.transient_growth_bound > 10.0
+
+        # Cross-check: numerical_abscissa >= spectral_abscissa
+        assert report.numerical_abscissa >= report.spectral_abscissa - 1e-9
+
+        # Pseudospectral abscissae monotone in epsilon
+        prev = float("-inf")
+        for eps in sorted(report.pseudospectral_abscissae.keys()):
+            assert report.pseudospectral_abscissae[eps] >= prev - 1e-12
+            prev = report.pseudospectral_abscissae[eps]
+
+    def test_custom_s_grid_params(self):
+        """Custom s_grid_params are respected."""
+        L = sp.diags([-2.0, -1.0, -0.5], format="csr")
+        report = compute_non_normality(
+            L,
+            s_grid_params={"re_min": 0.1, "re_max": 3.0, "n_re": 10,
+                           "im_max": 2.0, "n_im": 15},
+            epsilon_values=(1e-2, 1e-1),
+        )
+        assert isinstance(report, NonNormalityReport)
+        assert len(report.pseudospectral_abscissae) == 2
+        assert 1e-2 in report.pseudospectral_abscissae
+        assert 1e-1 in report.pseudospectral_abscissae
+
+    def test_cross_check_numerical_ge_spectral(self):
+        """Numerical abscissa >= spectral abscissa for random matrix."""
+        rng = np.random.default_rng(42)
+        A = rng.standard_normal((40, 40)) - 3.0 * np.eye(40)
+        report = compute_non_normality(A)
+        assert report.numerical_abscissa >= report.spectral_abscissa - 1e-9
+
+    @pytest.mark.slow
+    def test_compute_non_normality_on_bl_sized_matrix(self):
+        """BL-sized 2D test matrix via kron(D, I) + kron(I, D) at n=31.
+
+        Builds a representative 2D advection operator and verifies that
+        compute_non_normality completes within 30 seconds with all fields
+        populated.
+        """
+        from stencil_gen.phs import build_diff_matrix_rbf
+
+        n_1d = 31
+        D = build_diff_matrix_rbf(n_1d, p=2, q=3, epsilon=3.0,
+                                  kernel="tension", nu=1, nextra=0)
+        I_1d = np.eye(n_1d)
+        # 2D operator: D_x (x) I_y + I_x (x) D_y
+        L_2d = np.kron(D, I_1d) + np.kron(I_1d, D)
+
+        # Convert to sparse for the orchestrator
+        L_sp = sp.csr_matrix(L_2d)
+        n_2d = n_1d * n_1d  # 961
+
+        report = compute_non_normality(L_sp, small_dense_threshold=900)
+
+        assert report.n == n_2d
+        assert report.compute_time < 30.0
+
+        # Spectral abscissa should be finite
+        assert np.isfinite(report.spectral_abscissa)
+
+        # Numerical abscissa should be finite
+        assert np.isfinite(report.numerical_abscissa)
+
+        # Henrici departure should be finite and positive (non-normal operator)
+        assert np.isfinite(report.henrici_departure)
+        assert report.henrici_departure > 0.0
+
+        # Eigenvector condition should be NaN (N=961 > threshold=900)
+        assert np.isnan(report.eigenvector_condition)
+
+        # Kreiss constant should be finite
+        assert np.isfinite(report.kreiss_constant)
+
+        # Transient growth bound should be finite
+        assert np.isfinite(report.transient_growth_bound)
+
+        # All pseudospectral abscissae should be finite or -inf
+        for eps, alpha in report.pseudospectral_abscissae.items():
+            assert np.isfinite(alpha) or alpha == float("-inf")
+
+        # Cross-check
+        assert report.numerical_abscissa >= report.spectral_abscissa - 1e-9


### PR DESCRIPTION
_Clean-history stack 04/09 — based on `clean/03-pipeline-cutcell`. Part of a series that reorganizes the solver branch into reviewable, self-contained changes._

## Summary

Part of the SymPy stencil-derivation pipeline work. This change adds the
linear-stability analysis stack used to score and reject candidate boundary
closures before (and during) full solver runs.

The stack has four analyzers and a composing driver:

- **GKS Kreiss test** (`gks_kreiss.py`) -- the rigorous Gustafsson-Kreiss-
  Sundstrom determinant condition for semi-discrete boundary closures. For a
  mode `u_n(t) = e^(st) kappa^n` it solves the characteristic equation for the
  admissible roots `|kappa| < 1`, assembles the `r x r` Kreiss matrix `M(s)`,
  and sweeps `sigma_min(M(s))` over `Re(s) >= 0`. Imaginary-axis perturbation
  classifies tangent modes, and defective (repeated) roots raise
  `DefectiveKappaError`.
- **Group velocity** (`group_velocity.py`) -- modified wavenumber, phase
  velocity, and group velocity (exact and `numpy.gradient`-based) for uniform
  and nonuniform stencils, extended to per-point local group-velocity error
  and anisotropy over a 2D varying-coefficient field. To keep the module graph
  acyclic, its `interior`/`temo` dependencies are function-local imports.
- **Non-normality** (`non_normality.py`) -- pseudospectral diagnostics that
  surface transient growth invisible to the eigenvalues: spectral abscissa,
  numerical abscissa, Henrici departure from normality, eigenvector
  conditioning, pseudospectral abscissa, Kreiss constant, and the resulting
  transient-growth bound.
- **C++ bridge** (`cpp_bridge.py`) -- a subprocess harness that renders a Lua
  config from a marker-based template and runs the compiled `shoccs` binary on
  the Brady-Livescu 4.3 test, returning a `BridgeResult` parsed from
  `logs/system.csv`. Each invocation runs under its own
  `tempfile.TemporaryDirectory`, so concurrent sweep points are race-free, and
  the boundary parameter is passed through Lua so a single binary serves a
  whole sweep.
- **Layered driver** (`brady2d_stability.py`) -- `brady2d_stability_score`
  runs an L1-L8 early-rejection cascade that composes all four analyzers plus
  `phs` over the Brady-Livescu coefficient fields, cheapest layer first.

Benchmark fields for Brady & Livescu 2019 sections 4.3 (2D advection) and 4.2
(reflecting hyperbolic) ship under `benchmarks/`. The `brady2d_calibration`
and `alpha_basin_survey` benchmarks are deferred to the optimization change
along with their consumers.

## Changes

- Add `scripts/stencil_gen/stencil_gen/gks_kreiss.py` -- Kreiss determinant
  condition, kappa-root solver, Kreiss-matrix sigma_min sweep.
- Add `scripts/stencil_gen/stencil_gen/group_velocity.py` -- modified
  wavenumber / group velocity and 2D varying-coefficient and anisotropy
  checks.
- Add `scripts/stencil_gen/stencil_gen/non_normality.py` -- spectral abscissa,
  pseudospectra, Kreiss constant, transient-growth bound.
- Add `scripts/stencil_gen/stencil_gen/cpp_bridge.py` -- subprocess harness
  driving the compiled `shoccs` binary on Brady-Livescu 4.3.
- Add `scripts/stencil_gen/stencil_gen/brady2d_stability.py` -- L1-L8 layered
  stability cascade composing the analyzers plus `phs`.
- Add `scripts/stencil_gen/stencil_gen/benchmarks/brady_livescu_2d.py` and
  `brady_livescu_4_2.py` (and the `benchmarks/__init__.py` package marker).
- Add reference docs: `docs/brady2d_cpp_bridge_reference.md`,
  `scripts/stencil_gen/docs/group_velocity_reference.md`,
  `brady2d_stability_reference.md`, `bl42_reference.md`,
  `pareto_reference.md`.
- Add tests for each module under `scripts/stencil_gen/tests/`.

## Test plan

```
cd scripts/stencil_gen && SYMPY_CACHE_SIZE=50000 uv run pytest \
  tests/test_gks_kreiss.py \
  tests/test_group_velocity.py \
  tests/test_non_normality.py \
  tests/test_cpp_bridge.py \
  tests/test_brady2d_stability.py \
  tests/test_benchmarks.py
```