### PR TITLE
Add Spack-based devcontainer and project tooling

### DIFF
--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -1,0 +1,106 @@
+---
+name: Explore
+description: "Use this agent when you need to explore the codebase, find code definitions, trace call chains, locate implementations, understand how components connect, or answer questions about where things live in the codebase. This agent aggressively uses parallel tool calls and clangd LSP to navigate efficiently.\n\nExamples:\n- user: \"Where is the `handleRequest` function defined and what calls it?\"\n  assistant: \"I'll use the codebase-explorer agent to trace the definition and callers of `handleRequest`.\"\n  <commentary>The user wants to locate a function and understand its call graph. Launch the codebase-explorer agent which will use parallel grep, file reads, and LSP queries to find it fast.</commentary>\n\n- user: \"How does the authentication flow work in this project?\"\n  assistant: \"Let me use the codebase-explorer agent to trace the authentication flow across the codebase.\"\n  <commentary>The user wants to understand a cross-cutting concern. The codebase-explorer agent will use LSP go-to-definition, find-references, and parallel searches to map out the flow.</commentary>\n\n- user: \"Find all implementations of the `Serializable` interface\"\n  assistant: \"I'll launch the codebase-explorer agent to find all implementations.\"\n  <commentary>The user needs to find concrete implementations of an interface. The codebase-explorer agent will combine LSP type hierarchy queries with parallel grep to find them all.</commentary>\n\n- user: \"What files are involved in the database migration system?\"\n  assistant: \"Let me use the codebase-explorer agent to map out the database migration system.\"\n  <commentary>The user wants to understand which files comprise a subsystem. The codebase-explorer agent will search in parallel for migration-related patterns, schemas, and entry points.</commentary>"
+model: sonnet
+memory: project
+---
+
+You are an elite codebase navigator and exploration specialist. You have deep expertise in C/C++ codebases and are a power user of clangd LSP, grep, file reading, and all available tools. Your singular mission is to find things in the codebase as fast and accurately as possible.
+
+## Core Operating Principles
+
+1. **Maximize parallelism**: ALWAYS issue multiple tool calls simultaneously when possible. Never sequentially search for things you could search for in parallel. For example, if you need to find a function definition AND its callers, issue both searches at the same time. If you want to grep for 3 different patterns, do all 3 greps in one batch.
+
+2. **Use every tool available**: You have access to file reading, grep/ripgrep, LSP operations (go-to-definition, find-references, hover, diagnostics), directory listing, and more. Use the RIGHT tool for each sub-task:
+   - **LSP go-to-definition**: When you have a symbol and need its declaration/definition location
+   - **LSP find-references**: When you need all usages of a symbol
+   - **LSP hover**: When you need type information or documentation for a symbol
+   - **Grep/ripgrep**: When you need pattern-based search across many files, or when LSP isn't indexed yet
+   - **File reading**: When you need to examine surrounding context after finding a location
+   - **Directory listing**: When you need to understand project structure or find files by name
+   - **Glob/find**: When you need to locate files matching patterns
+
+3. **Start broad, then narrow**: Begin with multiple parallel searches to cast a wide net, then drill into the most promising results. Don't waste rounds on single sequential queries.
+
+4. **Cross-reference results**: Validate findings by cross-referencing LSP results with grep results. LSP gives semantic accuracy; grep gives exhaustive coverage. Use both.
+
+## Search Strategy
+
+When asked to find something:
+
+1. **First round** (parallel): Launch ALL of these simultaneously as applicable:
+   - Grep for the symbol/pattern name
+   - Grep for related names (variants, prefixes, suffixes)
+   - LSP queries if you have a file:line reference point
+   - Directory listings of likely locations
+   - Glob for likely filenames
+
+2. **Second round** (parallel): Based on first results:
+   - Read the most relevant files found
+   - LSP go-to-definition on symbols discovered
+   - LSP find-references on key symbols
+   - Grep for additional patterns revealed by first round
+
+3. **Synthesize**: Combine all findings into a clear, structured answer.
+
+## Output Format
+
+When reporting findings:
+- Always include **file paths and line numbers**
+- Show relevant code snippets
+- Explain relationships between components when tracing flows
+- If you found multiple candidates, rank them by relevance
+- If something wasn't found, explain what you searched and suggest next steps
+
+## Important Behaviors
+
+- **Never give up after one failed search**. Try alternative spellings, patterns, or tools.
+- **Read surrounding context**. Don't just report a line—read enough of the file to understand the context.
+- **Follow the chain**. If asked about a flow, trace it through multiple hops: caller → function → callee → deeper callee.
+- **Be explicit about uncertainty**. If LSP isn't available or results seem incomplete, say so and compensate with grep.
+- **Prefer precision over verbosity**. Report what was found concisely with exact locations.
+
+**Update your agent memory** as you discover codepaths, key file locations, module boundaries, symbol definitions, include hierarchies, and architectural patterns. This builds up institutional knowledge across conversations. Write concise notes about what you found and where.
+
+Examples of what to record:
+- Key class/struct definitions and their header file locations
+- Important entry points and main control flow paths
+- Module/directory organization and what each area is responsible for
+- Naming conventions and patterns used in the codebase
+- Build system structure and configuration file locations
+- Frequently referenced utility functions and where they live
+
+# Persistent Agent Memory
+
+You have a persistent Persistent Agent Memory directory at `/workspace/.claude/agent-memory/codebase-explorer/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your Persistent Agent Memory for relevant notes — and if nothing is written yet, record what you learned.
+
+Guidelines:
+- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
+- Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+- Organize memory semantically by topic, not chronologically
+- Use the Write and Edit tools to update your memory files
+
+What to save:
+- Stable patterns and conventions confirmed across multiple interactions
+- Key architectural decisions, important file paths, and project structure
+- User preferences for workflow, tools, and communication style
+- Solutions to recurring problems and debugging insights
+
+What NOT to save:
+- Session-specific context (current task details, in-progress work, temporary state)
+- Information that might be incomplete — verify against project docs before writing
+- Anything that duplicates or contradicts existing CLAUDE.md instructions
+- Speculative or unverified conclusions from reading a single file
+
+Explicit user requests:
+- When the user asks you to remember something across sessions (e.g., "always use bun", "never auto-commit"), save it — no need to wait for multiple interactions
+- When the user asks to forget or stop remembering something, find and remove the relevant entries from your memory files
+- When the user corrects you on something you stated from memory, you MUST update or remove the incorrect entry. A correction means the stored memory is wrong — fix it at the source before continuing, so the same mistake does not repeat in future conversations.
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you notice a pattern worth preserving across sessions, save it here. Anything in MEMORY.md will be included in your system prompt next time.

--- a/.claude/skills/group-velocity-analysis/SKILL.md
+++ b/.claude/skills/group-velocity-analysis/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: group-velocity-analysis
+description: Guide to group velocity analysis for finite difference stencils. Use when discussing wave propagation, dispersion, modified wavenumber, parasitic modes, GKS stability, cut-cell group velocity, or 2D anisotropy.
+---
+
+# Group Velocity Analysis
+
+Group velocity `C(ξ) = dω/dξ` governs how wave packets propagate through finite difference discretizations. Unlike phase velocity, group velocity determines energy transport and controls boundary stability (GKS theory).
+
+## Quick Reference
+
+| Function | Purpose |
+|----------|---------|
+| `interior_group_velocity(p, nu, xi)` | GV profile for E2-E8 interior stencils |
+| `boundary_group_velocity(p, q, nextra, nu, sigma, kernel, xi)` | GV for RBF/tension boundary rows |
+| `boundary_group_velocity_classical(boundary_rows, alpha_values, order, xi)` | GV for symbolic boundary stencils |
+| `cut_cell_group_velocity(result, psi_sym, psi_val, alpha, xi)` | GV for TEMO cut-cell stencils |
+| `psi_sweep_group_velocity(scheme, psi_values, alpha, xi)` | Sweep GV across ψ ∈ [0,1] |
+| `group_velocity_2d(kappa_x_star, kappa_y_star, xi, eta, a, b)` | 2D GV vector from pre-computed modified wavenumber arrays |
+| `anisotropy_profile(p, nu, theta, xi_mag)` | Grid anisotropy vs propagation angle |
+| `gks_group_velocity_check(D, xi, side=)` | GKS eigenmode boundary stability diagnostic (heuristic) |
+| `kreiss_stability_check(interior, offsets, brows)` | Rigorous GKS Kreiss determinant test (Trefethen 1983) |
+| `local_group_velocity(weights_func, x, xi)` | Local GV for varying coefficients (1D) |
+| `local_group_velocity_2d_varying(stencil_x, stencil_y, c_x, c_y, xi)` | Per-point local GV error on a 2D varying-coefficient grid |
+| `anisotropy_over_coefficient_field(scheme, c_x, c_y, grid, theta, xi_mag)` | 2D anisotropy projected onto a varying flow field |
+| `ray_trace_group_velocity(C_field, x, xi, ...)` | Ray tracing dx/dt = C, dξ/dt = -∂C/∂x |
+| `brady2d_stability_score(scheme, kernel, params, max_layer=)` | Layered stability scoring for Brady-Livescu 2D benchmark |
+| `build_bl42_operator(D)` | 2×2 block operator for BL §4.2 reflecting hyperbolic system |
+| `layer_bl42_reflecting_hyperbolic(scheme, kernel, params, n_values=)` | L3r eigenvalue analysis on BL §4.2 (purely imaginary continuous spectrum) |
+| `make_multi_objective(scheme, kernel, fields, *, gate_layer=None, max_layer=None)` | Vector-valued objective factory for NSGA-II (plan 45); finite sentinel `1e12` on infeasibility |
+| `run_nsga2(scheme, kernel, fields, bounds, *, pop_size, n_gen, seed)` | Multi-objective Pareto driver via pymoo NSGA-II; returns `ParetoResult` with HV trace |
+
+## Key Facts
+
+- **Sign convention:** `C(ξ) = d(Im(κ*))/dξ` where `κ*(ξ)` is the modified wavenumber
+- **Error amplification:** Group velocity error is `(2p+1)×` the phase velocity error for a 2p-order scheme
+- **Cutoff wavenumber:** Where `C(ξ) = 0` — above this, energy propagates backwards (parasitic)
+- **GKS connection:** Boundary instability ⟺ outgoing modes (`C > 0`) spontaneously generated at boundary
+- **Scaling advantage:** GV analysis is O(1) per stencil; eigenvalue analysis is O(N³) per grid
+
+## When to Use
+
+- Analyzing dispersion behavior of new stencil schemes
+- Diagnosing boundary instabilities via GKS group velocity check (heuristic) or rigorous Kreiss determinant test
+- Evaluating cut-cell stencils across the ψ range
+- Checking 2D grid anisotropy for tensor-product operators
+- Comparing GV analysis cost vs eigenvalue analysis for large problems
+- Scoring boundary closures against the Brady-Livescu 2D varying-coefficient benchmark (L1-L7 layered pipeline)
+- Layer 8 closed-loop validation: re-running top survivors through the compiled C++ solver (`run_cpp_brady2d` / `sweeps brady2d --validate-with-cpp`) to confirm analytical L1-L7 verdicts empirically
+- Non-normality diagnostics: spectral/numerical abscissa, Kreiss constant, transient growth bound
+- Optimizing boundary-closure parameters against any `StabilityReport` field using `stencil_gen.optimizer` (Nelder-Mead, COBYQA, SHGO, DE, staged cascade, multi-start); the scoring pipeline is the objective function
+- Testing boundary closures against the BL §4.2 neutrally-stable hyperbolic system — the strictest `div(c) = 0` discriminator, purely imaginary continuous spectrum, energy-conserving reflecting BCs (available as `layer_bl42.*` fields in `StabilityReport`)
+- Multi-objective Pareto exploration when stability metrics conflict (e.g., tension closures have low `layer1.boundary_gv_err` but high `layer_bl42.max_spectral_abscissa`; classical closures have the opposite trade-off) — use `python -m sweeps pareto` for an NSGA-II driver that exposes the full front (plan 45). The single-objective optimizer collapses these onto a scalar; Pareto exposes the trade-off explicitly.
+
+## Detailed Reference
+
+For complete API documentation, usage examples, and mathematical derivations, see:
+- `scripts/stencil_gen/docs/group_velocity_reference.md`
+- `scripts/stencil_gen/docs/brady2d_stability_reference.md` (layered stability pipeline for the Brady-Livescu 2D benchmark)
+- `docs/brady2d_cpp_bridge_reference.md` (L8 C++ bridge architecture: Lua template, subprocess runner, runtime-parameterized spline families)
+- `scripts/stencil_gen/docs/optimization_reference.md` (plan-43 optimizer: objective factory, local/global/staged drivers, multi-start, classical-α basin survey)
+- `scripts/stencil_gen/docs/bl42_reference.md` (plan-44 BL §4.2 reflecting-hyperbolic layer: problem statement, 2×2 block operator construction, calibration results)
+- `scripts/stencil_gen/docs/pareto_reference.md` (plan-45 NSGA-II multi-objective Pareto driver: `make_multi_objective`, `run_nsga2`, hypervolume tracking, per-run JSON persistence under `sweeps/pareto_fronts/`)

--- a/.claude/skills/stencil-sweeps/SKILL.md
+++ b/.claude/skills/stencil-sweeps/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: stencil-sweeps
+description: Guide to parameter sweep scripts for stencil stability analysis. Use when running epsilon sweeps, tension sweeps, footprint analysis, alpha extraction, or exploring optimal parameters for PHS/RBF stencils.
+---
+
+# Parameter Sweeps
+
+The `sweeps/` package provides standalone scripts for parameter space exploration, separated from the test suite. Sweeps discover optimal parameters; regression tests verify them.
+
+## CLI Quick Reference
+
+```bash
+cd scripts/stencil_gen
+
+# Epsilon (Gaussian/MQ kernel parameter) sweep
+uv run python -m sweeps epsilon --scheme E2 --kernel gaussian --n-eps 60
+
+# Tension (sigma parameter) sweep
+uv run python -m sweeps tension --scheme E4 --n-sigma 61
+
+# 2D tension + conservation penalty sweep
+uv run python -m sweeps tension-penalty --scheme E4 --n-sigma 25 --n-gamma 25
+
+# Mixed (per-row) epsilon sweep
+uv run python -m sweeps mixed-epsilon --scheme E4
+
+# Boundary footprint (nextra) sweep
+uv run python -m sweeps footprint --n-sigma 50
+
+# Multi-method comparison table
+uv run python -m sweeps comparison --scheme E2
+
+# Alpha extraction from RBF weights
+uv run python -m sweeps alpha --scheme E2
+
+# Group velocity vs stability Pareto front (research / docs only)
+uv run python -m sweeps gv-stability-pareto --scheme E2 --param tension --n-points 61
+
+# Brady-Livescu 2D stability scoring (layered analytical pipeline)
+uv run python -m stencil_gen.brady2d_cli --scheme E4 --kernel tension --sigma 3.0 --max-layer 6
+
+# Brady-Livescu 2D sweep (L1-L7 analytical; kernel in {classical, tension, gaussian, multiquadric})
+uv run python -m sweeps brady2d --scheme E4 --kernel tension --param-range 2 4 3 --max-layer 3
+
+# Same, but re-run top-3 survivors against the compiled C++ solver (L8 end-to-end validation)
+uv run python -m sweeps brady2d --scheme E4 --kernel tension --param-range 2 4 11 --max-layer 3 --validate-with-cpp
+
+# Optimize boundary-closure parameters (Nelder-Mead, COBYQA, SHGO, DE, or staged cascade)
+uv run python -m sweeps optimize --scheme E4 --kernel tension --objective layer1.boundary_gv_err --bounds 0.5 20 --method staged --n-restarts 10
+
+# Optimize against the BL §4.2 neutrally-stable hyperbolic eigenvalue (L3r; strictest discriminator)
+uv run python -m sweeps optimize --scheme E4 --kernel tension --objective layer_bl42.max_spectral_abscissa --bounds 0.5 20 --method Nelder-Mead --max-evals 40
+
+# NSGA-II multi-objective Pareto front over 2-3 stability metrics (plan 45); persists to sweeps/pareto_fronts/
+uv run python -m sweeps pareto --scheme E4 --kernel classical --objectives layer1.boundary_gv_err layer_bl42.max_spectral_abscissa --bounds -2 2 0.05 2 --pop-size 40 --n-gen 30 --seed 1 --persist
+
+# Multi-fidelity Bayesian optimization over the cascade (plan 47, BoTorch qMFKG); persists to sweeps/bo_runs/
+uv run python -m sweeps bo --scheme E4 --kernel classical --objective layer7.max_spectral_abscissa --cheap-fidelities 1 3 5 6 --bounds -2 2 0.05 2 --budget-evals 60 --seed 1 --persist
+
+# Run all sweeps (quick mode for smoke testing)
+uv run python -m sweeps all --quick
+
+# Update known_values.json with discovered optima
+uv run python -m sweeps epsilon --scheme E2 --update-known-values
+```
+
+## Group Velocity Objectives
+
+- `--include-gv` (tension/epsilon/tension-penalty/footprint): adds a `gv_err` column and a "Best feasible by GV error" line; persists additive `*.gv_error` and parallel `*_gv` keys to `known_values.json` when paired with `--update-known-values`. Stability stays the only hard feasibility gate; GV is a soft secondary objective minimized over the feasible set.
+- `--check-gks` (tension/epsilon): advisory only — runs `gks_group_velocity_check` at the stability optimum and prints `WARNING: outgoing boundary mode at xi=…` lines if any are detected. Necessary-not-sufficient for instability; never alters the optimum.
+
+## Workflow
+
+1. **Run sweep** → discovers optimal parameters, prints tables
+2. **Update JSON** → `--update-known-values` writes to `sweeps/known_values.json`
+3. **Regression tests** → `TestRegression*` classes in `test_phs.py` verify against JSON
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `sweeps/known_values.json` | Single source of truth for optimal parameters |
+| `sweeps/_common.py` | `STABILITY_TOL`, `SCHEME_PARAMS`, shared helpers |
+| `sweeps/gv_objectives.py` | Group-velocity scalar wrappers + GKS advisory printer |
+| `sweeps/epsilon_sweep.py` | Gaussian/MQ epsilon sweeps |
+| `sweeps/mixed_epsilon_sweep.py` | Per-row epsilon optimization |
+| `sweeps/tension_sweep.py` | Tension sigma sweeps |
+| `sweeps/tension_penalty_sweep.py` | 2D (sigma, gamma) joint sweeps |
+| `sweeps/footprint_sweep.py` | Boundary footprint (nextra) sweeps |
+| `sweeps/gv_stability_pareto.py` | 1D parametric scan with dominance filter — read-only research/docs |
+| `sweeps/pareto.py` | NSGA-II multi-objective Pareto driver (plan 45); produces full fronts |
+| `sweeps/_pareto_io.py` | JSON serialization for `ParetoResult` → `sweeps/pareto_fronts/<scheme>_<kernel>_<mangled>.json` |
+| `sweeps/comparison.py` | Multi-method comparison tables |
+| `sweeps/alpha_extraction.py` | Extract stencil alphas from RBF weights |
+| `sweeps/brady2d_sweep.py` | Brady-Livescu §4.3 2D sweep; `--validate-with-cpp` re-runs top-3 survivors through the compiled C++ solver (L8) |
+| `sweeps/bo.py` | Multi-fidelity Bayesian optimization driver (plan 47); BoTorch qMFKG over the cascade with cost-aware acquisition and ICM kernel |
+| `sweeps/_bo_io.py` | JSON serialization for `BOResult` → `sweeps/bo_runs/<scheme>_<kernel>_<mangled>_<seed>.json` |
+
+## When to Use
+
+- After changing stencil derivation code, verify optimal parameters still hold
+- Exploring a new kernel type or scheme order
+- Producing comparison tables for documentation/papers
+- Diagnosing why a scheme is unstable at certain parameters
+- Optimizing boundary-closure parameters against a `StabilityReport` field (single-objective + feasibility cliff; staged cheap-inner + expensive-validator pipeline); persists to `known_values.json["brady2d_optima"]`. See `scripts/stencil_gen/docs/optimization_reference.md`.
+- Multi-objective Pareto exploration when two metrics genuinely conflict (e.g., `layer1.boundary_gv_err` vs `layer_bl42.max_spectral_abscissa`); use `sweeps pareto` (NSGA-II via pymoo). See `scripts/stencil_gen/docs/pareto_reference.md`.
+- Multi-fidelity Bayesian optimization when expensive-validator wall-time dominates and you want a principled cost-aware HF/cheap split (instead of `optimize --method staged`'s hand-coded top-K threshold); use `sweeps bo` (BoTorch qMFKG with discrete-fidelity ICM kernel). See `scripts/stencil_gen/docs/mfbo_reference.md`.
+
+## Detailed Reference
+
+For complete CLI documentation, JSON schema, and adding new sweeps, see:
+- `scripts/stencil_gen/docs/sweeps_reference.md`
+- `scripts/stencil_gen/docs/pareto_reference.md` (plan 45 NSGA-II multi-objective driver)
+- `scripts/stencil_gen/docs/mfbo_reference.md` (plan 47 multi-fidelity Bayesian optimization driver)

--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__/
+build/
+.git/
+*.o
+*.a
+*.so

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,235 @@
+# syntax=docker/dockerfile:1.4
+# ^^^ Required for BuildKit cache mounts
+
+# =============================================================================
+# STAGE 1: Base system with compilers and build tools
+# =============================================================================
+
+FROM python:3.11-slim AS base-system
+
+ARG TZ
+ARG CLANG_VERSION=19
+ENV TZ="$TZ"
+
+# Install ca-certificates, wget, and gnupg2 FIRST
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    wget \
+    gnupg2 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy corporate CA bundle (empty file is fine for non-corporate environments)
+COPY .devcontainer/corporate-ca.pem /usr/local/share/ca-certificates/corporate-ca.crt
+RUN update-ca-certificates
+
+# SSL environment variables
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    UV_NATIVE_TLS=true
+
+# Add the LLVM apt repository for the requested clang version.
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
+    gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${CLANG_VERSION} main" \
+    > /etc/apt/sources.list.d/llvm.list
+
+# Install compilers and build tools
+# GCC provides gfortran and serves as the spack bootstrap compiler.
+# Clang provides clangd and clang-format for IDE support.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    gcc \
+    g++ \
+    gfortran \
+    clang-${CLANG_VERSION} \
+    clangd-${CLANG_VERSION} \
+    clang-format-${CLANG_VERSION} \
+    lld-${CLANG_VERSION} \
+    libc++-${CLANG_VERSION}-dev \
+    libc++abi-${CLANG_VERSION}-dev \
+    make \
+    cmake \
+    ninja-build \
+    bzip2 \
+    patch \
+    xz-utils \
+    unzip \
+    locales \
+    file \
+    swig \
+    && ln -sf /usr/bin/clang-${CLANG_VERSION} /usr/local/bin/clang \
+    && ln -sf /usr/bin/clang++-${CLANG_VERSION} /usr/local/bin/clang++ \
+    && ln -sf /usr/bin/clangd-${CLANG_VERSION} /usr/local/bin/clangd \
+    && ln -sf /usr/bin/clang-format-${CLANG_VERSION} /usr/local/bin/clang-format \
+    && ln -sf /usr/bin/lld-${CLANG_VERSION} /usr/local/bin/lld \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+    && locale-gen
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+# Create 'user' user early (needed for spack stage)
+ARG USERNAME=user
+RUN useradd -m -u 1000 -s /bin/zsh $USERNAME || true
+
+
+# =============================================================================
+# STAGE 2: Spack dependency builder
+# =============================================================================
+# This stage only rebuilds when:
+#   - base-system changes (compilers, etc.)
+#   - spack.yaml changes (dependency specifications)
+#   - Spack version changes
+#
+# All SHOCCS dependencies are in the standard spack builtin repo.
+# No custom spack_repo is needed.
+
+FROM base-system AS spack-builder
+
+ARG USERNAME=user
+ARG SPACK_MIRROR_URL=""
+USER $USERNAME
+WORKDIR /home/$USERNAME
+
+# Clone and configure Spack (use develop branch for Kokkos 5.0+ recipes)
+RUN git clone --depth=1 -b develop https://github.com/spack/spack.git /home/$USERNAME/spack
+
+# Copy the spack environment file
+COPY --chown=$USERNAME:$USERNAME .devcontainer/spack.yaml /home/$USERNAME/shoccs-env/spack.yaml
+
+# Configure Spack: find system compilers
+RUN /home/$USERNAME/spack/bin/spack compiler find
+
+# Concretize and build all dependencies
+# Cache mounts persist across builds for faster rebuilds:
+#   - var/spack/cache: downloaded source tarballs
+#   - .spack/cache: misc caches including fetch cache
+#   - .spack/bootstrap: spack's own bootstrapped tools (clingo, etc.)
+#   - /tmp/user/spack-stage: build staging area
+SHELL ["/bin/bash", "-c"]
+RUN --mount=type=cache,target=/home/user/spack/var/spack/cache,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/user/.spack/cache,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/user/.spack/bootstrap,uid=1000,gid=1000 \
+    --mount=type=cache,target=/tmp/user/spack-stage,uid=1000,gid=1000 \
+    source /home/$USERNAME/spack/share/spack/setup-env.sh && \
+    spack config add config:connect_timeout:60 && \
+    spack config add config:read_timeout:300 && \
+    spack config add config:retry:3 && \
+    if [ -n "$SPACK_MIRROR_URL" ]; then spack mirror add custom-mirror "$SPACK_MIRROR_URL"; fi && \
+    spack env create shoccs-dev /home/$USERNAME/shoccs-env/spack.yaml && \
+    spack env activate shoccs-dev && \
+    spack concretize && \
+    spack install -j $(nproc)
+
+
+# =============================================================================
+# STAGE 3: Final devcontainer image
+# =============================================================================
+
+FROM base-system AS final
+
+ARG TZ
+ARG USERNAME=user
+ARG CLAUDE_CODE_VERSION=latest
+ARG GIT_DELTA_VERSION=0.18.2
+
+# Install developer convenience tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    less \
+    procps \
+    sudo \
+    fzf \
+    zsh \
+    man-db \
+    gh \
+    iptables \
+    ipset \
+    iproute2 \
+    dnsutils \
+    aggregate \
+    jq \
+    neovim \
+    openssh-client \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv for Python package management
+RUN pip install --no-cache-dir uv
+
+# Configure user with sudo access
+RUN usermod -aG sudo $USERNAME
+
+# Persist bash history
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && mkdir /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R $USERNAME /commandhistory
+
+# Create workspace and config directories
+RUN mkdir -p /workspace /home/$USERNAME/.claude \
+    && chown -R $USERNAME:$USERNAME /workspace /home/$USERNAME/.claude
+
+# Install git-delta
+RUN ARCH=$(dpkg --print-architecture) && \
+    wget "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+    dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+    rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
+
+# =============================================================================
+# Copy artifacts from spack-builder
+# =============================================================================
+
+COPY --from=spack-builder --chown=$USERNAME:$USERNAME /home/$USERNAME/spack /home/$USERNAME/spack
+COPY --from=spack-builder --chown=$USERNAME:$USERNAME /home/$USERNAME/shoccs-env /home/$USERNAME/shoccs-env
+COPY --from=spack-builder --chown=$USERNAME:$USERNAME /home/$USERNAME/.spack /home/$USERNAME/.spack
+
+# =============================================================================
+# User configuration
+# =============================================================================
+
+USER $USERNAME
+
+# Install Claude Code CLI via native installer
+RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
+
+# Environment variables
+ENV DEVCONTAINER=true \
+    ENABLE_LSP_TOOLS=1 \
+    PATH=$PATH:/home/$USERNAME/.local/bin \
+    SHELL=/bin/zsh \
+    EDITOR=nvim \
+    VISUAL=nvim \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    UV_NATIVE_TLS=true
+
+# Install Oh My Zsh
+RUN git clone --depth=1 https://github.com/ohmyzsh/ohmyzsh.git /home/$USERNAME/.oh-my-zsh
+
+# Create .zshrc with all configurations
+RUN echo 'export ZSH="/home/user/.oh-my-zsh"' > /home/$USERNAME/.zshrc && \
+    echo 'ZSH_THEME="robbyrussell"' >> /home/$USERNAME/.zshrc && \
+    echo 'plugins=(git)' >> /home/$USERNAME/.zshrc && \
+    echo 'source $ZSH/oh-my-zsh.sh' >> /home/$USERNAME/.zshrc && \
+    echo '' >> /home/$USERNAME/.zshrc && \
+    echo '# Terminal and locale configuration' >> /home/$USERNAME/.zshrc && \
+    echo '[ -z "$TERM" ] && export TERM=xterm' >> /home/$USERNAME/.zshrc && \
+    echo 'export LANG="en_US.UTF-8"' >> /home/$USERNAME/.zshrc && \
+    echo 'export LANGUAGE="en_US:en"' >> /home/$USERNAME/.zshrc && \
+    echo 'export LC_ALL="en_US.UTF-8"' >> /home/$USERNAME/.zshrc && \
+    echo '' >> /home/$USERNAME/.zshrc && \
+    echo '# Command history persistence' >> /home/$USERNAME/.zshrc && \
+    echo 'export HISTFILE=/commandhistory/.bash_history' >> /home/$USERNAME/.zshrc && \
+    echo '' >> /home/$USERNAME/.zshrc && \
+    echo '# Spack initialization' >> /home/$USERNAME/.zshrc && \
+    echo 'source /home/user/spack/share/spack/setup-env.sh' >> /home/$USERNAME/.zshrc && \
+    echo 'spack env activate shoccs-dev' >> /home/$USERNAME/.zshrc
+
+WORKDIR /workspace
+CMD ["/bin/zsh"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+  "name": "SHOCCS Dev",
+  "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile",
+    "args": {
+      "TZ": "${localEnv:TZ:America/Denver}",
+      "CLANG_VERSION": "19"
+    }
+  },
+
+  "containerUser": "user",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+
+  "mounts": [
+    "source=shoccs-bashhistory,target=/commandhistory,type=volume"
+  ],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "cmake.configureOnOpen": true,
+        "cmake.generator": "Ninja",
+        "cmake.buildDirectory": "${workspaceFolder}/build",
+        "clangd.path": "/usr/local/bin/clangd",
+        "editor.formatOnSave": true
+      },
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "twxs.cmake"
+      ]
+    }
+  },
+
+  "initializeCommand": "",
+  "onCreateCommand": "",
+  "postCreateCommand": "cmake -S /workspace -B /workspace/build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON",
+
+  "remoteEnv": {
+    "DEVCONTAINER": "true"
+  }
+}

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Based on official Claude Code devcontainer firewall script
+# Adapted for VLM Processor with OpenAI API access
+# Source: https://github.com/anthropics/claude-code/tree/main/.devcontainer
+
+set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
+IFS=$'\n\t'       # Stricter word splitting
+
+# 1. Extract Docker DNS info BEFORE any flushing
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
+# Flush existing rules and delete existing ipsets
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# 2. Selectively restore ONLY internal Docker DNS resolution
+if [ -n "$DOCKER_DNS_RULES" ]; then
+    echo "Restoring Docker DNS rules..."
+    iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+    iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+    echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+else
+    echo "No Docker DNS rules to restore"
+fi
+
+# First allow DNS and localhost before any restrictions
+# Allow outbound DNS
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+# Allow inbound DNS responses
+iptables -A INPUT -p udp --sport 53 -j ACCEPT
+# Allow outbound SSH
+iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+# Allow inbound SSH responses
+iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+# Allow Claude Code OAuth callback (port 1455 from Docker host)
+iptables -A INPUT -p tcp --dport 1455 -j ACCEPT
+iptables -A OUTPUT -p tcp --sport 1455 -j ACCEPT
+# Allow localhost
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# Create ipset with CIDR support
+ipset create allowed-domains hash:net
+
+# Fetch GitHub meta information and aggregate + add their IP ranges
+echo "Fetching GitHub IP ranges..."
+gh_ranges=$(curl -s https://api.github.com/meta)
+if [ -z "$gh_ranges" ]; then
+    echo "ERROR: Failed to fetch GitHub IP ranges"
+    exit 1
+fi
+
+if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
+    echo "ERROR: GitHub API response missing required fields"
+    exit 1
+fi
+
+echo "Processing GitHub IPs..."
+while read -r cidr; do
+    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+        echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
+        exit 1
+    fi
+    echo "Adding GitHub range $cidr"
+    ipset add allowed-domains "$cidr" -exist
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+
+# Resolve and add allowed domains
+# OpenAI API domains added for VLM processing
+# GitHub domains explicitly added to ensure meta API IPs are covered
+for domain in \
+    "github.com" \
+    "api.github.com" \
+    "registry.npmjs.org" \
+    "api.anthropic.com" \
+    "api.openai.com" \
+    "openai.com" \
+    "sentry.io" \
+    "statsig.anthropic.com" \
+    "statsig.com" \
+    "marketplace.visualstudio.com" \
+    "vscode.blob.core.windows.net" \
+    "update.code.visualstudio.com" \
+    "pypi.org" \
+    "files.pythonhosted.org"; do
+    echo "Resolving $domain..."
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
+    if [ -z "$ips" ]; then
+        echo "WARNING: Failed to resolve $domain (continuing anyway)"
+        continue
+    fi
+
+    while read -r ip; do
+        if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            echo "ERROR: Invalid IP from DNS for $domain: $ip"
+            exit 1
+        fi
+        echo "Adding $ip for $domain"
+        ipset add allowed-domains "$ip" -exist
+    done < <(echo "$ips")
+done
+
+# Get host IP from default route
+HOST_IP=$(ip route | grep default | cut -d" " -f3)
+if [ -z "$HOST_IP" ]; then
+    echo "ERROR: Failed to detect host IP"
+    exit 1
+fi
+
+HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+echo "Host network detected as: $HOST_NETWORK"
+
+# Set up remaining iptables rules
+iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
+iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
+
+# Set default policies to DROP first
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# First allow established connections for already approved traffic
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Then allow only specific outbound traffic to allowed domains
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Explicitly REJECT all other outbound traffic for immediate feedback
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+echo "Firewall configuration complete"
+echo "Verifying firewall rules..."
+if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+    exit 1
+else
+    echo "Firewall verification passed - unable to reach https://example.com as expected"
+fi
+
+# Verify GitHub API access
+if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
+    exit 1
+else
+    echo "Firewall verification passed - able to reach https://api.github.com as expected"
+fi
+
+# Verify OpenAI API access (important for VLM processing)
+if ! curl --connect-timeout 5 https://api.openai.com >/dev/null 2>&1; then
+    echo "WARNING: Unable to reach https://api.openai.com (may not be critical)"
+else
+    echo "Firewall verification passed - able to reach https://api.openai.com as expected"
+fi

--- a/.devcontainer/spack.yaml
+++ b/.devcontainer/spack.yaml
@@ -1,0 +1,41 @@
+# Spack environment for SHOCCS development container
+#
+# All dependencies are from the standard spack builtin repository.
+# No custom spack repo is needed.
+#
+# Usage:
+#   spack env create shoccs-dev spack.yaml
+#   spack env activate shoccs-dev
+#   spack concretize
+#   spack install
+spack:
+  specs:
+    # Current dependencies (from CMakeLists.txt)
+    - lua
+    - lua-sol2
+    - "fmt@8:"
+    - "pugixml@1.10:"
+    - "spdlog@1.9:"
+    - cxxopts
+    - "catch2@3:"
+    - boost
+    - lapackpp
+    # Kokkos (parallel execution framework)
+    - "kokkos@5.0: cxxstd=20 +serial +openmp"
+    # Kokkos profiling tools (runtime profiling via KOKKOS_TOOLS_LIBS)
+    - kokkos-tools
+    # Microbenchmark framework (Google Benchmark)
+    - benchmark
+    - "cmake@3.24:"
+    - ninja
+
+  view: true
+
+  concretizer:
+    unify: true
+
+  packages:
+    all:
+      require: '%gcc'
+      prefer:
+        - cxxstd=20

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.claude/settings.local.json
+build
+.cache
+CMakeFiles
+logs/
+papers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+SHOCCS (Stable High-Order Cut-Cell Solver) is a C++ Cartesian cut-cell solver for time-dependent PDEs (heat equation, scalar wave, Euler equations). It uses high-order finite difference operators on structured grids with embedded boundaries. The codebase uses Kokkos for parallel execution.
+
+## Documentation map
+
+- `docs/ONBOARDING.md` — start here if you are new to the codebase.
+- `docs/CAPABILITY_AUDIT.md` — per-subsystem maturity status (what actually works vs. scaffolding).
+- `docs/reference/` — per-subsystem reference docs.
+- `docs/CLEANUP_PLAN.md` — known issues and remediation plan (see §0/§0a for the Kokkos 5.1 build fix and the one remaining test failure).
+- `docs/handoff/MASTER.md` — Python framework (stencil derivation / sweeps) handoff.
+
+## Build Commands
+
+> ✅ **Build status (2026-06-04):** Green. A Kokkos 5.0→5.1.1 `create_graph` API break was fixed by migrating the call sites to `create_graph<execution_space>(...)`; `ctest` passes 47/48, with one remaining failure (`t-laplacian`); `t-csr` and `t-E2_1` are fixed. Tracked in `docs/CLEANUP_PLAN.md` §0a.
+> Also: if `build.ninja` errors with a missing cmake path (stale tree), re-run `cmake -S . -B build -G Ninja ...` (see "Reconfigure from scratch" below) to regenerate it.
+
+```bash
+# Build (from repo root; build/ is pre-configured with Ninja)
+cmake --build build
+
+# Build a single target
+cmake --build build --target t-heat
+
+# Run all tests
+ctest --test-dir build
+
+# Run tests by label (fields, matrices, operators, stencils, mesh, systems, temporal, simulation)
+ctest --test-dir build -L fields
+
+# Run a single test by name
+ctest --test-dir build -R t-dense
+
+# Reconfigure from scratch
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON -DBUILD_BENCHMARKS=ON
+```
+
+## Benchmarks
+
+```bash
+# Run all benchmarks and compare against stored baseline
+./scripts/bench_compare.sh
+
+# Save a new baseline
+./scripts/bench_compare.sh --save
+```
+
+Benchmark executables are in `build/benchmarks/` (bench_stencil, bench_block, bench_derivative, bench_expr, bench_selection, bench_rhs).
+
+## Code Conventions
+
+- **C++20** with concepts, `std::ranges`, and `std::span`. No C++23 features; missing C++23 utilities (stride, zip_transform, cartesian_product, bind_back) have project-local implementations in `src/fields/lazy_views.hpp`.
+- **Namespace:** Everything lives under `ccs`. Core type aliases in `src/shoccs_config.hpp`: `real = double`, `integer = long`, `int3 = std::array<int,3>`, `real3 = std::array<real,3>`.
+- **Kokkos types** in `src/kokkos_types.hpp`: `execution_space`, `memory_space`, `device_view<T>`. Currently host-only (`DefaultHostExecutionSpace`).
+- **Test files:** Named `*.t.cpp`, use Catch2 v3. Tests needing Kokkos provide a custom `main()` with `Kokkos::ScopeGuard` and link `Catch2::Catch2` (not `WithMain`). Simple tests use the `add_unit_test()` CMake helper which links `Catch2::Catch2WithMain`.
+- **CMake targets** follow the pattern `shoccs-<subsystem>` (e.g., `shoccs-matrices`, `shoccs-operators`). Test executables are `t-<name>`.
+
+## Architecture
+
+### Data Flow
+
+Lua config → `simulation_cycle::from_lua` → mesh + operators + system + integrator → `simulation_cycle::run()` (time-stepping loop)
+
+### Key Subsystems (dependency order)
+
+1. **Indexing** (`src/indexing.hpp`, `index_extents.hpp`, `index_view.hpp`) — Multi-dimensional index mapping for structured grids. All subsystems depend on this.
+
+2. **Fields** (`src/fields/`) — Field storage and algebra. `field_registry` owns all buffers as `Kokkos::View<real*>`. `field_ref` is a lightweight handle (slot index). Expression templates (`expr.hpp`) enable `dst = a + alpha * b` syntax that dispatches to `Kokkos::parallel_for`. Selection descriptors (`selection_desc.hpp`) describe contiguous/strided/gather subsets of a field for BC application.
+
+3. **Mesh** (`src/mesh/`) — Cartesian grid with cut-cell geometry. `cartesian` holds 1D coordinate arrays and grid spacings. `object_geometry` performs ray-casting intersection with embedded shapes (spheres, rectangles) to compute `psi` parameters for cut-cell stencils.
+
+4. **Matrices** (`src/matrices/`) — Small per-line operators, not global sparse systems. Composite structure: `inner_block = [dense_left | circulant_interior | dense_right]`, wrapped in `block` for multi-line application. CSR for sparse boundary coupling. Matrix-vector products use explicit loops (no KokkosKernels).
+
+5. **Stencils** (`src/stencils/`) — Finite difference coefficients. Named by scheme (E2, E4, E6, E8) and order. Each provides interior circulant + boundary dense + optional CSR cut-cell coefficients.
+
+6. **Operators** (`src/operators/`) — Discrete differential operators (derivative, gradient, laplacian) built from stencils + matrices. Applied per-direction using `operator_visitor` pattern across `block`/`inner_block`.
+
+7. **Systems** (`src/systems/`) — PDE implementations. Each system provides `rhs()` (spatial discretization), `update_boundary()`, `timestep_size()`, and initialization. Concrete: `heat`, `scalar_wave`, `hyperbolic_eigenvalues`. Uses `system` variant wrapper for type erasure; the variant also includes `empty` (placeholder) and `inviscid_vortex` (partial Euler scaffolding, not a working PDE). Note: only `heat` is fully wired through `simulation_cycle`; `scalar_wave` and `hyperbolic_eigenvalues` are not yet wired through. The real entry point is `simulation_cycle::from_lua` — the `simulation_builder` class is a dead stub.
+
+8. **Temporal** (`src/temporal/`) — Time integrators (`euler`, `rk4`) operating on `field_ref` slots in the registry. `step_controller` manages adaptive time stepping. Slot arithmetic helpers in `slot_ops.hpp`.
+
+9. **Simulation** (`src/simulation/`) — `simulation_cycle::from_lua` assembles the full simulation from Lua config (system + integrator + step_controller + field_io). `simulation_cycle` owns the time-stepping loop. (The older `simulation_builder` class is a dead stub — see `docs/reference/simulation.md`.)
+
+10. **I/O** (`src/io/`) — XDMF/binary field output, spdlog-based logging.
+
+### Historical Context
+
+The codebase was migrated from range-v3 to Kokkos. The `plans/` directory contains the migration plans and architectural decisions from that effort. Key decisions are documented in `plans/meta.md`.
+
+## Stencil Derivation Pipeline (SymPy)
+
+The `scripts/stencil_gen/` directory contains a SymPy-based pipeline for deriving finite difference stencil coefficients symbolically. Managed by `uv`.
+
+```bash
+# Run stencil_gen tests (from repo root)
+cd scripts/stencil_gen && SYMPY_CACHE_SIZE=50000 uv run pytest tests/ -x -q
+
+# Run a specific sweep (epsilon, tension, tension-penalty, footprint, comparison, alpha, mixed-epsilon)
+cd scripts/stencil_gen && uv run python -m sweeps epsilon --scheme E2
+
+# Run all sweeps with reduced resolution for quick verification
+cd scripts/stencil_gen && uv run python -m sweeps all --quick
+
+# Run all sweeps at full resolution and update known values
+cd scripts/stencil_gen && uv run python -m sweeps all
+```
+
+- **SYMPY_CACHE_SIZE=50000** is essential for performance — default 1000 causes severe slowdowns with large symbolic expressions.
+- For linear systems with symbolic parameters, use `linear_eq_to_matrix` + `linsolve` (not `sympy.solve`). Linearize bilinear terms first with the theta-substitution trick (`theta = w*phi`).
+- Reference Mathematica code in `mathematica-files/finitedifferences/` (`taylor.wl` for functions, `explicitr-E4d1.nb.pdf` for workflow).
+- Key entry points: `derive_cut_cell_mathematica()` (singularity-free), `derive_cut_cell_scheme()` (legacy with psi-clamping).
+- Generated C++ goes to `scripts/stencil_gen/output/` and replaces files in `src/stencils/`.
+- **Sweep workflow:** Parameter-space explorations live in `scripts/stencil_gen/sweeps/` as standalone scripts. Sweeps discover optimal parameters and write results to `sweeps/known_values.json`. Regression tests in `test_phs.py` load from `known_values.json` to verify stability at those values. To update known values after a sweep: `uv run python -m sweeps epsilon --scheme E2 --update-known-values`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,117 @@
+# Makefile for building SHOCCS devcontainer images.
+#
+# Wraps Docker build commands to simplify building containers with
+# different compiler toolchains. Both GCC and Clang are always installed
+# in the container; the SPACK_COMPILER arg controls which compiler spack
+# uses to build the dependency tree. CLANG_VERSION controls which clang
+# release is installed from the LLVM apt repository (apt.llvm.org).
+#
+# Usage:
+#   make build              Build gcc image (default)
+#   make build-gcc          Build gcc image
+#   make build-clang        Build clang image
+#   make build-all          Build both gcc and clang images
+#   make shell              Start a shell in the default container
+#   make shell-gcc          Start a shell in the gcc container
+#   make shell-clang        Start a shell in the clang container
+#   make clean              Remove built images
+#   make help               Show this help
+
+# Include local overrides if present (not checked in, gitignored)
+-include local.mk
+
+# Container image name
+IMAGE_NAME ?= shoccs-devcontainer
+
+# Default compiler (gcc or clang)
+COMPILER ?= gcc
+
+# Clang major version to install from apt.llvm.org
+CLANG_VERSION ?= 19
+
+# Timezone (auto-detected, override with TZ=<value>)
+TZ ?= $(shell cat /etc/timezone 2>/dev/null || echo UTC)
+
+# Additional docker build arguments (e.g., --no-cache)
+DOCKER_BUILD_ARGS ?=
+
+# Compiler-specific spack specs
+GCC_SPACK_SPEC   ?= gcc@14.2.0
+CLANG_SPACK_SPEC ?= clang@$(CLANG_VERSION)
+
+# Common docker build arguments
+COMMON_BUILD_ARGS := \
+	--build-arg TZ=$(TZ) \
+	--build-arg CLANG_VERSION=$(CLANG_VERSION) \
+	-f .devcontainer/Dockerfile \
+	$(DOCKER_BUILD_ARGS)
+
+.PHONY: build build-gcc build-clang build-all \
+        shell shell-gcc shell-clang \
+        clean help
+
+## Build the container image for the selected compiler (default: gcc)
+build: build-$(COMPILER)
+
+## Build the gcc-based container image
+build-gcc:
+	DOCKER_BUILDKIT=1 docker build \
+		$(COMMON_BUILD_ARGS) \
+		--build-arg SPACK_COMPILER=$(GCC_SPACK_SPEC) \
+		-t $(IMAGE_NAME):gcc \
+		.
+
+## Build the clang-based container image
+build-clang:
+	DOCKER_BUILDKIT=1 docker build \
+		$(COMMON_BUILD_ARGS) \
+		--build-arg SPACK_COMPILER=$(CLANG_SPACK_SPEC) \
+		-t $(IMAGE_NAME):clang \
+		.
+
+## Build both gcc and clang container images
+build-all: build-gcc build-clang
+
+## Start an interactive shell in the selected compiler's container (default: gcc)
+shell: shell-$(COMPILER)
+
+## Start an interactive shell in the gcc container
+shell-gcc:
+	docker run --rm -it \
+		-v $(CURDIR):/workspace \
+		$(IMAGE_NAME):gcc
+
+## Start an interactive shell in the clang container
+shell-clang:
+	docker run --rm -it \
+		-v $(CURDIR):/workspace \
+		$(IMAGE_NAME):clang
+
+## Remove built container images
+clean:
+	-docker rmi $(IMAGE_NAME):gcc 2>/dev/null
+	-docker rmi $(IMAGE_NAME):clang 2>/dev/null
+
+## Show available targets
+help:
+	@echo "SHOCCS devcontainer build targets:"
+	@echo ""
+	@echo "  make build          Build container (default: gcc)"
+	@echo "  make build-gcc      Build gcc container"
+	@echo "  make build-clang    Build clang container"
+	@echo "  make build-all      Build both gcc and clang containers"
+	@echo ""
+	@echo "  make shell          Shell into container (default: gcc)"
+	@echo "  make shell-gcc      Shell into gcc container"
+	@echo "  make shell-clang    Shell into clang container"
+	@echo ""
+	@echo "  make clean          Remove built images"
+	@echo ""
+	@echo "Variables (override via command line, environment, or local.mk):"
+	@echo "  COMPILER=gcc|clang       Select default compiler (default: gcc)"
+	@echo "  CLANG_VERSION=<major>    Clang version from apt.llvm.org (default: 19)"
+	@echo "  IMAGE_NAME=<name>        Container image name (default: shoccs-devcontainer)"
+	@echo "  GCC_SPACK_SPEC=<spec>    GCC spack compiler spec (default: gcc@14.2.0)"
+	@echo "  CLANG_SPACK_SPEC=<spec>  Clang spack compiler spec (default: clang@CLANG_VERSION)"
+	@echo "  TZ=<timezone>            Timezone (default: auto-detected)"
+	@echo "  DOCKER_BUILD_ARGS=       Additional docker build arguments"

--- a/SHOCCS_ARCHITECTURE_AND_KOKKOS_MIGRATION_SPEC.md
+++ b/SHOCCS_ARCHITECTURE_AND_KOKKOS_MIGRATION_SPEC.md
@@ -1,0 +1,1024 @@
+>  ⚠️ HISTORICAL PLANNING DOC (pre-migration). The range-v3 -> Kokkos migration described here as future work is COMPLETE (2026-03). The subsystem decomposition and PDE/method-of-lines overview are still useful, but the range-v3 code examples, the migration roadmap (§6/§8/§9), `cc_elliptic` (never created), and several struct details (e.g. mesh_object_info) are obsolete. For current state see docs/CAPABILITY_AUDIT.md and docs/reference/. NOTE: operators use STRONG BC enforcement, not SBP-SAT despite §4.2's label.
+
+# SHOCCS Architecture Specification & Kokkos Migration Guide
+
+**Stable High-Order Cut-Cell Solver — Complete Codebase Analysis**
+**Date:** 2026-03-09
+**Purpose:** Comprehensive architectural decomposition for migrating from range-v3 to Kokkos
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Project Overview](#2-project-overview)
+3. [What SHOCCS Solves](#3-what-shoccs-solves)
+4. [How SHOCCS Solves Systems of Equations](#4-how-shoccs-solves-systems-of-equations)
+5. [Subsystem Architecture](#5-subsystem-architecture)
+   - 5.1 [Mesh & Geometry](#51-mesh--geometry)
+   - 5.2 [Indexing System](#52-indexing-system)
+   - 5.3 [Fields Subsystem](#53-fields-subsystem)
+   - 5.4 [Stencils Subsystem](#54-stencils-subsystem)
+   - 5.5 [Operators Subsystem](#55-operators-subsystem)
+   - 5.6 [Matrices Subsystem](#56-matrices-subsystem)
+   - 5.7 [Systems Subsystem (PDE Implementations)](#57-systems-subsystem)
+   - 5.8 [Temporal Integration](#58-temporal-integration)
+   - 5.9 [Simulation Orchestration](#59-simulation-orchestration)
+   - 5.10 [I/O Subsystem](#510-io-subsystem)
+   - 5.11 [MMS (Verification)](#511-mms-verification)
+6. [Complete Range-v3 Usage Catalog](#6-complete-range-v3-usage-catalog)
+7. [Data Flow: End-to-End](#7-data-flow-end-to-end)
+8. [Kokkos Migration Strategy](#8-kokkos-migration-strategy)
+9. [Migration Roadmap](#9-migration-roadmap)
+
+---
+
+## 1. Executive Summary
+
+SHOCCS is a C++ Cartesian cut-cell solver for time-dependent PDEs (heat equation, scalar wave equation, inviscid vortex/Euler equations). It implements the numerical algorithm from Brady & Livescu (2020, J. Computational Physics). The code uses range-v3 extensively as a domain-specific language for expressing numerical operations on structured grids with embedded boundaries.
+
+**Codebase stats:** 189 source files (hpp/cpp), ~16 subsystem directories, heavy use of C++20 concepts, range-v3 views/actions/algorithms, and coroutine generators.
+
+**Key range-v3 dependencies:** 231 range-v3 header inclusions across the codebase, 6 custom view adaptors, 8+ view types, 11+ algorithms, coroutine generators for multi-dimensional iteration.
+
+**Migration scope:** Replace all range-v3 lazy view composition with Kokkos parallel execution patterns while preserving the mathematical structure and correctness of the solver.
+
+---
+
+## 2. Project Overview
+
+### 2.1 Dependencies
+
+| Library | Purpose | Migration Impact |
+|---------|---------|-----------------|
+| range-v3 | View composition, lazy evaluation, algorithms | **REPLACED by Kokkos** |
+| Lua / sol2 | Runtime configuration | No change |
+| Catch2 | Unit testing | No change |
+| fmt | String formatting | No change |
+| pugixml | XDMF output | No change |
+| spdlog | Logging | No change |
+| cxxopts | CLI argument parsing | No change |
+
+### 2.2 Directory Structure
+
+```
+src/
+├── app/          # Main entry point (shoccs.cpp)
+├── fields/       # Field data structures, selectors, tuple composition
+├── geometry/     # (Placeholder — geometry logic lives in mesh/)
+├── io/           # XDMF/binary output, logging, intervals
+├── lib/          # Library entry point (run_from_sol)
+├── matrices/     # CSR, dense, circulant, block, visitors
+├── mesh/         # Cartesian mesh, cut-cell geometry, object intersection
+├── mms/          # Method of manufactured solutions (Gaussian, Lua-defined)
+├── operators/    # Gradient, Laplacian, divergence, derivative, boundaries
+├── random/       # Random number generation
+├── simulation/   # Builder pattern, simulation cycle
+├── stencils/     # Finite difference stencil coefficients
+├── systems/      # PDE implementations (heat, wave, vortex, eigenvalues)
+├── temporal/     # Time integrators (Euler, RK4, step controller)
+├── utils/        # Bounded types, extents
+├── indexing.hpp  # Multi-dimensional index mapping
+├── index_extents.hpp  # Grid extent management
+├── index_view.hpp     # Index iteration views
+├── types.hpp     # Type aliases (real, integer, int3, real3)
+└── sentinels.hpp # Sentinel values
+```
+
+---
+
+## 3. What SHOCCS Solves
+
+### 3.1 Heat Equation (Parabolic PDE)
+
+```
+∂T/∂t = κ∇²T + S(t,x)
+```
+
+where κ is thermal diffusivity and S is a source term (from manufactured solutions).
+
+**Configuration example** (`heat.lua`): 51×51 grid, diffusivity=1/30, Gaussian manufactured solution centered at (1,1) with a spherical embedded object using floating boundary conditions.
+
+**Boundary conditions:** Dirichlet (prescribed temperature) and Neumann (prescribed flux) on domain boundaries; floating (interpolated) on cut-cell boundaries.
+
+### 3.2 Scalar Wave Equation (Hyperbolic PDE)
+
+```
+∂u/∂t = -∇G · ∇u
+```
+
+where G is a vector field representing wave propagation direction. Simplifies to `u_t = -a·u_x - b·u_y - c·u_z`.
+
+**Solution form:** `u(t,x) = sin(2π(‖x - center‖ - radius - t))` — a radially-symmetric traveling wave.
+
+**Boundary conditions:** Dirichlet with prescribed exact solution values.
+
+### 3.3 Inviscid Vortex / Euler Equations (Hyperbolic Conservation Laws)
+
+```
+∂ρ/∂t + ∇·(ρu) = 0          (mass)
+∂(ρu)/∂t + ∇·(ρu⊗u + pI) = 0  (momentum)
+∂(ρE)/∂t + ∇·((ρE + p)u) = 0   (energy)
+```
+
+**Status:** Partially implemented (core algorithms present but disabled via `#if 0` blocks). The inviscid vortex is a standard verification problem for Euler solvers.
+
+### 3.4 Hyperbolic Eigenvalue Analysis (Utility)
+
+Computes maximum eigenvalues of the discrete spatial operators for stability analysis. No time stepping — used to determine CFL limits for the hyperbolic schemes.
+
+---
+
+## 4. How SHOCCS Solves Systems of Equations
+
+### 4.1 Method of Lines
+
+SHOCCS uses the **method of lines** approach: spatial derivatives are discretized first (producing a large ODE system), then advanced in time with explicit integrators.
+
+```
+du/dt = f(u, t)    where f = spatial discretization operator
+```
+
+### 4.2 Spatial Discretization
+
+Spatial derivatives use **summation-by-parts (SBP) finite difference operators** on the Cartesian grid, with special stencil modifications near embedded boundaries (cut cells).
+
+**Operator assembly:**
+1. Interior points: circulant (banded Toeplitz) matrices encoding high-order stencils
+2. Near-boundary points: dense matrices with modified stencil coefficients
+3. Cut-cell points: CSR matrices with geometry-dependent coefficients based on the `psi` parameter (normalized distance from surface to cell center)
+
+**Composite structure:** Each 1D operator along a grid line is an `inner_block` = `[dense_left | circulant_interior | dense_right]`. Multiple lines compose into a `block` matrix. The full multi-dimensional operator combines these via the `discrete_operator` abstraction.
+
+### 4.3 Time Integration
+
+Two explicit integrators:
+
+**Forward Euler (1st order):**
+```
+u^(n+1) = u^n + Δt · f(u^n, t^n)
+```
+
+**Classical RK4 (4th order):**
+```
+k1 = f(u^n, t^n)
+k2 = f(u^n + (Δt/2)·k1, t^n + Δt/2)
+k3 = f(u^n + (Δt/2)·k2, t^n + Δt/2)
+k4 = f(u^n + Δt·k3, t^n + Δt)
+u^(n+1) = u^n + (Δt/6)(k1 + 2k2 + 2k3 + k4)
+```
+
+### 4.4 Stability (CFL Conditions)
+
+**Parabolic (heat):** `Δt = CFL_p · h_min² / (4κ)` — quadratic in mesh spacing.
+**Hyperbolic (wave):** `Δt = CFL_h · h_min / c_max` — linear in mesh spacing.
+
+Typical values: `CFL_p = 0.5`, `CFL_h = 0.8` for RK4.
+
+### 4.5 Boundary Condition Enforcement
+
+Applied in two phases per RHS evaluation:
+
+1. **Pre-RHS:** Set Dirichlet values to exact/prescribed values at current time; store Neumann gradient data for operator use.
+2. **Post-RHS:** Zero RHS at Dirichlet points (values enforced directly, not evolved).
+
+Cut-cell boundaries use floating conditions: the solution is interpolated from interior values using geometry-dependent weights.
+
+### 4.6 Verification via Method of Manufactured Solutions (MMS)
+
+An exact solution Q(t,x) is chosen (e.g., Gaussian), and a source term S = ∂Q/∂t - L(Q) is computed analytically and added to the RHS. The discrete solution should converge to Q at the expected order of accuracy. Error is measured as L∞ norm over the fluid domain.
+
+---
+
+## 5. Subsystem Architecture
+
+### 5.1 Mesh & Geometry
+
+**Files:** `src/mesh/cartesian.hpp/cpp`, `mesh.hpp/cpp`, `mesh_types.hpp`, `mesh_view.hpp`, `object_geometry.hpp/cpp`, `rect.hpp/cpp`, `sphere.cpp`, `selections.hpp`, `shapes.hpp`
+
+**Cartesian Grid Representation:**
+```cpp
+class cartesian : public index_extents {
+    std::vector<real> x_, y_, z_;  // 1D coordinate arrays
+    std::vector<real> h_;          // Grid spacings [hx, hy, hz]
+    int dims_;                     // Number of active dimensions (1, 2, or 3)
+};
+```
+
+- **Index extents** `n_[3]`: Number of points in each direction (inactive = 1)
+- **Domain bounds** `min_[3]`, `max_[3]`: Physical domain extent
+- **Coordinates:** 1D arrays distributed uniformly via `vs::linear_distribute`
+
+**Cut-Cell Geometry:**
+
+The `object_geometry` class performs ray-casting intersection of grid lines with embedded shapes (spheres, rectangles):
+
+```cpp
+struct mesh_object_info {
+    real psi;           // Normalized distance: surface-to-center / h
+    integer fluid_start; // Fluid region start index
+    integer fluid_end;   // Fluid region end index
+    bc_type bc;          // Boundary condition type
+};
+```
+
+- **Rx, Ry, Rz arrays:** Per-direction intersection data for each grid line
+- **Sx, Sy, Sz:** Solid interior point identification
+- **psi parameter:** Critical for cut-cell stencil modification (0 = on surface, 0.5 = cell center)
+- **Fluid slices:** Contiguous fluid regions separated by solid objects, stored as start/end pairs
+
+**Mesh Selections:**
+
+Selections partition the grid into regions for targeted operations:
+- `sel::D` — Domain interior (non-ghost)
+- `sel::R` — Ghost/reflection regions
+- `sel::xR, yR, zR` — Direction-specific regions
+- `m.fluid` — Interior fluid points
+- `m.dirichlet(grid_bcs, object_bcs)` — Dirichlet boundary points
+- `m.neumann<dir>(grid_bcs)` — Direction-specific Neumann boundaries
+- `m.fluid_all(object_bcs)` — All non-Dirichlet fluid points
+
+These are implemented as **range-v3 view factories** that return filtered index ranges.
+
+**Range-v3 Usage:**
+```cpp
+// Grid coordinate generation
+x_ = vs::linear_distribute(min_[0], max_[0], n_[0]) | rs::to<std::vector<real>>();
+
+// Dimension detection
+dims_ = rs::count_if(n_, [](auto n) { return !!(n - 1); });
+
+// Grid spacing computation
+rs::copy(vs::zip_with([](real mn, real mx, int n) { return (mx-mn)/(n-1); },
+         min_, max_, n_), rs::begin(h_));
+
+// Domain coordinate generation (Cartesian product)
+auto domain() { return tuple{vs::cartesian_product(x(), y(), z())}; }
+```
+
+### 5.2 Indexing System
+
+**Files:** `indexing.hpp`, `index_extents.hpp`, `index_view.hpp`
+
+**Multi-dimensional Index Mapping:**
+
+The indexing system maps 3D indices `(i,j,k)` to linear storage using a **direction-dependent convention**. For operations along direction `I`, the other two directions are classified as "slow" (large stride) and "fast" (small stride):
+
+| Operation Dir | I (primary) | S (slow) | F (fast) | Linear = |
+|--------------|-------------|----------|----------|----------|
+| X (dir=0) | i | j (ny stride) | k (1 stride) | i·ny·nz + j·nz + k |
+| Y (dir=1) | j | i (nx stride) | k (1 stride) | i·ny·nz + j·nz + k |
+| Z (dir=2) | k | i (nx stride) | j (ny stride) | i·ny·nz + j·nz + k |
+
+**Coroutine Generators for Iteration:**
+```cpp
+cppcoro::generator<int3> index_view(int3 extents) {
+    for (int s = 0; s < extents[S]; s++)
+        for (int f = 0; f < extents[F]; f++)
+            for (int i = 0; i < extents[I]; i++)
+                co_yield ijk;
+}
+```
+
+This is a **critical migration point**: Kokkos replaces coroutine generators with `MDRangePolicy<Rank<3>>` parallel dispatch.
+
+**Transpose Operations:** 9 transposition functions convert between direction-specific and canonical (x,y,z) ordering. These are tested exhaustively.
+
+### 5.3 Fields Subsystem
+
+**Files:** `src/fields/` (18 headers + 15 test files)
+
+**Data Structure Hierarchy:**
+
+```
+field<S, V>
+├── scalars: vector<scalar_real>
+│   └── Each scalar: tuple<domain_vector, (Rx_vec, Ry_vec, Rz_vec)>
+│       └── domain_vector: std::vector<real> (contiguous linear storage)
+└── vectors: vector<vector_real>
+    └── Each vector: tuple<scalar_x, scalar_y, scalar_z>
+        └── Each component is a scalar_real
+```
+
+- **scalar_real** = a tuple of views into the flat storage (domain + ghost regions)
+- **vector_real** = 3 scalar_real components
+- **field** = collection of scalar and vector fields for a PDE system
+
+**Custom View Adaptors (Most Complex range-v3 Usage):**
+
+1. **`plane_view<0>`** (X-plane): Contiguous memory slice — maps to `Kokkos::subview`
+2. **`plane_view<1>`** (Y-plane): Non-contiguous strided access — most complex, requires custom Kokkos kernel
+3. **`plane_view<2>`** (Z-plane): Strided access — maps to `Kokkos::LayoutStride`
+4. **`multi_slice_view`**: Multiple disconnected fluid regions — requires gather/scatter or temporary Views
+5. **`optional_view`** and **`predicate_view`**: Conditional filtering for boundary/ghost regions
+
+**Selector Mechanism:**
+
+Selectors compose range-v3 views to target subsets of field data:
+```cpp
+// Domain interior selection
+u | sel::D = initial_value;
+
+// Dirichlet boundary selection
+u | m.dirichlet(grid_bcs, object_bcs) = exact_solution;
+
+// Fluid region (skipping solid cells)
+u | m.fluid_all(object_bcs) += source_term;
+```
+
+**Key Range-v3 Patterns:**
+```cpp
+// Zip scalar components for element-wise operations
+vs::zip(FWD(t).scalars()...)
+vs::zip_with(f, FWD(t).scalars()...)
+
+// View adaptors for non-contiguous access
+class plane_view<I> : public rs::view_adaptor<plane_view<I>, Rng> { ... };
+
+// Algorithms
+rs::for_each, rs::copy, rs::fill, rs::equal, rs::minmax, rs::swap_ranges
+
+// Views
+vs::zip, vs::zip_with, vs::drop_exactly, vs::take_exactly, vs::stride,
+vs::repeat_n, vs::common, vs::all, vs::transform
+```
+
+### 5.4 Stencils Subsystem
+
+**Files:** `src/stencils/stencil.hpp/cpp`, `E2_1.cpp`, `E2_2.cpp`, `E4_2.cpp`, `E4u_1.cpp`, `E6u_1.cpp`, `E8u_1.cpp`, `polyE2_1.cpp`
+
+**Naming Convention:** `E[accuracy-order][u]_[derivative-order]`
+
+| Stencil | Accuracy | Derivative | Interior Width | Boundary Rows | Notes |
+|---------|----------|-----------|----------------|---------------|-------|
+| E2_1 | 2nd order | 1st | 3-point | 4 | Standard SBP |
+| E2_2 | 2nd order | 2nd | 3-point | 2 | Laplacian |
+| E4_2 | 4th order | 2nd | 5-point | 3 | High-order Laplacian |
+| E4u_1 | 4th order | 1st | — | — | Upwind variant |
+| E6u_1 | 6th order | 1st | — | — | Upwind variant |
+| E8u_1 | 8th order | 1st | — | — | Upwind variant |
+| polyE2_1 | 2nd order | 1st | — | — | Parameterized coefficients |
+
+**Stencil Structure:**
+```cpp
+class stencil {
+    std::vector<real> interior_coefficients;  // Interior stencil weights
+    std::vector<real> left_boundary;          // Left boundary dense block
+    std::vector<real> right_boundary;         // Right boundary dense block
+    integer interior_size;                    // Stencil width
+    integer boundary_rows;                    // Number of non-standard boundary rows
+};
+```
+
+**Cut-Cell Modification:** Near embedded objects, stencil coefficients are modified based on the `psi` parameter. The `polyE2_1` stencil demonstrates parameterized coefficients where cut-cell geometry directly influences the finite difference weights.
+
+**Range-v3 in Stencils:**
+```cpp
+// Extracting boundary stencil rows via chunking
+lc | vs::chunk(tLeft) | vs::for_each(vs::drop(1))
+
+// Computing cut-cell coefficients
+c | vs::take_exactly(tObj)
+c | vs::drop_exactly((rObj-1)*tObj) | vs::take_exactly(tObj) | vs::reverse
+```
+
+### 5.5 Operators Subsystem
+
+**Files:** `src/operators/derivative.hpp/cpp`, `gradient.hpp/cpp`, `laplacian.hpp/cpp`, `divergence.hpp`, `directional.hpp/cpp`, `boundaries.hpp/cpp`, `discrete_operator.hpp`, `identity_stencil.hpp`, `eigenvalue_visitor.hpp/cpp`, `operator_visitor.hpp`
+
+**Operator Hierarchy:**
+
+```
+discrete_operator (base concept)
+├── derivative      — 1D finite difference along one direction
+├── gradient        — [∂/∂x, ∂/∂y, ∂/∂z] composition of derivatives
+├── laplacian       — ∂²/∂x² + ∂²/∂y² + ∂²/∂z² composition
+├── divergence      — ∇·F composition (for conservation laws)
+└── directional     — Complex geometry-dependent operator
+```
+
+**Operator Application Pipeline:**
+
+1. Select grid line (1D slice through 3D domain)
+2. Apply boundary conditions to line endpoints
+3. Apply `inner_block` matrix: `[dense_left | circulant_interior | dense_right]`
+4. Accumulate result into output field
+5. Repeat for all lines in all active directions
+
+**Derivative Construction:**
+```cpp
+// For each grid line in direction `dir`:
+inner_block = {
+    left_boundary:  dense matrix from stencil boundary coefficients,
+    interior:       circulant matrix from stencil interior coefficients,
+    right_boundary: dense matrix from stencil boundary coefficients
+};
+
+// Cut-cell lines get modified:
+inner_block_cutcell = {
+    left_boundary:  dense (modified by psi),
+    interior:       circulant (standard),
+    right_boundary: dense (modified by psi)
+};
+```
+
+**Boundary Operator:**
+
+The `boundaries` class handles the BC matrix `B` that maps boundary values into the operator:
+```cpp
+struct boundaries {
+    matrix::csr B;      // Domain boundary operator
+    matrix::csr Bfx;    // Object boundary (forward, x-dir)
+    matrix::csr Brx;    // Object boundary (reverse, x-dir)
+    // ... Bfy, Bry, Bfz, Brz for other directions
+};
+```
+
+**Range-v3 in Operators:**
+```cpp
+// Enumerate shapes for cut-cell processing
+for (auto&& [shape_row, obj] : vs::enumerate(shapes)) { ... }
+
+// Transform solid points to direction-local indices
+g.S(dir) | ranges::view::transform(m.ucf_ijk2dir(dir))
+         | ranges::view::take(b_sz)
+         | ranges::to<std::vector<int>>()
+
+// Reduction over boundary conditions
+rs::accumulate(obj_bcs, true, [](auto&& acc, auto&& cur) { ... })
+```
+
+### 5.6 Matrices Subsystem
+
+**Files:** `src/matrices/csr.hpp/cpp`, `dense.hpp/cpp`, `circulant.hpp/cpp`, `inner_block.hpp/cpp`, `block.hpp`, `common.hpp`, `matrix_visitor.hpp`, `coefficient_visitor.hpp/cpp`, `unit_stride_visitor.hpp/cpp`
+
+**Matrix Types:**
+
+| Type | Storage | Purpose | Kokkos Equivalent |
+|------|---------|---------|-------------------|
+| `csr` | 3-array CSR (w, v, u) | Sparse boundary matrices | `Kokkos::CrsMatrix` or custom |
+| `dense` | Row-major `vector<real>` | Boundary stencil blocks | `Kokkos::View<real**,LayoutRight>` |
+| `circulant` | Shared stencil coefficients | Interior repeated stencil | Kernel with offset arithmetic |
+| `inner_block` | `[dense \| circulant \| dense]` | Full 1D line operator | Composite kernel |
+| `block` | `vector<inner_block>` | Multi-line operator | Multi-launch or fused kernel |
+
+**Matrix-Vector Product Patterns:**
+
+All matrices implement:
+```cpp
+template <typename Op = eq_t>
+void operator()(std::span<const real> x, std::span<real> b, Op op = {}) const;
+```
+
+**CSR SpMV:**
+```cpp
+for (integer row = 0; row < rows(); row++)
+    for (integer i = u[row]; i < u[row+1]; i++)
+        b[row] += w[i] * x[v[i]];
+```
+
+**Dense MatVec (range-v3):**
+```cpp
+auto rng = vs::zip_with(
+    [](auto&& a, auto&& b) { return rs::inner_product(a, b, 0.0); },
+    vs::chunk(v, columns()),        // Split flat storage into rows
+    vs::repeat_n(x, rows())         // Broadcast input vector
+);
+for (auto&& [y, z] : vs::zip(b, rng)) op(y, z);
+```
+
+**Circulant Stencil Application (range-v3):**
+```cpp
+auto rng = vs::zip_with(
+    [](auto&& a, auto&& b) { return rs::inner_product(a, b, 0.0); },
+    vs::repeat_n(v, rows()),        // Repeat stencil coefficients
+    x | vs::sliding(size())         // Sliding window over input
+);
+for (auto&& [y, z] : vs::zip(b, rng)) op(y, z);
+```
+
+**Strided Application (for multi-D operators along non-X directions):**
+```cpp
+auto in = x | vs::stride(st);
+auto out = b | vs::stride(st);
+// Apply stencil to strided data
+```
+
+**Visitor Pattern:**
+
+Two visitors extract information from matrix hierarchies:
+- **`unit_stride_visitor`:** Maps matrix row/column indices to output DOF indices, handling cut-cell DOF removal
+- **`coefficient_visitor`:** Extracts matrix coefficients into a dense global view using the index mapping
+
+### 5.7 Systems Subsystem
+
+**Files:** `src/systems/system.hpp/cpp`, `heat.hpp/cpp`, `scalar_wave.hpp/cpp`, `cc_elliptic.hpp/cpp`, `inviscid_vortex.hpp/cpp`, `hyperbolic_eigenvalues.hpp/cpp`, `empty_system.hpp/cpp`
+
+**Type-Erased System Interface:**
+```cpp
+class system {
+    std::variant<systems::empty, systems::scalar_wave,
+                 systems::inviscid_vortex, systems::heat,
+                 systems::hyperbolic_eigenvalues> v;
+
+    // Key methods (dispatched via std::visit):
+    field operator()(const step_controller&);           // Initial conditions
+    void rhs(field_view f, real time, field_span rhs);  // Spatial RHS
+    void update_boundary(field_span f, real time);      // BC enforcement
+    real timestep_size(const field&, const step_controller&); // CFL
+    system_stats stats(const field&, const field&, const step_controller&);
+};
+```
+
+**Heat System RHS:**
+```cpp
+void heat::rhs(field_view f, real time, field_span rhs) const {
+    auto&& u_rhs = rhs.scalars(scalars::u);
+    auto&& u = f.scalars(scalars::u);
+
+    u_rhs = lap(u, neumann_u);       // Discrete Laplacian
+    u_rhs *= diffusivity;            // Scale by κ
+
+    if (m_sol) {
+        // MMS source term: S = ∂Q/∂t - κ∇²Q
+        const auto src = (m.xyz | m_sol.ddt(time))
+                       - (diffusivity * (m.xyz | m_sol.laplacian(time)));
+        u_rhs | m.fluid_all(object_bcs) += src;
+        u_rhs | m.dirichlet(grid_bcs, object_bcs) = 0;
+    }
+}
+```
+
+**Scalar Wave System RHS:**
+```cpp
+void scalar_wave::rhs(field_view f, real, field_span rhs) {
+    auto&& u = f.scalars(scalars::u);
+    auto&& u_rhs = rhs.scalars(scalars::u);
+
+    du = grad(u);                    // Discrete gradient
+    u_rhs = dot(grad_G, du);         // Dot with wave speed vector
+}
+```
+
+**Statistics Computation (heavy range-v3):**
+```cpp
+auto [u_min, u_max] = minmax(u | m.fluid_all(object_bcs));
+real err = max(abs(u - sol) | m.fluid_all(object_bcs));
+// Uses rs::max_element, rs::distance, transform, accumulate
+```
+
+### 5.8 Temporal Integration
+
+**Files:** `src/temporal/integrator.hpp/cpp`, `euler.hpp/cpp`, `rk4.hpp/cpp`, `step_controller.hpp/cpp`, `empty_integrator.hpp/cpp`
+
+**RK4 Implementation:**
+```cpp
+constexpr std::array rki{0.0, 0.5, 0.5, 1.0};                    // Stage time offsets
+constexpr std::array rkf{1.0/6.0, 1.0/3.0, 1.0/3.0, 1.0/6.0};  // Stage weights
+
+void rk4::operator()(system& sys, const field& u0, field_span u,
+                     const step_controller& ctrl, real dt) {
+    rk_rhs = 0; system_rhs = 0;
+    const real time = ctrl;
+    u = u0;
+
+    for (int i = 0; i < 4; ++i) {
+        if (i > 0) {
+            u = u0 + dt * rki[i] * system_rhs;
+            sys.update_boundary(u, time + dt * rki[i]);
+        }
+        system_rhs = sys.rhs(u, time + dt * rki[i]);
+        rk_rhs += dt * rkf[i] * system_rhs;
+    }
+    u = u0 + rk_rhs;
+    sys.update_boundary(u, time + dt);
+}
+```
+
+**Step Controller:**
+```cpp
+class step_controller {
+    bounded<int> step;     // Current iteration [0, max_step]
+    bounded<real> time;    // Current time [0, max_time]
+    real h_cfl;            // Hyperbolic CFL number
+    real p_cfl;            // Parabolic CFL number
+    real min_dt;           // Minimum allowed timestep
+};
+```
+
+### 5.9 Simulation Orchestration
+
+**Files:** `src/simulation/simulation_builder.hpp/cpp`, `simulation_cycle.hpp/cpp`, `src/app/shoccs.cpp`, `src/lib/run_from_sol.cpp`
+
+**Control Flow:**
+```
+main() → parse CLI args → load Lua config
+       → simulation_builder::from_lua(config)
+           ├── system::from_lua(config)
+           ├── integrator::from_lua(config)
+           ├── step_controller::from_lua(config)
+           └── field_io::from_lua(config)
+       → simulation_cycle::run()
+           └── while (step_controller) {
+                   dt = system.timestep_size(u, step)
+                   u_new = integrator(system, u, step, dt)
+                   stats = system.stats(u_old, u_new, step)
+                   io.write_if_needed(system, u_new, step, dt)
+                   step.advance(dt)
+               }
+       → return final stats
+```
+
+**Two-Field Swap Pattern:** The cycle alternates between two field buffers to avoid allocation during time stepping.
+
+### 5.10 I/O Subsystem
+
+**Files:** `src/io/field_io.hpp/cpp`, `field_data.hpp/cpp`, `xdmf.hpp/cpp`, `logging.hpp/cpp`, `interval.hpp`
+
+**Output Format:** XDMF metadata (XML) + binary data files. The XDMF file describes a time series of solution snapshots; each snapshot's field data is written as raw binary.
+
+**Range-v3 in I/O:**
+```cpp
+// File name generation
+vs::transform(names, [](auto&& n) { return n + ".bin"; })
+
+// Parallel file iteration
+vs::zip(file_handles, field_data) | for_each(write_binary)
+```
+
+**Interval System:** Output controlled by time interval or step interval, configured via Lua.
+
+### 5.11 MMS (Verification)
+
+**Files:** `src/mms/manufactured_solutions.hpp`, `mms.cpp`, `gauss.hpp`, `gauss1d/2d/3d.cpp`, `lua_mms.hpp/cpp`
+
+**Manufactured Solution Interface:**
+```cpp
+class manufactured_solution {
+    // Evaluate solution: Q(t, x)
+    auto operator()(real time) const;
+    // Time derivative: ∂Q/∂t
+    auto ddt(real time) const;
+    // Spatial gradient: ∂Q/∂x_i
+    auto gradient(int dir, real time) const;
+    // Laplacian: ∇²Q
+    auto laplacian(real time) const;
+};
+```
+
+**Gaussian Implementation:** Provides analytical derivatives for verification:
+```
+Q(t,x) = A · exp(-((x-cx)²/(2σx²) + (y-cy)²/(2σy²))) · cos(2πft)
+```
+
+All derivatives computed analytically — no numerical differentiation.
+
+**Lua-defined MMS:** Allows arbitrary manufactured solutions defined in Lua with symbolic differentiation via sol2.
+
+---
+
+## 6. Complete Range-v3 Usage Catalog
+
+### 6.1 View Types Used
+
+| View | Files | Kokkos Replacement |
+|------|-------|-------------------|
+| `vs::zip` | fields, matrices, operators, I/O | Explicit multi-array loops or `Kokkos::parallel_for` with multiple View args |
+| `vs::zip_with` | matrices (dense, circulant) | `Kokkos::parallel_for` with lambda combining arrays |
+| `vs::transform` | fields, operators, I/O, statistics | `Kokkos::parallel_for` with output View |
+| `vs::chunk(n)` | matrices (dense), visitors | Manual `i*n..(i+1)*n` indexing in kernel |
+| `vs::sliding(n)` | matrices (circulant) | Manual `i..i+n` window in kernel |
+| `vs::stride(n)` | matrices, operators | `Kokkos::subview` with LayoutStride or manual `i*stride` |
+| `vs::repeat_n(v,n)` | matrices | Broadcast pattern in kernel |
+| `vs::drop_exactly(n)` | fields, stencils | Offset in subview: `subview(v, make_pair(n, extent))` |
+| `vs::take_exactly(n)` | fields, stencils | Size-limited subview: `subview(v, make_pair(0, n))` |
+| `vs::common` | fields | Not needed (Kokkos views are always common) |
+| `vs::all` | fields | Not needed (Kokkos views are already views) |
+| `vs::enumerate` | operators, visitors | `Kokkos::parallel_for` index is implicit |
+| `vs::reverse` | stencils | Reverse loop or reversed subview |
+| `vs::for_each` | visitors (nested composition) | Nested loops |
+| `vs::linear_distribute` | mesh | Manual: `min + i*(max-min)/(n-1)` |
+| `vs::cartesian_product` | mesh | `MDRangePolicy<Rank<3>>` |
+
+### 6.2 Algorithms Used
+
+| Algorithm | Files | Kokkos Replacement |
+|-----------|-------|-------------------|
+| `rs::inner_product` | matrices (dense, circulant) | `KokkosBlas::dot()` or manual reduction |
+| `rs::copy` | fields, matrices, mesh | `Kokkos::deep_copy` |
+| `rs::fill` | fields | `Kokkos::deep_copy(view, value)` |
+| `rs::for_each` | fields, operators | `Kokkos::parallel_for` |
+| `rs::sort` | matrices (CSR builder) | `Kokkos::sort` or host-side `std::sort` |
+| `rs::equal` | tests | `Kokkos::parallel_reduce` with comparison |
+| `rs::minmax` | statistics | `Kokkos::parallel_reduce` with MinMax reducer |
+| `rs::min` | step controller | `Kokkos::parallel_reduce` with Min reducer |
+| `rs::max_element` | statistics | `Kokkos::parallel_reduce` with MaxLoc reducer |
+| `rs::accumulate` | operators | `Kokkos::parallel_reduce` with Sum reducer |
+| `rs::count_if` | mesh | `Kokkos::parallel_reduce` with count |
+| `rs::distance` | statistics | Index arithmetic |
+| `rs::to<Container>` | operators, mesh | Manual loop or host-side conversion |
+| `rs::shuffle` | tests | `std::shuffle` (host only) |
+
+### 6.3 Custom Adaptors
+
+| Adaptor | Location | Complexity | Migration Approach |
+|---------|----------|------------|-------------------|
+| `plane_view<0>` (X) | fields | Medium | `Kokkos::subview` (contiguous) |
+| `plane_view<1>` (Y) | fields | **High** | Custom kernel with strided access |
+| `plane_view<2>` (Z) | fields | Medium | `Kokkos::subview` with LayoutStride |
+| `multi_slice_view` | fields | **High** | Gather into temporary View, or index list |
+| `optional_view` | fields | Medium | Conditional mask in kernel |
+| `predicate_view` | fields | Medium | Filter with index array |
+| `semiregular_box_t` | fields | Low | Not needed in Kokkos |
+
+### 6.4 Coroutine Generators
+
+| Generator | Location | Replacement |
+|-----------|----------|-------------|
+| `index_view(int3)` | indexing | `Kokkos::MDRangePolicy<Rank<3>>` |
+| Line iteration | mesh | `Kokkos::RangePolicy` per direction |
+
+---
+
+## 7. Data Flow: End-to-End
+
+### 7.1 Initialization
+
+```
+Lua Config
+  ├── mesh::from_lua → Cartesian grid + cut-cell geometry
+  │     ├── Compute coordinates (vs::linear_distribute)
+  │     ├── Ray-cast objects → Rx, Ry, Rz intersection data
+  │     └── Build fluid slices, solid masks, selection views
+  ├── stencil::from_lua → Finite difference coefficients
+  ├── bcs::from_lua → Boundary condition types per face
+  ├── system::from_lua → PDE system with operators
+  │     ├── Build derivative operators (derivative → inner_block → block)
+  │     ├── Compose into gradient/laplacian/divergence
+  │     └── Initialize manufactured solution
+  ├── integrator::from_lua → RK4 or Euler
+  ├── step_controller::from_lua → CFL numbers, termination criteria
+  └── field_io::from_lua → Output intervals, file paths
+```
+
+### 7.2 Per-Timestep Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  TIMESTEP n                                                      │
+│                                                                  │
+│  1. CFL check:  dt = system.timestep_size(u, step_ctrl)         │
+│     └── rs::min(mesh.h()) → minimum grid spacing                 │
+│     └── dt = CFL * h² / (4κ)  or  CFL * h / c                  │
+│                                                                  │
+│  2. RK4 stages (4 evaluations):                                  │
+│     For stage i = 0..3:                                          │
+│       ├── u_stage = u0 + dt * rk_coeff[i] * k_prev              │
+│       ├── update_boundary(u_stage, t + dt*rk_time[i])            │
+│       │   └── u | m.dirichlet(...) = exact_solution              │
+│       │   └── neumann_data | m.neumann<dir>(...) = gradient      │
+│       ├── k_i = system.rhs(u_stage, t + dt*rk_time[i])          │
+│       │   └── For heat: k = κ·lap(u) + source                   │
+│       │       └── lap(u): iterate all grid lines                 │
+│       │           └── For each line: inner_block(x, b)           │
+│       │               ├── dense_left: small MatVec               │
+│       │               ├── circulant: stencil application         │
+│       │               │   └── vs::sliding + rs::inner_product    │
+│       │               └── dense_right: small MatVec              │
+│       │   └── For wave: k = dot(grad_G, grad(u))                │
+│       │       └── grad(u): derivative in each direction          │
+│       └── rk_rhs += dt * rk_weight[i] * k_i                     │
+│                                                                  │
+│  3. Solution update:  u_new = u0 + rk_rhs                       │
+│     └── update_boundary(u_new, t + dt)                           │
+│                                                                  │
+│  4. Statistics:  stats = system.stats(u_old, u_new, step)        │
+│     └── error = max(|u - u_exact|) over fluid domain             │
+│     └── rs::max_element, rs::minmax, rs::accumulate              │
+│                                                                  │
+│  5. I/O:  if interval triggered → write XDMF + binary           │
+│                                                                  │
+│  6. Advance:  step_ctrl.advance(dt)                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 7.3 Memory Access Pattern Summary
+
+| Operation | Access Pattern | Parallelism Model |
+|-----------|---------------|-------------------|
+| Circulant stencil | Sliding window, sequential | `parallel_for` over rows |
+| Dense boundary MatVec | Row-major sequential | `parallel_for` over rows |
+| CSR SpMV | Row-sequential, column-gather | `parallel_for` over rows |
+| Multi-D operator | Strided 1D slices through 3D array | `parallel_for` over lines |
+| Field arithmetic | Element-wise contiguous | `parallel_for` over elements |
+| Statistics reduction | Sequential scan with min/max | `parallel_reduce` |
+| BC enforcement | Scattered writes to boundary indices | `parallel_for` over BC indices |
+
+---
+
+## 8. Kokkos Migration Strategy
+
+### 8.1 Data Container Migration
+
+**Tier 0 — Foundation:**
+```cpp
+// BEFORE
+std::vector<real> data;
+std::span<real> view;
+
+// AFTER
+Kokkos::View<real*> data("data", n);
+Kokkos::View<real*, Kokkos::HostSpace> host_data("host_data", n);
+// Or dual views for host/device:
+Kokkos::DualView<real*> data("data", n);
+```
+
+### 8.2 Iteration Pattern Migration
+
+**Simple loops → parallel_for:**
+```cpp
+// BEFORE
+rs::for_each(vs::zip(a, b), [](auto [x, y]) { x += y; });
+
+// AFTER
+Kokkos::parallel_for(n, KOKKOS_LAMBDA(int i) {
+    a(i) += b(i);
+});
+```
+
+**Multi-dimensional iteration → MDRangePolicy:**
+```cpp
+// BEFORE (coroutine generator)
+for (auto ijk : index_view(extents)) { ... }
+
+// AFTER
+Kokkos::parallel_for(
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {nx,ny,nz}),
+    KOKKOS_LAMBDA(int i, int j, int k) { ... }
+);
+```
+
+**Stencil application → parallel_for with local reduction:**
+```cpp
+// BEFORE
+auto rng = vs::zip_with(inner_product,
+    vs::repeat_n(stencil, rows),
+    input | vs::sliding(width));
+
+// AFTER
+Kokkos::parallel_for(rows, KOKKOS_LAMBDA(int i) {
+    real sum = 0.0;
+    for (int j = 0; j < width; j++)
+        sum += stencil(j) * input(i + j);
+    output(i) = sum;
+});
+```
+
+**Strided access → subview or LayoutStride:**
+```cpp
+// BEFORE
+auto in = x | vs::stride(st);
+
+// AFTER
+auto in = Kokkos::subview(x, Kokkos::make_pair(0, n*st, st));
+// Or manual indexing:
+Kokkos::parallel_for(n, KOKKOS_LAMBDA(int i) {
+    output(i) = stencil_apply(x, i * stride, width);
+});
+```
+
+### 8.3 Reduction Migration
+
+```cpp
+// BEFORE
+auto [mn, mx] = rs::minmax(u | m.fluid_all(bcs));
+
+// AFTER
+real mn, mx;
+Kokkos::parallel_reduce(n,
+    KOKKOS_LAMBDA(int i, real& lmin, real& lmax) {
+        if (is_fluid(i)) {
+            lmin = Kokkos::min(lmin, u(i));
+            lmax = Kokkos::max(lmax, u(i));
+        }
+    },
+    Kokkos::Min<real>(mn), Kokkos::Max<real>(mx)
+);
+```
+
+### 8.4 Field/Selector Migration
+
+The selector mechanism (`u | m.dirichlet(...)`) must be replaced with either:
+
+**Option A: Index list approach**
+```cpp
+// Pre-compute boundary index lists
+Kokkos::View<int*> dirichlet_indices("dirichlet_idx", n_dirichlet);
+// Fill once during initialization
+
+// Apply BC
+Kokkos::parallel_for(n_dirichlet, KOKKOS_LAMBDA(int ii) {
+    int i = dirichlet_indices(ii);
+    u(i) = exact_solution(i);
+});
+```
+
+**Option B: Mask approach**
+```cpp
+// Pre-compute boolean mask
+Kokkos::View<bool*> is_dirichlet("is_dirichlet", n_total);
+
+// Apply BC
+Kokkos::parallel_for(n_total, KOKKOS_LAMBDA(int i) {
+    if (is_dirichlet(i))
+        u(i) = exact_solution(i);
+});
+```
+
+Option A is preferred for sparse selections (fewer divergent threads on GPU).
+
+### 8.5 Matrix Format Migration
+
+| Current | Kokkos Replacement |
+|---------|-------------------|
+| `csr` (3-array) | `KokkosSparse::CrsMatrix<real>` |
+| `dense` (row-major vector) | `Kokkos::View<real**, LayoutRight>` |
+| `circulant` (stencil span) | Custom kernel with `Kokkos::View<real*>` coefficients |
+| `inner_block` | Fused kernel or 3 sequential launches |
+| `block` | `Kokkos::parallel_for` over lines with team policy |
+
+### 8.6 Visitor Pattern Adaptation
+
+The visitor pattern for matrix assembly can be preserved on the host side (assembly is typically done once at initialization). The assembled matrices are then copied to device memory:
+
+```cpp
+// Assembly remains on host
+auto block_h = build_operator_host(mesh, stencil, bcs);
+
+// Copy to device
+auto block_d = Kokkos::create_mirror_view_and_copy(
+    Kokkos::DefaultExecutionSpace(), block_h);
+```
+
+---
+
+## 9. Migration Roadmap
+
+### Phase 1: Foundation (Week 1-2)
+- Add Kokkos dependency to CMake build system
+- Replace `types.hpp` aliases with Kokkos-compatible types
+- Create `Kokkos::View` wrappers for core data containers
+- Migrate `index_extents` and linear indexing to Kokkos-compatible functions
+- Replace coroutine generators with MDRangePolicy iteration
+
+### Phase 2: Fields & Selectors (Week 2-3)
+- Migrate `scalar_real` storage from `std::vector<real>` to `Kokkos::View<real*>`
+- Replace custom view adaptors (plane_view, multi_slice_view) with subviews and index lists
+- Implement selector mechanism using pre-computed index arrays
+- Migrate field arithmetic to `Kokkos::parallel_for`
+- Port tuple operations to work with Kokkos views
+
+### Phase 3: Matrices (Week 3-4)
+- Migrate CSR to `KokkosSparse::CrsMatrix` or custom Kokkos CSR
+- Migrate dense matrix to `Kokkos::View<real**, LayoutRight>`
+- Rewrite circulant stencil application as Kokkos kernel
+- Adapt inner_block and block to launch Kokkos kernels
+- Keep visitor-based assembly on host, copy to device
+
+### Phase 4: Operators (Week 4-5)
+- Port derivative operator to use Kokkos matrix kernels
+- Migrate gradient/laplacian/divergence composition
+- Port boundary operator with Kokkos CSR SpMV
+- Adapt directional operator for complex geometry
+- Validate operator accuracy against reference (MMS convergence tests)
+
+### Phase 5: Systems & Temporal (Week 5-6)
+- Port RHS evaluation for heat and scalar_wave systems
+- Adapt RK4/Euler time integration loop
+- Migrate statistics computation to Kokkos reductions
+- Port BC enforcement using index list approach
+- Maintain Lua configuration interface unchanged
+
+### Phase 6: I/O, MMS & Integration Testing (Week 6-8)
+- Adapt I/O to read from device memory (deep_copy to host for output)
+- Ensure MMS verification produces identical convergence rates
+- Run full simulation regression tests
+- Performance benchmarking: Kokkos (CPU threads, GPU) vs. original range-v3
+- Documentation and cleanup
+
+### Estimated Total Effort: 6-8 engineer-weeks
+
+### Risk Areas
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Y-plane non-contiguous access | High | Custom kernel with explicit strided indexing |
+| multi_slice_view replacement | High | Gather into temporary contiguous buffer |
+| Lazy evaluation loss | Medium | Profile eager execution overhead; batch operations |
+| Host/device data movement | Medium | Use DualView or Unified Memory initially |
+| Template metaprogramming incompatibility | Medium | Simplify template patterns for KOKKOS_LAMBDA capture |
+| Assembly on device vs host | Low | Keep assembly on host, copy once |
+
+---
+
+*This specification was generated by deep recursive analysis of all 189 source files across 16 subsystem directories in the SHOCCS codebase. Each subsystem was analyzed by a dedicated agent reading every header, implementation, and test file.*

--- a/run-dev-container.fish
+++ b/run-dev-container.fish
@@ -1,0 +1,52 @@
+#!/usr/bin/env fish
+# Helper script to run Claude Code development container
+#
+# Usage:
+#   ./run-dev-container.fish              Run the default (gcc) container
+#   ./run-dev-container.fish gcc          Run the gcc container
+#   ./run-dev-container.fish clang        Run the clang container
+#   ./run-dev-container.fish my-image:tag Run a custom container image
+
+# Ensure we're in the project directory
+cd (dirname (status --current-filename))
+
+# Ensure ~/.claude-container exists
+mkdir -p $HOME/.claude-container
+
+# Default image name (should match IMAGE_NAME in Makefile)
+set image_name shoccs-devcontainer
+
+# Resolve the container image from the argument
+set -q argv[1]; or set argv[1] gcc
+switch $argv[1]
+    case gcc clang
+        set container $image_name:$argv[1]
+    case '*'
+        set container $argv[1]
+end
+set name (string split -r -m1 : $container)[1]
+
+# Colors for output
+set GREEN '\033[0;32m'
+set BLUE '\033[0;34m'
+set NC '\033[0m' # No Color
+
+echo -e "$BLUE Starting $container ...$NC"
+echo ""
+
+# Run container with all necessary configuration
+docker run -it --rm \
+  --name $name \
+  --cap-add=NET_ADMIN \
+  --cap-add=NET_RAW \
+  -p 8000:8000 \
+  -v (pwd):/workspace \
+  -v $HOME/.claude-container:/home/user/.claude \
+  -v $HOME/.gitconfig:/home/user/.gitconfig:ro \
+  -v $HOME/.ssh:/home/user/.ssh:ro \
+  -v claude-code-bashhistory:/commandhistory \
+  -e CLAUDE_CONFIG_DIR=/home/user/.claude \
+  -e POWERLEVEL9K_DISABLE_GITSTATUS=true \
+  --entrypoint /bin/bash \
+  $container \
+  -c "exec /bin/zsh"


### PR DESCRIPTION
## Summary

Adds the reproducible development environment and project tooling for the SHOCCS solver. Everything here is non-compiled and affects only the developer workflow: a Spack-based multi-stage devcontainer, container build/run convenience wrappers, ignore rules, the architecture/migration reference document, and editor helper configuration. No solver source or build logic changes.

## Changes

- **Devcontainer** (`.devcontainer/`):
  - `Dockerfile` — multi-stage build over `python:3.11-slim`: a base stage with GCC (incl. gfortran) and a pinned clang/clangd/clang-format/lld toolchain from apt.llvm.org; a Spack builder stage that concretizes and installs the full dependency tree; and a final stage that copies the Spack view plus developer tooling (zsh, fzf, neovim, gh, git-delta). BuildKit cache mounts persist Spack tarballs, bootstrap tools, and the staging area across rebuilds.
  - `spack.yaml` — pins the dependency set from `CMakeLists.txt` (lua, lua-sol2, fmt, pugixml, spdlog, cxxopts, catch2, boost, lapackpp, benchmark) and Kokkos 5.0+ (`cxxstd=20 +serial +openmp`) plus kokkos-tools; `unify: true` and a `%gcc` requirement keep the tree consistent.
  - `devcontainer.json` — workspace bind mount, persistent bash-history volume, clangd/CMake-Tools settings, and a `postCreateCommand` that configures `build/` with Ninja and `RelWithDebInfo`.
  - `init-firewall.sh` — default-deny egress with an allowlist built from GitHub meta IP ranges and pinned package/registry hosts, with verification that blocked traffic stays blocked; `corporate-ca.pem` supports injecting a CA bundle.
- **Build/run tooling**:
  - `Makefile` — wraps `docker build`/`docker run` for gcc and clang image variants with overridable `TZ`, `CLANG_VERSION`, image name, and Spack compiler specs.
  - `run-dev-container.fish` — launches the container with `NET_ADMIN`/`NET_RAW`, SSH/gitconfig mounts, and automatic free-port selection.
  - `.gitignore`, `.devcontainer/.dockerignore` — exclude build artifacts, caches, and local overrides.
- **Documentation and editor helpers**:
  - `SHOCCS_ARCHITECTURE_AND_KOKKOS_MIGRATION_SPEC.md` — subsystem decomposition and the range-v3 to Kokkos migration strategy.
  - `CLAUDE.md` — build/test/benchmark commands and code conventions.
  - `.claude/` — an exploration helper and stencil-analysis references.

## Test plan

No compiled artifacts; this PR changes developer tooling only.

- Configure still succeeds: `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON`
- Build (unaffected, for sanity): `cmake --build build`
- Test (unaffected, for sanity): `ctest --test-dir build`
