### PR TITLE
devcontainer: project-owned Spack repo for dependencies (Kokkos 5.1.1)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -83,10 +83,14 @@ RUN useradd -m -u 1000 -s /bin/zsh $USERNAME || true
 # This stage only rebuilds when:
 #   - base-system changes (compilers, etc.)
 #   - spack.yaml changes (dependency specifications)
-#   - Spack version changes
+#   - the spack_repo/ recipe changes
+#   - the pinned Spack / spack-packages versions change
 #
-# All SHOCCS dependencies are in the standard spack builtin repo.
-# No custom spack_repo is needed.
+# SHOCCS dependencies are provisioned from a PROJECT-OWNED custom spack repo
+# (spack_repo/shoccs, checked into the git repo) that declares a single
+# `shoccs` recipe. The community spack-packages repo is pinned (in spack.yaml)
+# to a develop commit that ships Kokkos 5.1+ (the Graph API the solver needs;
+# no tagged spack-packages release carries 5.1.x yet).
 
 FROM base-system AS spack-builder
 
@@ -95,16 +99,31 @@ ARG SPACK_MIRROR_URL=""
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
-# Clone and configure Spack (use develop branch for Kokkos 5.0+ recipes)
-RUN git clone --depth=1 -b develop https://github.com/spack/spack.git /home/$USERNAME/spack
+# Clone Spack at a pinned 1.x release for reproducibility (since Spack 1.0 the
+# builtin package recipes live in the separate spack-packages repo, which the
+# environment manifest pins to a develop commit containing Kokkos 5.1).
+RUN git clone --depth=1 -b v1.1.1 https://github.com/spack/spack.git /home/$USERNAME/spack
+
+# Copy the project-owned custom spack repo to the ABSOLUTE path referenced by
+# the environment manifest's `repos:` entry.
+COPY --chown=$USERNAME:$USERNAME spack_repo /home/$USERNAME/spack_repo
 
 # Copy the spack environment file
 COPY --chown=$USERNAME:$USERNAME .devcontainer/spack.yaml /home/$USERNAME/shoccs-env/spack.yaml
 
-# Configure Spack: find system compilers
+# Configure Spack: find system compilers (Spack 1.0 records these as externals
+# in packages.yaml)
 RUN /home/$USERNAME/spack/bin/spack compiler find
 
-# Concretize and build all dependencies
+# Concretize and build all dependencies.
+# NOTE: `spack repo update builtin` is REQUIRED. Spack auto-clones the DEFAULT
+# builtin repo (this Spack release pins releases/v2025.11, which has no kokkos
+# 5.1) on first use and does NOT re-sync that on-disk clone to the commit pinned
+# under `repos: builtin:` in spack.yaml. `spack repo update` forces the checkout
+# to the pinned commit, which ships kokkos 5.1.1.
+# The commit SHA on the `spack repo update builtin --commit` line below is what
+# actually takes effect; keep it in sync with the `builtin::` commit in
+# .devcontainer/spack.yaml (editing only the manifest is silently ignored).
 # Cache mounts persist across builds for faster rebuilds:
 #   - var/spack/cache: downloaded source tarballs
 #   - .spack/cache: misc caches including fetch cache
@@ -122,8 +141,10 @@ RUN --mount=type=cache,target=/home/user/spack/var/spack/cache,uid=1000,gid=1000
     if [ -n "$SPACK_MIRROR_URL" ]; then spack mirror add custom-mirror "$SPACK_MIRROR_URL"; fi && \
     spack env create shoccs-dev /home/$USERNAME/shoccs-env/spack.yaml && \
     spack env activate shoccs-dev && \
+    spack repo update builtin --commit 1b13532cdcb78de32ef23a83a05d2ab144bd0702 && \
+    spack repo list && \
     spack concretize && \
-    spack install -j $(nproc)
+    spack install -j $(nproc) --only dependencies
 
 
 # =============================================================================
@@ -185,6 +206,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
 COPY --from=spack-builder --chown=$USERNAME:$USERNAME /home/$USERNAME/spack /home/$USERNAME/spack
 COPY --from=spack-builder --chown=$USERNAME:$USERNAME /home/$USERNAME/shoccs-env /home/$USERNAME/shoccs-env
 COPY --from=spack-builder --chown=$USERNAME:$USERNAME /home/$USERNAME/.spack /home/$USERNAME/.spack
+# The custom repo must remain at the absolute path the environment's repos:
+# entry points at, so `spack env activate shoccs-dev` can load the recipe.
+COPY --from=spack-builder --chown=$USERNAME:$USERNAME /home/$USERNAME/spack_repo /home/$USERNAME/spack_repo
 
 # =============================================================================
 # User configuration
@@ -207,7 +231,8 @@ ENV DEVCONTAINER=true \
     REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
-    UV_NATIVE_TLS=true
+    UV_NATIVE_TLS=true \
+    CMAKE_PREFIX_PATH=/home/$USERNAME/spack/var/spack/environments/shoccs-dev/.spack-env/view
 
 # Install Oh My Zsh
 RUN git clone --depth=1 https://github.com/ohmyzsh/ohmyzsh.git /home/$USERNAME/.oh-my-zsh
@@ -229,7 +254,7 @@ RUN echo 'export ZSH="/home/user/.oh-my-zsh"' > /home/$USERNAME/.zshrc && \
     echo '' >> /home/$USERNAME/.zshrc && \
     echo '# Spack initialization' >> /home/$USERNAME/.zshrc && \
     echo 'source /home/user/spack/share/spack/setup-env.sh' >> /home/$USERNAME/.zshrc && \
-    echo 'spack env activate shoccs-dev' >> /home/$USERNAME/.zshrc
+    echo 'spack env activate shoccs-dev || echo "warning: could not activate shoccs-dev; run: spack env list"' >> /home/$USERNAME/.zshrc
 
 WORKDIR /workspace
 CMD ["/bin/zsh"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,7 @@
 
   "initializeCommand": "",
   "onCreateCommand": "",
-  "postCreateCommand": "cmake -S /workspace -B /workspace/build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON",
+  "postCreateCommand": "bash -c 'source /home/user/spack/share/spack/setup-env.sh && spack env activate shoccs-dev && cmake -S /workspace -B /workspace/build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON'",
 
   "remoteEnv": {
     "DEVCONTAINER": "true"

--- a/.devcontainer/spack.yaml
+++ b/.devcontainer/spack.yaml
@@ -1,33 +1,41 @@
-# Spack environment for SHOCCS development container
+# Spack 1.0+ environment for the SHOCCS development container.
 #
-# All dependencies are from the standard spack builtin repository.
-# No custom spack repo is needed.
+# Dependencies are provisioned from the project-owned custom repo
+# (spack_repo/shoccs, checked into this git repo) which declares a single
+# `shoccs` recipe. The Dockerfile copies that repo to the ABSOLUTE path
+# referenced below and creates a named environment from this manifest:
 #
-# Usage:
-#   spack env create shoccs-dev spack.yaml
+#   spack env create shoccs-dev .devcontainer/spack.yaml
 #   spack env activate shoccs-dev
-#   spack concretize
-#   spack install
+#   spack install --only dependencies        # build just the TPLs
+#
+# This file uses an ABSOLUTE repo path on purpose: a named/managed environment
+# copies its manifest into Spack's environments directory, so a relative repo
+# path would be rewritten/relocated.
 spack:
   specs:
-    # Current dependencies (from CMakeLists.txt)
-    - lua
-    - lua-sol2
-    - "fmt@8:"
-    - "pugixml@1.10:"
-    - "spdlog@1.9:"
-    - cxxopts
-    - "catch2@3:"
-    - boost
-    - lapackpp
-    # Kokkos (parallel execution framework)
-    - "kokkos@5.0: cxxstd=20 +serial +openmp"
-    # Kokkos profiling tools (runtime profiling via KOKKOS_TOOLS_LIBS)
-    - kokkos-tools
-    # Microbenchmark framework (Google Benchmark)
-    - benchmark
-    - "cmake@3.24:"
-    - ninja
+    # +profiling pulls kokkos-tools (an unpinned `develop` branch) to match the
+    # project's runtime profiling setup; drop it for a fully pinned build.
+    # Pin kokkos to the exact validated 5.1.1 — an open `@5.1:` range otherwise
+    # lets the concretizer slide kokkos to the `develop` branch version.
+    - shoccs +tests +benchmarks +profiling ^kokkos@5.1.1
+
+  repos:
+    # Project recipe, copied here by the Dockerfile.
+    shoccs: /home/user/spack_repo/shoccs
+    # Pin the community package repo to a develop commit that ships Kokkos 5.1.1
+    # (the Graph API the solver uses; no tagged release has 5.1.x yet — the
+    # newest tag, v2026.03.0, caps at 5.0.2). Pinning a commit keeps the
+    # container build reproducible. The trailing `::` fully REPLACES the
+    # inherited default entry (a plain `builtin:` would deep-merge into a
+    # conflicting branch+commit pair). Bump this commit (or switch to a tag) once
+    # a tagged spack-packages release ships kokkos 5.1+.
+    # NOTE: the Dockerfile re-syncs the on-disk clone via
+    # `spack repo update builtin --commit <sha>`; that SHA is what actually takes
+    # effect, so keep it identical to the commit below.
+    builtin::
+      git: https://github.com/spack/spack-packages.git
+      commit: 1b13532cdcb78de32ef23a83a05d2ab144bd0702
 
   view: true
 
@@ -36,6 +44,10 @@ spack:
 
   packages:
     all:
-      require: '%gcc'
+      # Build everything with GCC. Spack 1.0 made compilers dependencies, so a
+      # bare `require: "%gcc"` would force a compiler onto language-less
+      # packages and fail to concretize. The conditional per-language form only
+      # constrains packages that actually compile C/C++/Fortran code.
+      require: "%[when=%c]c=gcc %[when=%cxx]cxx=gcc %[when=%fortran]fortran=gcc"
       prefer:
         - cxxstd=20

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Docker build context for the devcontainer image (context = repo root).
+# The image only needs the project Spack repo and the .devcontainer/ files
+# (the source tree is bind-mounted at runtime, not copied at build time), so
+# ignore everything by default and re-include just what the Dockerfile COPYs.
+# This keeps the ~1.4 GB build/ directory (and .git, io/, logs/, …) out of the
+# build context.
+*
+!spack_repo
+!.devcontainer

--- a/run-dev-container.fish
+++ b/run-dev-container.fish
@@ -31,7 +31,16 @@ set GREEN '\033[0;32m'
 set BLUE '\033[0;34m'
 set NC '\033[0m' # No Color
 
+# Find a free host port (starting at 8000) to forward to container port 8000.
+# Avoids "Bind for 0.0.0.0:8000 failed: port is already allocated" when another
+# process/container already holds the port. No manual editing required.
+set host_port 8000
+while lsof -nP -iTCP:$host_port -sTCP:LISTEN >/dev/null 2>&1
+    set host_port (math $host_port + 1)
+end
+
 echo -e "$BLUE Starting $container ...$NC"
+echo -e "$GREEN Forwarding host port $host_port -> container port 8000$NC"
 echo ""
 
 # Run container with all necessary configuration
@@ -39,7 +48,7 @@ docker run -it --rm \
   --name $name \
   --cap-add=NET_ADMIN \
   --cap-add=NET_RAW \
-  -p 8000:8000 \
+  -p $host_port:8000 \
   -v (pwd):/workspace \
   -v $HOME/.claude-container:/home/user/.claude \
   -v $HOME/.gitconfig:/home/user/.gitconfig:ro \

--- a/spack_repo/shoccs/packages/shoccs/package.py
+++ b/spack_repo/shoccs/packages/shoccs/package.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2022, Triad National Security, LLC. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Spack 1.0+ / Package API v2: build-system base classes now live in the
+# (separately versioned) builtin package repository, not in core spack. The
+# directives (version, variant, depends_on, ...) still come from spack.package.
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Shoccs(CMakePackage):
+    """SHOCCS (Stable High-Order Cut-Cell Solver): a C++20 Cartesian cut-cell
+    solver for time-dependent PDEs (heat equation, scalar wave, Euler
+    equations). It uses high-order finite-difference operators on structured
+    grids with embedded boundaries and is parallelized with Kokkos."""
+
+    # TODO(maintainer): confirm canonical repo URL (origin remote is
+    # github.com/pbrady/shoccs; upstream is github.com/lanl/shoccs).
+    homepage = "https://github.com/lanl/shoccs"
+    git = "https://github.com/lanl/shoccs.git"
+
+    maintainers("pbrady")
+
+    license("BSD-3-Clause")
+
+    # Development version tracked from the default branch. The devcontainer and
+    # `spack develop` workflows build from a live checkout, so no sha256 is
+    # needed here.
+    version("main", branch="main")
+    # TODO(maintainer): add tagged releases as they are cut, e.g.:
+    #   version("1.0.0", sha256="<spack checksum shoccs 1.0.0>")
+
+    # ------------------------------------------------------------------ #
+    # Build options (mapped to the project's CMake cache options below)  #
+    # ------------------------------------------------------------------ #
+    variant("tests", default=True, description="Build the Catch2 unit tests")
+    variant(
+        "benchmarks",
+        default=False,
+        description="Build the Google Benchmark microbenchmark suite",
+    )
+    # Off by default so the standard build stays fully pinned/offline-capable
+    # (kokkos-tools has only an unpinned `develop` branch — see below). The
+    # devcontainer turns this on explicitly.
+    variant(
+        "profiling",
+        default=False,
+        description="Install kokkos-tools for runtime Kokkos profiling "
+        "(loaded via KOKKOS_TOOLS_LIBS)",
+    )
+
+    # ------------------------------------------------------------------ #
+    # Language (compiler) dependencies                                   #
+    # Spack 1.0 models compilers as real nodes in the DAG, so a package  #
+    # must declare the language virtuals it compiles. SHOCCS is          #
+    # project(shoccs LANGUAGES CXX); C is pulled in by CMake probing and #
+    # several transitive deps, so both are declared.                     #
+    # ------------------------------------------------------------------ #
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    # ------------------------------------------------------------------ #
+    # Build tools                                                        #
+    # ------------------------------------------------------------------ #
+    depends_on("cmake@3.22:", type="build")
+    depends_on("ninja", type="build")
+
+    # ------------------------------------------------------------------ #
+    # Link / run libraries (default dependency type is build+link)       #
+    # ------------------------------------------------------------------ #
+    depends_on("lua")
+    depends_on("lua-sol2")
+    depends_on("fmt@8:")
+    depends_on("pugixml@1.10:")
+    depends_on("spdlog@1.9:")
+    depends_on("cxxopts")
+    # SHOCCS only uses Boost header-only (Boost.MP11). The spack boost recipe
+    # has no header_only variant; instead every compiled-library variant
+    # defaults off, so a plain `boost` spec yields a cheap header-only install
+    # (Boost is configured with --with-libraries=headers).
+    depends_on("boost")
+    # C++ LAPACK/BLAS wrapper. Pulls the blas/lapack virtuals; the concrete
+    # provider (e.g. openblas) is chosen by site/environment config.
+    depends_on("lapackpp")
+
+    # Host-only Kokkos. The serial and openmp backends both default to off in
+    # the current recipe, so +serial must be requested explicitly. cxxstd=20 is
+    # the default (and only sensible value) for kokkos@5:, stated for clarity.
+    # The solver's create_graph call sites use the Kokkos 5.1 Graph API
+    # (one-arg create_graph<execution_space>(closure), DeviceHandle era). Bound
+    # to the validated 5.1.x series: 5.1.0 is the floor (the 5.0 two-arg form no
+    # longer compiles) and the upper bound guards against a future 5.2/6.0
+    # changing this still-Experimental overload — widen only after re-validating
+    # the call sites. As of June 2026 kokkos 5.1.x lives only on the
+    # spack-packages `develop` branch (newest tag v2026.03.0 caps at 5.0.2); the
+    # devcontainer pins a develop commit, native users point their builtin there.
+    depends_on("kokkos@5.1.0:5.1 +serial +openmp cxxstd=20")
+    # Enable with +profiling. kokkos-tools currently ships only a `develop`
+    # branch version (no tagged release), so this resolves to @develop and needs
+    # git access at build time; it is therefore left off by default.
+    depends_on("kokkos-tools", type=("build", "run"), when="+profiling")
+
+    # ------------------------------------------------------------------ #
+    # Test- / benchmark-only dependencies                                #
+    # ------------------------------------------------------------------ #
+    depends_on("catch2@3:", when="+tests")
+    depends_on("benchmark", when="+benchmarks")
+
+    def cmake_args(self):
+        return [
+            self.define_from_variant("BUILD_TESTING", "tests"),
+            self.define_from_variant("BUILD_BENCHMARKS", "benchmarks"),
+        ]

--- a/spack_repo/shoccs/repo.yaml
+++ b/spack_repo/shoccs/repo.yaml
@@ -1,0 +1,3 @@
+repo:
+  namespace: shoccs
+  api: v2.0


### PR DESCRIPTION
Provision SHOCCS dependencies from a Package-API-v2 custom Spack repo (spack_repo/shoccs) with a `shoccs` CMakePackage recipe, dropping the external shoccs-tpl bundle.

- spack_repo/shoccs: api v2.0 repo + recipe; kokkos@5.1.0:5.1 +serial +openmp cxxstd=20, header-only boost, lapackpp, catch2/benchmark via +tests/+benchmarks, kokkos-tools via +profiling.
- .devcontainer/spack.yaml: single `shoccs ... ^kokkos@5.1.1` spec; builtin (spack-packages) pinned to a develop commit shipping kokkos 5.1.1 (no tagged release has 5.1.x yet); gcc via the Spack 1.0 conditional require.
- .devcontainer/Dockerfile: Spack v1.1.1, copy spack_repo, `spack repo update builtin --commit` to force the clone to the pinned commit, install --only dependencies, export CMAKE_PREFIX_PATH.
- .devcontainer/devcontainer.json: activate the Spack env in postCreateCommand.
- .dockerignore: keep build/ and other large dirs out of the image build context.
- run-dev-container.fish: auto-select a free host port (avoid 8000 collisions).

Verified in-container: image builds; SHOCCS compiles against kokkos@5.1.1; ctest 47/48 (pre-existing t-laplacian failure).