### PR TITLE
Add polynomial-interpolation cut-cell stencils (E2); harden devcontainer build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -144,7 +144,7 @@ RUN --mount=type=cache,target=/home/user/spack/var/spack/cache,uid=1000,gid=1000
     spack repo update builtin --commit 1b13532cdcb78de32ef23a83a05d2ab144bd0702 && \
     spack repo list && \
     spack concretize && \
-    spack install -j $(nproc) --only dependencies
+    spack install -j $(nproc) --only dependencies --fail-fast
 
 
 # =============================================================================

--- a/scripts/stencil_gen/.gitignore
+++ b/scripts/stencil_gen/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/stencil_gen/_proto_interp.py
+++ b/scripts/stencil_gen/_proto_interp.py
@@ -1,0 +1,306 @@
+"""PROTOTYPE / VALIDATION (throwaway, left for the lead).
+
+Proves the "polynomial-interpolation -> derivative via d/dy|0" idea in sympy
+for E2 (p=1, nu=1), the way temo/boundary code is structured. Run with:
+
+    cd scripts/stencil_gen && SYMPY_CACHE_SIZE=50000 uv run python _proto_interp.py
+
+Five checks:
+ 1. interior interp polynomial via Taylor matching (rhs[k] = y^k/k!)
+ 2. d/dy|0 of (1) == central difference [-1/2, 0, 1/2] == derive_interior(0,1,1)
+ 3. one left-boundary cut-cell interp row gamma[1,j](y,psi,fa,ia) matched to
+    golden values (incl. the 1/(1+psi) denominator), and its d/dy|0 row matched
+    to the floating-derivative golden row.
+ 4. value/derivative decoupling: ia only in y^0 term, fa only in y^1 term.
+ 5. numeric cross-check vs the actual C++ polyE2_1.cpp formulas.
+"""
+
+from sympy import (
+    Matrix,
+    Rational,
+    Symbol,
+    cancel,
+    diff,
+    factorial,
+    symbols,
+)
+
+from stencil_gen.interior import derive_interior, full_gamma_array
+
+y = Symbol("y")
+psi = Symbol("psi")
+
+
+def interp_rhs(n_eqs):
+    """RHS functional for f[i+y]: Taylor row k is the coeff of f^(k)[i] in the
+    expansion of f[i+y], i.e. y^k / k!. (This is the single structural change
+    vs. the derivative path, whose RHS is a unit vector at row nu.)"""
+    return Matrix([Rational(1) * y**k / factorial(k) for k in range(n_eqs)])
+
+
+def passed(name, ok):
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    return ok
+
+
+all_ok = []
+
+# ----------------------------------------------------------------------------
+print("=" * 72)
+print("CHECK 1: interior interp polynomial on nodes {-1,0,1} via Taylor match")
+print("=" * 72)
+
+# Unknown coeffs gamma_{-1}, gamma_0, gamma_1 (functions of y).
+g = symbols("g_m1 g_0 g_p1")
+nodes = [-1, 0, 1]
+n_eqs = 3  # 3 unknowns -> rows k = 0,1,2
+
+# Vandermonde: row k, col j  ==  node_j^k / k!   (discreteTaylorSeries / toTable)
+A = Matrix(
+    [[Rational(nodes[j] ** k) / factorial(k) for j in range(3)] for k in range(n_eqs)]
+)
+b = interp_rhs(n_eqs)
+
+# Entries are exact in y (no psi) -> Matrix.solve is fine; cancel to clean form.
+sol_vec = A.solve(b)
+interior_interp = [cancel(c) for c in sol_vec]
+
+expected_interp = [(y**2 - y) / 2, 1 - y**2, (y**2 + y) / 2]
+print("  derived gamma[-1,0,1](y):")
+for s_, c_ in zip(["gamma[-1]", "gamma[0]", "gamma[1]"], interior_interp):
+    print(f"    {s_} = {c_}")
+ok1 = all(
+    cancel(a - e) == 0 for a, e in zip(interior_interp, expected_interp)
+)
+all_ok.append(passed("interior interp == [(y^2-y)/2, 1-y^2, (y^2+y)/2]", ok1))
+
+# ----------------------------------------------------------------------------
+print("=" * 72)
+print("CHECK 2: d/dy|0 of interior interp == central difference [-1/2,0,1/2]")
+print("=" * 72)
+
+deriv_from_interp = [cancel(diff(c, y).subs(y, 0)) for c in interior_interp]
+print(f"  d/dy|0 -> {deriv_from_interp}")
+
+# Compare to derive_interior(0, 1, 1) full gamma array (the production path).
+ic = derive_interior(0, 1, 1)
+prod_deriv = full_gamma_array(ic)
+print(f"  derive_interior(0,1,1) full_gamma_array -> {prod_deriv}")
+ok2 = (
+    deriv_from_interp == [Rational(-1, 2), Rational(0), Rational(1, 2)]
+    and [Rational(v) for v in deriv_from_interp] == [Rational(v) for v in prod_deriv]
+)
+all_ok.append(passed("d/dy|0 == [-1/2,0,1/2] == derive_interior(0,1,1)", ok2))
+
+# ----------------------------------------------------------------------------
+print("=" * 72)
+print("CHECK 3: left-boundary cut-cell interp row i=0 (C++ interp_wall left case0)")
+print("=" * 72)
+
+# Param symbols use build_symbol_map's name_i convention: fa_0 -> "fa[0]".
+fa0, fa1 = symbols("fa_0 fa_1")
+ia0, ia1 = symbols("ia_0 ia_1")
+
+# --- GOLDEN: the exact C++ interp_wall left case0 coefficients (polyE2_1.cpp:116-124),
+# transcribed with the documented column relabel applied so columns are in the
+# C++ order [wall, node0, node1, node2]:
+#   c0 = wall@(ymin - psi*h),  c1 = node@ymin,  c2 = node@ymin+h,  c3 = node@ymin+2h
+t6_ = 1 / (1 + psi)
+golden = [
+    (1 + psi + ia1 - y + fa1 * y) * Rational(1, 2) * t6_,                       # c0 wall
+    (1 + psi + fa0 * y + ia0 - y) * Rational(1, 2),                             # c1 node0
+    (-psi + (fa0 * y + ia0) * (-2) + y
+     + (-2 * ia1 - psi * ia1 + y - 2 * fa1 * y - psi * fa1 * y) * t6_)
+    * Rational(1, 2),                                                           # c2 node1
+    (ia1 + fa0 * y + ia0 + fa1 * y) * Rational(1, 2),                           # c3 node2
+]
+
+# --- THE NODE LAYOUT (reverse-engineered from polyE2_1.t.cpp:294-309 "left 0").
+# mesh = linear_distribute(ymin,ymax,t-1); set ymin=0, h=1 -> nodes at 0,1,2.
+# Column vector m = [ymin-psi*h, ymin, ymin+h, ymin+2h] -> x-positions:
+xs = [-psi, Rational(0), Rational(1), Rational(2)]
+# stencil::interp adjusts y by (psi-1) when the closest node IS the wall node
+# (left 0: lc==ic), so interp_wall receives the adjusted y. In wall-local coords
+# the row reproduces a field evaluated at:
+xe = -psi + y  # == (ymin - h + y_raw*h) with y the *adjusted* y; verified vs test
+T = 4
+
+# --- DERIVE from scratch (the TEMO-style recipe), proving the construction:
+#  (1) particular solution: a deg-1-exact interp with NO free params (Lagrange on
+#      a chosen 2-node subset, others zero) -> the param-free backbone.
+#  (2) nullspace basis: vectors n with sum_j n_j x_j^k = 0 for k=0,1. Adding any
+#      multiple preserves deg-1 exactness. polyBlend feeds each as (ia + y*fa).
+# Exactness rows k=0,1 (constant + linear) -> 2 constraints on T=4 unknowns -> 2-dim
+# free space (the 2 free DOFs that become ia0/fa0 and ia1/fa1).
+def interp_rhs_at(n_eqs, x):
+    return Matrix([x**k / factorial(k) for k in range(n_eqs)])
+
+# Particular solution: solve using the LAST two columns held to 0 (cols 0,3 free=0),
+# i.e. plain 2-node Lagrange on nodes {x1=0, x2=1}.
+A_part = Matrix([[xs[j] ** k / factorial(k) for j in (1, 2)] for k in range(2)])
+p_sub = A_part.solve(interp_rhs_at(2, xe))
+particular = [Rational(0), cancel(p_sub[0]), cancel(p_sub[1]), Rational(0)]
+
+# Nullspace basis: 2 vectors v with V @ v = 0 where V has rows k=0,1 over xs.
+V = Matrix([[xs[j] ** k / factorial(k) for j in range(T)] for k in range(2)])
+nullbasis = [list(v) for v in V.nullspace()]  # 2 vectors, length 4
+print(f"  particular (param-free) = {[cancel(c) for c in particular]}")
+print(f"  nullspace basis vectors = {[[cancel(e) for e in v] for v in nullbasis]}")
+
+# The two free DOFs are blended (ia_k + y*fa_k). The golden values fix the exact
+# linear combination of the nullspace basis; recover the blend coefficients by
+# matching column 0 and column 3 (the cleanest columns) to golden.
+# golden = particular + (ia0 + y*fa0)*b0 + (ia1 + y*fa1)*b1, where b0,b1 are a
+# specific basis. We solve for that basis by least-structure: express the golden
+# homogeneous part (golden - particular) in the nullspace and read the blend.
+homog = [cancel(golden[j] - particular[j]) for j in range(T)]
+# Build the matrix [nullbasis[0] nullbasis[1]] and solve column-wise for the
+# coefficient (which is a function of y carrying ia + y*fa).
+Nb = Matrix.hstack(Matrix(nullbasis[0]), Matrix(nullbasis[1]))
+# Solve Nb @ [a; b] = homog (overdetermined 4x2 but consistent since homog is in span)
+coeffs_ab = (Nb.T * Nb).inv() * Nb.T * Matrix(homog)
+a_coef = cancel(coeffs_ab[0])  # multiplies nullbasis[0]; should be a (ia + y*fa) blend
+b_coef = cancel(coeffs_ab[1])  # multiplies nullbasis[1]
+print(f"  recovered blend on basis0 = {a_coef}")
+print(f"  recovered blend on basis1 = {b_coef}")
+
+# Reconstruct and verify EXACT match to golden.
+derived = [
+    cancel(particular[j] + a_coef * nullbasis[0][j] + b_coef * nullbasis[1][j])
+    for j in range(T)
+]
+labels = ["c0(wall)", "c1(n0)", "c2(n1)", "c3(n2)"]
+ok3a = True
+for lbl, c_, g_ in zip(labels, derived, golden):
+    match = cancel(c_ - g_) == 0
+    ok3a = ok3a and match
+    print(f"    {lbl}: {'MATCH' if match else 'MISMATCH'}")
+    if not match:
+        print(f"         derived = {c_}\n         golden  = {cancel(g_)}")
+all_ok.append(passed("derived row (particular + nullspace blend) == golden", ok3a))
+
+# Confirm the blends are exactly (ia + y*fa): y^0 part is ia-only, y^1 part fa-only.
+ok3blend = True
+for nm, blend in [("basis0", a_coef), ("basis1", b_coef)]:
+    v0 = cancel(blend.subs(y, 0))
+    v1 = cancel(diff(blend, y))
+    rem = cancel(blend - v0 - y * v1)
+    is_blend = (
+        {fa0, fa1}.isdisjoint(v0.free_symbols)
+        and {ia0, ia1}.isdisjoint(v1.free_symbols)
+        and rem == 0
+    )
+    ok3blend = ok3blend and is_blend
+    print(f"  {nm} blend = (ia-part: {v0}) + y*(fa-part: {v1})  -> {'ia+y*fa OK' if is_blend else 'NOT a blend'}")
+all_ok.append(passed("free DOFs enter as (ia + y*fa) blends (polyBlend structure)", ok3blend))
+
+# d/dy|0 of this interp row gives the floating-derivative row; verify it is exactly
+# the y^1 part and depends on fa (not ia) -> this IS the nbs_floating-style row.
+deriv_row = [cancel(diff(c_, y).subs(y, 0)) for c_ in derived]
+golden_deriv = [cancel(diff(g_, y).subs(y, 0)) for g_ in golden]
+print("  d/dy|0 (-> derivative row):")
+ok3b = True
+for lbl, c_, gd in zip(labels, deriv_row, golden_deriv):
+    match = cancel(c_ - gd) == 0
+    ok3b = ok3b and match
+    has_no_ia = {ia0, ia1}.isdisjoint(c_.free_symbols)
+    ok3b = ok3b and has_no_ia
+    print(f"    d/dy {lbl} = {c_}  ({'no ia' if has_no_ia else 'HAS ia!'})")
+all_ok.append(passed("d/dy|0 row == d/dy of golden, depends on fa only (derivative duality)", ok3b))
+
+# ----------------------------------------------------------------------------
+print("=" * 72)
+print("CHECK 4: value/derivative decoupling (ia in y^0 only, fa in y^1 only)")
+print("=" * 72)
+
+# Use c2 (node1, the most coupled coefficient) as the witness.
+g13 = golden[2]
+value_part = cancel(g13.subs(y, 0))  # y=0 value
+deriv_part = cancel(diff(g13, y).subs(y, 0))  # d/dy|0
+# higher-order remainder
+remainder = cancel(g13 - value_part - y * deriv_part)
+print(f"  c2(y)          = {cancel(g13)}")
+print(f"  value (y=0)    = {value_part}")
+print(f"  deriv (d/dy|0) = {deriv_part}")
+print(f"  O(y^2) remaind = {remainder}")
+value_syms = value_part.free_symbols
+deriv_syms = deriv_part.free_symbols
+ok4 = (
+    {fa0, fa1}.isdisjoint(value_syms)  # no fa in the value part
+    and {ia0, ia1}.isdisjoint(deriv_syms)  # no ia in the deriv part
+    and remainder == 0  # exactly linear in y for this coeff
+)
+print(f"  value free syms = {sorted(str(s) for s in value_syms)}")
+print(f"  deriv free syms = {sorted(str(s) for s in deriv_syms)}")
+all_ok.append(passed("ia only in value(y=0), fa only in d/dy|0, exact-linear", ok4))
+
+# ----------------------------------------------------------------------------
+print("=" * 72)
+print("CHECK 5: numeric cross-check vs C++ polyE2_1.cpp formulas")
+print("=" * 72)
+
+# 5a) interior interp: C++ ships the 2-point linear reduction (query_interp {2,4}).
+#     For y>0:  c0 = 1 - y, c1 = y.  Our 3-pt poly restricted to nodes {0,1}
+#     is exactly that 2-pt linear interp; verify numerically at y=0.3.
+yv = 0.3
+# 2-pt linear (forward) interp the C++ uses:
+cpp_int = [1 + -1 * yv, yv]
+# Build the 2-pt poly ourselves (nodes {0,1}, rhs y^k/k!, rows k=0,1):
+A2 = Matrix([[Rational(0) ** k / factorial(k), Rational(1) ** k / factorial(k)] for k in range(2)])
+sol2 = A2.solve(interp_rhs(2))
+our_int = [float(cancel(c).subs(y, yv)) for c in sol2]
+print(f"  interior y=0.3: ours={our_int}  cpp={cpp_int}")
+ok5a = all(abs(a - b_) < 1e-12 for a, b_ in zip(our_int, cpp_int))
+
+# 5b) boundary interp_wall left case0: our DERIVED row (proven == golden) must
+#     match the literal C++ formulas element-wise at sample (psi,y,fa,ia).
+#     C++ left case0 (polyE2_1.cpp:116-124), with t6=1/(1+psi), t7=-y,
+#     t14=fa0*y,t15=ia0,t8=fa1,t10=ia1,t9=fa1*y:
+psiv, yvv = 0.8, 0.3
+fa0v, fa1v, ia0v, ia1v = 0.1, 0.2, 0.7, 0.8
+t6n = 1.0 / (1 + psiv)
+t7n, t14n, t15n, t8n, t10n, t9n = -yvv, fa0v * yvv, ia0v, fa1v, ia1v, fa1v * yvv
+cpp_row = [
+    (1 + psiv + t10n + t7n + t9n) * 0.5 * t6n,                                  # c0
+    (1 + psiv + t14n + t15n + t7n) * 0.5,                                       # c1
+    (-1 * psiv + (t14n + t15n) * -2 + yvv
+     + (-2 * t10n - 1 * psiv * t10n + yvv - 2 * t8n * yvv - 1 * psiv * t8n * yvv) * t6n)
+    * 0.5,                                                                      # c2
+    (t10n + t14n + t15n + t9n) * 0.5,                                           # c3
+]
+subs_map = {psi: Rational(8, 10), y: Rational(3, 10),
+            fa0: Rational(1, 10), fa1: Rational(2, 10),
+            ia0: Rational(7, 10), ia1: Rational(8, 10)}
+our_row = [float(cancel(c).subs(subs_map)) for c in derived]
+print(f"  interp_wall left case0 full row:")
+print(f"    ours = {our_row}")
+print(f"    cpp  = {cpp_row}")
+ok5b = all(abs(a - b_) < 1e-12 for a, b_ in zip(our_row, cpp_row))
+
+# 5c) End-to-end test oracle: the row must reproduce bf(x)=2x+1 at the eval point
+#     the C++ test checks. C++ "left 0": y_raw=0.3, psi=0.8, ymin=0,h=1; the
+#     orchestrator adjusts y->y+psi-1=0.1, and expects bf(ymin - h + y_raw*h)=bf(-0.7).
+y_adj = 0.1  # = y_raw + psi - 1
+xnodes = [-psiv, 0.0, 1.0, 2.0]  # wall, n0, n1, n2 (ymin=0,h=1)
+row_at_adj = [float(cancel(c).subs({psi: Rational(8, 10), y: Rational(1, 10),
+                                    fa0: Rational(1, 10), fa1: Rational(2, 10),
+                                    ia0: Rational(7, 10), ia1: Rational(8, 10)}))
+              for c in derived]
+bf = lambda x: 2 * x + 1
+interp_val = sum(row_at_adj[j] * bf(xnodes[j]) for j in range(4))
+expected = bf(-1 + 0.3)  # bf(ymin - h + y_raw*h)
+print(f"  bf reproduction: interp={interp_val}  expected bf(-0.7)={expected}")
+ok5c = abs(interp_val - expected) < 1e-12
+
+all_ok.append(
+    passed("numeric match vs C++ (interior 2pt + interp_wall full row + bf oracle)",
+           ok5a and ok5b and ok5c)
+)
+
+# ----------------------------------------------------------------------------
+print("=" * 72)
+print(f"SUMMARY: {sum(all_ok)}/{len(all_ok)} checks passed")
+print("=" * 72)
+if not all(all_ok):
+    raise SystemExit("ONE OR MORE CHECKS FAILED")
+print("ALL CHECKS PASSED -- the poly-interp -> derivative idea works in sympy.")

--- a/scripts/stencil_gen/docs/poly_interp_design.md
+++ b/scripts/stencil_gen/docs/poly_interp_design.md
@@ -1,0 +1,573 @@
+# Polynomial-Interpolation Cut-Cell Stencils — Design & Implementation Spec
+
+**Status:** ready to implement. **North star:** regenerate `src/stencils/polyE2_1.cpp`
+from sympy so it is numerically equivalent to the committed hand-port and `t-polyE2_1`
+still passes (47/48 → 48/48 contributions unchanged elsewhere).
+
+**Audience:** an engineer implementing the migration directly from this document.
+
+**Scope:** add the polynomial-interpolation derivation to the sympy framework
+(`scripts/stencil_gen/`) plus the codegen that emits real `interp_interior`/`interp_wall`
+bodies and a real `query_interp`. The derivative side (`nbs_floating`/`nbs_dirichlet`,
+`interior`) is *already* produced correctly by `generate_nbs_method`; this work is purely
+additive and gated behind `None`-default fields so no existing stencil/test changes.
+
+This spec is grounded in the live tree (file:line are current):
+- C++ north star: `src/stencils/polyE2_1.cpp`, test `src/stencils/polyE2_1.t.cpp`.
+- Orchestration contract: `src/stencils/stencil.hpp:213-270` (`stencil::interp`).
+- Mathematica routines: `taylor.wl:824-998` (+ supporting `40-57`, `401-408`, `511-517`).
+- Worked E2 derivation: `PolyE2_1.nb.pdf` (e2D pp.1-2, e2I pp.2-6).
+- Validated sympy prototype: `scripts/stencil_gen/_proto_interp.py` (7/7 checks pass).
+- Reuse targets: `taylor_system.py`, `interior.py`, `boundary.py`, `codegen.py`,
+  `printer.py`, `_util.py:solve_linear`.
+
+---
+
+## 1. Overview — the novel idea
+
+### 1.1 One polynomial, two extractions
+
+Define an **interpolation polynomial** stencil that approximates the field value at a
+fractional offset `y` from grid node `i`:
+
+```
+f[i+y] = Σ_j  gamma[i,j](y, psi, params) · f[node_j]          (the INTERP polynomial)
+```
+
+Each coefficient `gamma[i,j]` is a polynomial in `y` (degree ≤ scheme order) whose
+coefficients depend on the cut fraction `psi` and the scheme's free parameters. From the
+**same** polynomial set we take two products:
+
+1. **Interpolation stencil** — evaluate `gamma[i,j](y)` at the runtime `y`. Emitted by
+   `interp_interior` / `interp_wall`. Pure value interpolation, no `h`, no antisymmetry.
+2. **Derivative stencil** — `f'[i] = (1/h) · d/dy gamma[i,j](y)|_{y=0}`, because
+   `d/dy f[i+y]|_{y=0} = f'[i]`. Emitted by `nbs_floating` / `nbs_dirichlet`.
+
+### 1.2 Verified E2 example
+
+Interior interpolation on nodes `{-1, 0, 1}` (Taylor-match `f[i+y]`, RHS `y^k/k!`):
+
+```
+gamma[-1] = (y² − y)/2     gamma[0] = 1 − y²     gamma[1] = (y² + y)/2
+d/dy|_{y=0}:   −1/2                0                   +1/2     ← central difference ✓
+```
+
+(`PolyE2_1.nb.pdf` p.6 `int`; reproduced symbolically in `_proto_interp.py` CHECK 1–2:
+`d/dy|0` byte-equals `derive_interior(0,1,1)`.)
+
+### 1.3 One consistent free-parameter set: `fa` / `da` / `ia`
+
+The raw poly free parameters (`alpha`, `beta`) are renamed by `constrainInterp`
+(`taylor.wl:987-998`) to the scheme parameters. Every free DOF enters via the *blend*
+`polyBlend` (`taylor.wl:892`): a raw free coefficient `g → u + y·v`. Therefore:
+
+- **`fa` (floating)** — the `v` part, multiplying `y`. It **survives** `d/dy|_{y=0}`, so the
+  SAME `fa` set feeds **both** the interp wall rows and the floating derivative rows.
+- **`ia` (interp-only)** — the `u` part, sitting in the `y^0` term. It **vanishes** under
+  `d/dy|_{y=0}`, so it touches only the interpolation value, never the derivative.
+- **`da` (dirichlet)** — the floating derivative blend renamed `fa → da` for the Dirichlet
+  closure (`polyScheme` does `D[…,y]/.y->0`; the dirichlet flavor feeds `nbs_dirichlet`).
+
+Concrete witness (`PolyE2_1.nb.pdf` p.2, left row i=1, interior column):
+
+```
+gamma[1,1](y) = (1 + psi − y + ia0 + y·fa0) / (2(1+psi))
+   value (y=0)    = (1 + psi + ia0) / (2(1+psi))      ← ia only
+   d/dy|0         = (fa0 − 1)       / (2(1+psi))       ← fa only
+```
+
+This is the entire migration: build the interp polynomials once; the derivative falls out
+by `d/dy|0`; the three array splits (`fa[6]`, `da[3]`, `ia[4]`) are just three renamings of
+the same blended free parameters.
+
+### 1.4 The E2 C++ array contract (the target)
+
+| MMA symbol | meaning                      | `d/dy`? | params           | C++ method                     | array            |
+|------------|------------------------------|---------|------------------|--------------------------------|------------------|
+| `e2I`      | interp polynomials           | no      | `fa[0..5]`,`ia`  | `interp_interior`,`interp_wall`| `ia[4]`; shares `fa` |
+| `e2F`      | floating derivative rows     | yes,y=0 | `fa[0..5]`       | `nbs_floating`                 | `fa[6]` (3 rows×2) |
+| `e2D`      | dirichlet derivative rows    | yes,y=0 | `da[0..2]`       | `nbs_dirichlet`                | `da[3]`          |
+
+Packed-alpha split in `stencil.cpp` ("E2-poly"): `fa = alpha[0:6]`, `da = alpha[6:9]`,
+`ia = alpha[9:13]` — total 13 reals; `make_polyE2_1(fa, da, ia)` is also called with three
+separate Lua tables (`floating_alpha`, `dirichlet_alpha`, `interpolant_alpha`). **No C++ or
+CMake change is required** — `polyE2_1` is already fully wired.
+
+---
+
+## 2. New sympy module: `stencil_gen/interp.py`
+
+A new file mirroring the style of `boundary.py` / `interior.py`. It reuses the Vandermonde
+machinery and adds the interp RHS, the cut-cell wall rows, the `d/dy|0` map, and the
+`constrain_interp` renaming.
+
+### 2.1 The single structural change: interp RHS helper (in `taylor_system.py`)
+
+The Vandermonde matrix `V[k,j] = (j−i)^k/k!` (`taylor_system.py:38-44`) is identical for
+derivative and interpolation. **Only the RHS differs.** Add to `taylor_system.py`:
+
+```python
+def _interp_rhs(n_eqs: int, y) -> Matrix:
+    """Column vector rhs[k] = y**k / k! — the Taylor-evaluation functional at offset y.
+
+    Derivation: f[i+y] = Σ_k f^(k)[i] y^k/k!, so to reproduce f[i] (and its moments)
+    the coefficients must satisfy Σ_j c_j (j-i)^k = y^k, i.e. rhs[k] = y^k/k!.
+    This is the interpolation analogue of _unit_rhs (taylor_system.py:10).
+    factorial is already imported (taylor_system.py:7)."""
+    return Matrix(n_eqs, 1, lambda k, _: y**k / factorial(k))
+
+
+def build_interp_system(i: int, t: int, q: int, y) -> tuple[Matrix, Matrix]:
+    """Interpolation analogue of build_taylor_system. Reuses V verbatim; swaps the
+    RHS to the eval-at-y functional. Returns (V, rhs)."""
+    V, _ = build_taylor_system(i, t, q, nu=1)   # reuse the matrix only
+    return V, _interp_rhs(q + 1, y)
+```
+
+(`build_taylor_system` builds `V` independent of `nu`; reusing it for `V` is exact.)
+
+### 2.2 Dataclasses
+
+```python
+@dataclass
+class InterpInterior:
+    """Interior interpolation polynomials (Mathematica interiorInterp, taylor.wl:832-835).
+    coeffs has length 2*p+1, each a polynomial in y. For p=1: [(y²-y)/2, 1-y², (y²+y)/2].
+    runtime_p / runtime_coeffs hold the *shipped* low-order form (see §6.1): a 2-point
+    linear interp selected by sign(y), which is what query_interp().p and interp_interior
+    actually emit."""
+    coeffs: list           # full 2p+1 polynomial (used to DERIVE the interior derivative)
+    p: int
+    runtime_p: int         # = query_interp().p  (2 for E2)
+    runtime_pos: list      # length runtime_p, the y>0 branch weights (e.g. [1-y, y])
+    runtime_neg: list      # length runtime_p, the y<=0 branch weights (e.g. [-y, 1+y])
+
+
+@dataclass
+class InterpRow:
+    """One cut-cell interpolation wall row (Mathematica polyInterpSchemes output,
+    taylor.wl:901-933). coeffs is length T, each Expr in (y, psi, fa_k, ia_k).
+    Column order matches C++: left -> [wall, node, node, node]; right -> [node,node,node,wall]."""
+    row_index: int         # i (0..R-2): cell-distance wall->closest node
+    coeffs: list
+    fa_syms: list          # the fa (floating) symbols used in this row's y^1 terms
+    ia_syms: list          # the ia (interp-only) symbols used in this row's y^0 terms
+
+
+@dataclass
+class InterpResult:
+    """Full interp side of a poly stencil — the codegen feed."""
+    interior: InterpInterior
+    left_rows: list        # R-1 InterpRow for the left/interior wall (cases 0..R-2)
+    right_rows: list       # R-1 InterpRow for the right wall (mirror, independently derived)
+    interp_P: int          # query_interp().p (= interior.runtime_p)
+    interp_T: int          # query_interp().t (= T)
+    y: Symbol
+    psi: Symbol
+```
+
+### 2.3 Functions
+
+```python
+def derive_interior_interp(p: int, y: Symbol) -> InterpInterior:
+    """Mathematica interiorInterp (taylor.wl:832-835). Solve Σ_{j=-p..p} gamma_j f[i+j]
+    = f[i+y] on a centered uniform 2p+1 stencil via build_interp_system over deltas
+    {-p..p}. Entries are exact in y (no psi), so Matrix.solve + cancel suffices (no
+    solve_in_field). Returns InterpInterior with the full 2p+1 polynomial AND the shipped
+    2-point linear runtime form (the bracketing-pair Lagrange weights selected by sign(y);
+    see §6.1). For p=1: full=[(y²-y)/2, 1-y², (y²+y)/2]; runtime_pos=[1-y, y],
+    runtime_neg=[-y, 1+y]."""
+
+
+def derivative_from_interp(interp_coeffs: list, y: Symbol, nu: int = 1) -> list:
+    """THE NOVEL CORE. f^(nu)[i] = d^nu/dy^nu f[i+y]|_{y=0}. Two lines:
+        return [cancel(diff(c, y, nu).subs(y, 0)) for c in interp_coeffs].
+    Verified: [(y²-y)/2, 1-y², (y²+y)/2] -> [-1/2, 0, 1/2]. Maps Mathematica polyScheme's
+    `MapAt[D[#,y]&, ...] /. y->0` (taylor.wl:954). Because each coeff is (poly in y, linear
+    in ia=u and fa=v), d/dy|0 kills the ia (y^0) part and keeps fa (y^1)."""
+
+
+def solve_interp_row(
+    i: int, T: int, q: int, y: Symbol, psi: Symbol,
+    zeroed_col: int, free_symbols: list,
+) -> list:
+    """ONE variant of a cut-cell wall row (one schemeCoefficients call inside
+    polyInterpSchemes). Cut-cell analogue of boundary.solve_boundary_row (boundary.py:27),
+    but with two differences:
+      (1) RHS = _interp_rhs(q+1, y) instead of _unit_rhs;
+      (2) deltas are cut-cell positions, not 0..T-1 (see §5.2: [-psi, 0, 1, 2] for E2 left).
+    Drops `zeroed_col` (polyZero, taylor.wl:885-890), partitions remaining columns into
+    determined (q+1) + free (the rest assigned `free_symbols`), and solves via Matrix.solve
+    over QQ(psi)[y] with cancel (y never enters a denominator for E2; if a future scheme
+    needs it, route through temo.solve_in_field). Returns length-T list of Expr."""
+
+
+def derive_cut_cell_interp(
+    p: int, q: int, psi: Symbol, y: Symbol,
+    fa_syms: list, ia_syms: list,
+    left: bool = True,
+) -> list:
+    """Mathematica polyInterpBoundary (taylor.wl:973-984): map polyInterpSchemes over the
+    R-1 wall rows. For each row i:
+      - run solve_interp_row TWICE with the two zeroed columns (polyZero variant k=1,2);
+      - apply the polyBlend: each raw free param -> (ia_k + y*fa_k) (poly_constrain_free);
+      - simpleAverage the two variant results coeff-by-coeff (taylor.wl:899);
+    Returns a list of length-T coeff lists (NOT yet renamed). The SAME (ia_k, fa_k) must
+    feed both variants so the average stays linear in them. Build right rows by passing
+    left=False and the right-anchored cut-cell deltas."""
+
+
+def constrain_interp(
+    rows: list, fa_syms: list, ia_syms: list, left: bool,
+) -> list:
+    """Mathematica constrainInterp (taylor.wl:987-998). Renames the raw blend symbols to
+    the final scheme symbols in the order the C++ arrays expect:
+      - LEFT: ascending column order   -> v->fa_k, u->ia_k for k=0,1,2,...
+      - RIGHT: descending/right-anchored order (taylor.wl:991-994 SortBy[-First...]).
+    THE CRITICAL CORRECTNESS POINT — the assignment order picks which fa[k]/ia[k] lands in
+    which coefficient and must match polyE2_1.cpp exactly (see §6.3). Returns rows with
+    fa_k/ia_k substituted; symbols already named fa_0, ia_0, ... so printer.build_symbol_map
+    emits fa[0], ia[0] with no remap."""
+
+
+def derive_poly_interp(p: int, q: int) -> InterpResult:
+    """Top-level orchestrator for the interp side. Allocates psi, y, the shared fa symbols
+    (same names as the derivative scheme's renamed floating params) and new ia symbols, then:
+      interior   = derive_interior_interp(p, y)
+      left_rows  = constrain_interp(derive_cut_cell_interp(..., left=True),  ..., left=True)
+      right_rows = constrain_interp(derive_cut_cell_interp(..., left=False), ..., left=False)
+    Wraps everything in InterpResult. For E2: p=1, q=2, interp_T=4, interp_P=2."""
+```
+
+### 2.4 Reuse summary
+
+| New thing | Reuses |
+|---|---|
+| `build_interp_system` | `build_taylor_system` (matrix) + new `_interp_rhs` |
+| `derive_interior_interp` | `build_interp_system`, `Matrix.solve`, `cancel`; cross-check vs `derive_interior` |
+| `solve_interp_row` | `boundary.solve_boundary_row` structure; `temo.build_cut_cell_deltas` for the cut-cell layout; `_util.solve_linear` / `Matrix.solve` |
+| `derivative_from_interp` | `sympy.diff`, `cancel` — output must equal `generate_nbs_method`'s coeffs |
+| `constrain_interp` | `printer.build_symbol_map` naming convention (`fa_0` → `fa[0]`) |
+
+### 2.5 Mathematica → sympy routine map (full)
+
+| Mathematica (`taylor.wl`) | sympy (`interp.py`) | note |
+|---|---|---|
+| `interiorInterp` 825-835 | `derive_interior_interp` | RHS swap only |
+| `boundaryInterp` 837-843 | (folded into `solve_interp_row`) | uniform precursor; optional standalone |
+| `interpSymbol` 861-863 | — | dropped; pass `y` explicitly |
+| `polyZero` 885-890 | `zeroed_col` arg to `solve_interp_row` | 0-based column index |
+| `polyBlend` 892-893 | the `u + y*v` substitution inside `derive_cut_cell_interp` | the fa/ia split |
+| `polyConstrainFree` 894-896 | per-row blend application | |
+| `simpleAverage` 899 | `(a+b)/2` element-wise in `derive_cut_cell_interp` | yields the `0.5 *` factors |
+| `polyInterpSchemes` 901-933 | `solve_interp_row` ×2 + blend + average | central routine |
+| `polyScheme`/`polyBoundary` 936-971 | `derivative_from_interp` | `D[#,y]/.y->0` |
+| `polyInterpBoundary` 973-984 | `derive_cut_cell_interp` | map over rows |
+| `constrainInterp` 987-998 | `constrain_interp` | rename + ordering |
+| `bIndex`/`rIndex` 401-408, `stencilColRange` 515-517 | cut-cell deltas in `solve_interp_row` | wall = col 0 (left) |
+
+---
+
+## 3. Codegen changes (`codegen.py` + `printer.py`)
+
+All additive; gated on new `None`-default fields so every existing spec keeps emitting the
+current no-op interp stubs.
+
+### 3.1 New `StencilGenSpec` fields (after `interp_T`, `codegen.py:261`)
+
+```python
+    # Interp bodies. None => emit the existing no-op stubs (back-compat).
+    interp_interior_pos: list | None = None   # y>0 branch weights, length interp_P
+    interp_interior_neg: list | None = None   # y<=0 branch weights, length interp_P
+    interp_wall_left_rows: list | None = None   # (R-1) rows, each length T, Expr in y/psi/fa/ia
+    interp_wall_right_rows: list | None = None  # (R-1) rows, mirror
+```
+
+`has_interp` continues to gate `query_interp`; the new lists gate the real bodies.
+
+### 3.2 `printer.py` — handle symbol `y`
+
+`Symbol('y')` already prints as `y` via the `_print_Symbol` fallback (`printer.py:62-65`),
+so this is defensive only. Add in `build_symbol_map` right before the `h` mapping
+(`printer.py:94`):
+
+```python
+    smap[Symbol("y")] = "y"
+```
+
+No `/h` is applied to interp coeffs, so there is no h-division concern here.
+
+### 3.3 `_emit_query_methods` — thread `printer`, conditionally emit real bodies
+
+Change the signature to `def _emit_query_methods(spec, printer):` and update the call site
+in `generate_stencil_cpp` (`codegen.py:557`) to `_emit_query_methods(spec, printer)`.
+`query_max`/`query`/`query_interp` (`codegen.py:355-377`) are unchanged. Replace the no-op
+block (`codegen.py:379-389`) with:
+
+```python
+    lines.append("")
+    if spec.interp_interior_pos is not None:
+        lines.append(generate_interp_interior_method(
+            spec.interp_interior_pos, spec.interp_interior_neg, printer))
+    else:
+        lines.append(f"{indent}std::span<const real> interp_interior(real, std::span<real> c) const {{ return c; }}")
+    lines.append("")
+    if spec.interp_wall_left_rows is not None:
+        lines.append(generate_interp_wall_method(spec, printer))
+    else:
+        lines.extend([
+            f"{indent}std::span<const real> interp_wall(int, real, real, std::span<real> c, bool) const",
+            f"{indent}{{", f"{indent8}return c;", f"{indent}}}",
+        ])
+```
+
+### 3.4 `generate_interp_interior_method` — new helper
+
+Match `polyE2_1.cpp:46-56` exactly. Two sign branches (the `y>0` branch corresponds to the
+`st1/st2` swap at `stencil.hpp:225-227`), `subspan(0, interp_P)`, **no h, no CSE** (literals
+direct for p=2):
+
+```python
+def generate_interp_interior_method(pos, neg, printer) -> str:
+    indent, indent8 = "    ", "        "
+    lines = [f"{indent}std::span<const real> interp_interior(real y, std::span<real> c) const",
+             f"{indent}{{", f"{indent8}if (y > 0) {{"]
+    for j, c in enumerate(pos):
+        lines.append(f"{indent8}    c[{j}] = {printer.doprint(c)};")
+    lines.append(f"{indent8}}} else {{")
+    for j, c in enumerate(neg):
+        lines.append(f"{indent8}    c[{j}] = {printer.doprint(c)};")
+    lines += [f"{indent8}}}", f"{indent8}return c.subspan(0, {len(pos)});", f"{indent}}}"]
+    return "\n".join(lines)
+```
+
+For E2: `pos = [1 - y, y]` prints as `1 + -1 * y` and `y`; `neg = [-y, 1 + y]` prints as
+`-1 * y` and `1 + y`. (Printer renders `1 - y` as `1 + -1 * y` — matches the committed file.)
+
+### 3.5 `generate_interp_wall_method` — new helper (the big one)
+
+Match `polyE2_1.cpp:58-139`. Structure is **inverted** vs `nbs`: `if (right) {...} else {...}`
+outermost, `switch (i)` inside each branch, CSE applied **per branch over the whole branch's
+coefficient list** (the `t5,t6,...` pool is shared across `case 0` and `case 1`):
+
+```python
+def generate_interp_wall_method(spec, printer) -> str:
+    indent, indent8 = "    ", "        "
+    out = [f"{indent}std::span<const real>",
+           f"{indent}interp_wall(int i, real y, real psi, std::span<real> c, bool right) const",
+           f"{indent}{{",
+           f"{indent8}if (right) {{"]
+    out += _emit_interp_switch(spec.interp_wall_right_rows, printer, depth=3)
+    out.append(f"{indent8}}} else {{")
+    out += _emit_interp_switch(spec.interp_wall_left_rows, printer, depth=3)
+    out += [f"{indent8}}}", f"{indent8}return c.subspan(0, {spec.interp_T});", f"{indent}}}"]
+    return "\n".join(out)
+
+
+def _emit_interp_switch(rows, printer, depth) -> list:
+    ind = "    " * depth
+    flat = [e for row in rows for e in row]          # CSE over the whole branch
+    repls, reduced = apply_cse(flat, start=5)        # start=5 matches the hand file
+    lines = [f"{ind}const real {sym.name} = {printer.doprint(e)};" for sym, e in repls]
+    lines.append(f"{ind}switch (i) {{")
+    k = 0
+    for ci, row in enumerate(rows):
+        lines.append(f"{ind}case {ci}:")
+        for j in range(len(row)):
+            lines.append(f"{ind}    c[{j}] = {printer.doprint(reduced[k])};")
+            k += 1
+        lines.append(f"{ind}    break;")
+    lines.append(f"{ind}}}")
+    return lines
+```
+
+Behavioral asymmetry vs `nbs` (must NOT be copied from `generate_nbs_method`):
+- **No `/h`** — interp is value-based.
+- **No `*= -1` + `std::ranges::reverse`** for `right` — the right branch is a *separately
+  derived mirror stencil* (right wall), already correct as emitted.
+- **Column order moves the wall**: left → `c[0]` is the wall (carries `1/(1+psi)`),
+  `c[1..T-1]` interior nodes increasing-x; right → `c[T-1]` is the wall, `c[0..T-2]` interior.
+- **`1/(1+psi)`** is produced automatically by `StencilCodePrinter._print_Pow` (exp==-1,
+  `printer.py:28-30`) acting on `(1+psi)**-1` and hoisted by CSE as `t16/t17` (right) or
+  `t5/t6` (left) — no special handling.
+- **No `default:`** in the switch (the hand file omits it; emit exactly `R-1` cases).
+
+### 3.6 Assembly (`build_polyE2_1_spec`)
+
+Add a thin orchestrator (in `interp.py` or a small `poly_assemble.py`) wired from
+`__main__.py`'s `generate` stub (`__main__.py:25-30`):
+
+1. Derive the derivative side (existing path) → flatten the floating matrix into
+   `floating_coeffs` (R·T) and the dirichlet matrix into `dirichlet_coeffs` (R·T; codegen
+   drops row 0 at `codegen.py:482`). Use the **shared** `fa` symbols.
+2. `res = derive_poly_interp(p=1, q=2)` → populate `interp_interior_pos/neg`,
+   `interp_wall_left_rows`, `interp_wall_right_rows`, `has_interp=True`,
+   `interp_P=res.interp_P` (2), `interp_T=res.interp_T` (4).
+3. `param_arrays = {"fa": 6, "da": 3, "ia": 4}`; `P=1, R=3, T=4, X=0`; `is_uniform=False`.
+4. `generate_stencil_cpp(spec)` → `output/polyE2_1.cpp`.
+
+`_emit_struct_preamble` (`codegen.py:315-325`, multi-array ctor) and `_emit_factory`
+(`codegen.py:527-538`) already emit the 3-arg `fa/da/ia` constructor + factory; `LUA_KEY_MAP`
+(`codegen.py:583-588`) already maps `fa/da/ia` → `floating_alpha/dirichlet_alpha/interpolant_alpha`.
+
+---
+
+## 4. Golden / test plan
+
+Run sympy tests from `scripts/stencil_gen` with `SYMPY_CACHE_SIZE=50000 uv run pytest`.
+
+### 4.1 Symbolic golden + derivation correctness — `tests/test_interp.py` (new)
+
+| test name | assertion |
+|---|---|
+| `test_interior_interp_golden` | `derive_interior_interp(1, y).coeffs == [(y²-y)/2, 1-y², (y²+y)/2]` via `cancel(a-e)==0` (`PolyE2_1.nb.pdf` p.6) |
+| `test_interior_runtime_2pt` | `runtime_pos == [1-y, y]`, `runtime_neg == [-y, 1+y]` |
+| `test_derivative_from_interp_central` | `derivative_from_interp([(y²-y)/2,1-y²,(y²+y)/2], y) == [-1/2, 0, 1/2]` and equals `full_gamma_array(derive_interior(0,1,1))` |
+| `test_left_row0_golden` | left wall row i=0 coeffs match `PolyE2_1.nb.pdf` p.2 `gamma[1,·]` (column-reordered to C++ `[wall,node,node,node]`); `cancel(diff)==0` per column |
+| `test_left_row1_golden` | left wall row i=1 matches p.3 `gamma[2,·]` |
+| `test_right_rows_golden` | right rows match p.4-5 `gamma[n-1,·]`, `gamma[n,·]` |
+| `test_ia_vanishes_under_ddy` | for every wall coeff, `ia_k ∉ derivative_from_interp(row).free_symbols`; `fa_k ∈` |
+| `test_value_deriv_decoupling` | `gamma|y=0` free syms ⊂ {ia,psi}; `d/dy|0` free syms ⊂ {fa,psi}; O(y²) remainder == 0 (`_proto_interp.py` CHECK 4) |
+| `test_interp_exactness` | for each row deltas `δ_j`: `Σ_j c_j δ_j^k == y^k` for `k=0..q` (interp analogue of `conftest._check_taylor_accuracy`) |
+| `test_duality_vs_nbs` | `derivative_from_interp(left_row_i)` (pre-`/h`) equals the corresponding `nbs_floating` row from the derivative path, for all i |
+
+### 4.2 Codegen emission shape — `tests/test_codegen.py` (extend `poly_spec`)
+
+Populate the new `interp_*` fields on the existing `poly_spec` (`test_codegen.py:506`), then
+assert substrings in `generate_stencil_cpp(spec)`:
+
+- `interp_info query_interp() const { return {2, 4}; }`
+- `std::span<const real> interp_interior(real y, std::span<real> c) const`, `if (y > 0) {`,
+  `return c.subspan(0, 2);`
+- `interp_wall(int i, real y, real psi, std::span<real> c, bool right) const`, `if (right) {`,
+  `switch (i) {`, `case 0:`, `case 1:`, `return c.subspan(0, 4);`
+- `const real t5 =` (CSE present)
+- **Negative**: `interp_wall` body contains no `/= h` and no `std::ranges::reverse`.
+
+### 4.3 Numeric match vs the hard-coded C++ arrays
+
+| oracle | source | check |
+|---|---|---|
+| dirichlet coeffs | `polyE2_1.t.cpp:63-70` (8 floats, `psi=0.001, h=1, da=[0.12,0.13,0.14]`) | regenerated `nbs_dirichlet` symbolic eval reproduces the array to `1e-12` (derivative path — should already pass) |
+| interp_interior scan | `polyE2_1.t.cpp:249-265` (11 y-values) | `Σ v·bf(mesh) == bf(mesh[center]+y·h)`, `center=1-(y>0)` |
+| interp_wall left/right ×4 | `polyE2_1.t.cpp:294-363` | each of left0/left1/right0/right1 reproduces the stated `bf(...)`; use fixed `fa=[0.1..0.6]`, `ia=[0.7,0.8,0.9,1.0]` for a deterministic diff vs the committed C++ formulas (`_proto_interp.py` CHECK 5 pattern; extend `tools/eval_e2_1.py` with `parse_interp_wall`) |
+
+Important `y`-coordinate detail (from `stencil.hpp:250,264`): `interp_wall` receives the
+**post-adjusted** `y` (the orchestrator adds `psi-1` on the left when `lc==ic`, `1-psi` on the
+right when `rc==ic`). The symbolic rows must be written in that adjusted coordinate; the
+deltas are `[-psi, 0, 1, 2]` (left) — see §6.2.
+
+### 4.4 Capstone — regenerate and prove equivalence
+
+`tests/test_codegen_poly.py` (new) or a marked test in `test_codegen.py`:
+
+1. `spec = build_polyE2_1_spec(); code = generate_stencil_cpp(spec)`.
+2. **Numeric equivalence** (not byte equivalence — CSE temp names/ordering may differ):
+   parse both the regenerated `code` and the committed `src/stencils/polyE2_1.cpp` with the
+   `tools/eval_e2_1.py` harness and assert agreement to `1e-12` across a sampled grid of
+   `(y, psi, fa, ia, da)` for `interp_interior`, `interp_wall`, `nbs_floating`, `nbs_dirichlet`.
+3. **Cross-method duality at the C++ level**: numerically differentiate the generated
+   `interp_wall` w.r.t. `y` at `y=0` and assert it equals generated `nbs_floating`/`nbs_dirichlet`
+   (after `/h`).
+4. **The definition of done**: write `code` to `src/stencils/polyE2_1.cpp`, then
+   `cmake --build build --target t-polyE2_1 && ctest --test-dir build -R t-polyE2_1` passes
+   (all six TEST_CASEs unchanged). Optionally keep a `--update-golden` flag (sweeps' pattern)
+   so the committed file is refreshed deliberately, not on every run.
+
+---
+
+## 5. Step-by-step implementation checklist (ordered, each independently verifiable)
+
+1. **`_interp_rhs` + `build_interp_system`** in `taylor_system.py`.
+   *Verify:* `build_interp_system(0, 3, 2, y)[1] == Matrix([1, y, y²/2])`.
+2. **`derive_interior_interp`** in new `interp.py`.
+   *Verify:* `.coeffs == [(y²-y)/2, 1-y², (y²+y)/2]`; `.runtime_pos == [1-y, y]`.
+3. **`derivative_from_interp`**.
+   *Verify:* central diff `[-1/2,0,1/2]`; equals `full_gamma_array(derive_interior(0,1,1))`.
+4. **Cut-cell deltas + `solve_interp_row`** (single variant).
+   *Verify:* with E2 left deltas `[-psi,0,1,2]` and one zeroed column, the resulting row is
+   degree-1 exact: `Σ_j c_j δ_j^k == y^k` for `k=0,1`.
+5. **`derive_cut_cell_interp`** (two variants + polyBlend + simpleAverage).
+   *Verify:* left row i=0 matches `PolyE2_1.nb.pdf` p.2 `gamma[1,·]` symbolically (modulo
+   column order); the `0.5 *` factors and `1/(1+psi)` denominators appear.
+6. **`constrain_interp`** (left ascending / right descending ordering).
+   *Verify:* the renamed rows reproduce the exact `fa[k]`/`ia[k]` indices in
+   `polyE2_1.cpp` cases 0/1 for both branches (§6.3).
+7. **`derive_poly_interp`** orchestrator + cross-check duality.
+   *Verify:* `derivative_from_interp` of each left/right row equals the `nbs_floating` rows
+   from the derivative path (`_proto_interp.py` CHECK 3 final cross-check).
+8. **printer.py**: add `smap[Symbol("y")] = "y"`. *Verify:* `test_printer` still green;
+   `printer.doprint(1 - y) == "1 + -1 * y"`.
+9. **codegen.py**: add 4 `StencilGenSpec` fields; add `generate_interp_interior_method`,
+   `generate_interp_wall_method`, `_emit_interp_switch`; thread `printer` into
+   `_emit_query_methods` and update the call site.
+   *Verify:* `tests/test_codegen.py` substring assertions (§4.2); existing codegen tests green.
+10. **`build_polyE2_1_spec`** + wire `__main__.py generate polyE2_1`.
+    *Verify:* `uv run python -m stencil_gen generate polyE2_1` writes `output/polyE2_1.cpp`.
+11. **Numeric equivalence harness** (`tools/eval_e2_1.py` += `parse_interp_wall`/`parse_interp_interior`).
+    *Verify:* regenerated vs committed agree to `1e-12` on all four methods.
+12. **Capstone**: copy `output/polyE2_1.cpp` → `src/stencils/polyE2_1.cpp`;
+    `cmake --build build --target t-polyE2_1 && ctest --test-dir build -R t-polyE2_1` passes.
+
+---
+
+## 6. Risks / open questions (and resolutions)
+
+### 6.1 2-point linear vs 3-point quadratic interior interp (RESOLVE: match the C++)
+
+Mathematica `interiorInterp` for E2 yields the 3-point quadratic `[(y²-y)/2, 1-y², (y²+y)/2]`.
+But `polyE2_1.cpp:46-56` ships a **2-point linear** interp selected by `sign(y)`
+(`query_interp().p == 2`), because `stencil::interp` (`stencil.hpp:225-227`) picks a 2-node
+bracketing window via the `st1/st2` swap. **Resolution:** derive the full 3-point polynomial
+(needed to derive the *interior derivative* `[-1/2,0,1/2]`), but emit the 2-point linear
+runtime form (`runtime_pos/neg`) for `interp_interior`. `InterpInterior` carries both. This
+is a deliberate divergence for runtime compatibility, not an error.
+
+### 6.2 Cut-cell delta layout (RESOLVE: deltas are `[-psi, 0, 1, 2]`, y is post-adjusted)
+
+The prior port-spec guidance used deltas `[0, psi, 1+psi, 2+psi]`; the prototype proved that
+**wrong** (no exactness beyond k=1). The correct E2 left layout, reverse-engineered from the
+test (`polyE2_1.t.cpp:294-309`) and confirmed in `_proto_interp.py`, is node x-positions
+`[-psi, 0, 1, 2]` = `[wall, node0, node1, node2]`, with the interp target at `x = -psi + y`
+where `y` is the **post-adjustment** value (`stencil::interp` already applied `±(psi-1)`).
+Skipping that adjustment leaves a spurious `1-psi` residual. **Resolution:** build
+`solve_interp_row` with these deltas; document the post-adjusted-`y` convention in the
+docstring; assert §4.1 exactness against `Σ c_j δ_j^k = y^k`.
+
+### 6.3 `constrain_interp` ordering is load-bearing (RESOLVE: cross-check against C++)
+
+The left vs right rename order differs (`taylor.wl:987-990` ascending vs `991-994`
+descending). It determines which `fa[k]`/`ia[k]` lands in which coefficient. Concretely
+(`polyE2_1.cpp`): left case0 → `fa[0],fa[1],ia[0],ia[1]`; left case1 → `fa[2],fa[3],ia[2],ia[3]`;
+the right branch mirrors these. Also note the shared `fa` set spans both: `fa[0..3]` appear in
+both interp and floating-derivative rows, while `fa[4..5]` are floating-only (the third
+derivative row has no interp wall row). **Resolution:** implement both orderings; the
+capstone numeric-equivalence test (§4.4) is the gate. The prototype warns that a naive
+"zero-and-average" without the correct variant column choice + sort does NOT reproduce the
+golden basis combination.
+
+### 6.4 Solver field for the `(psi, y)` 2-variable solve (RESOLVE: Matrix.solve + cancel)
+
+E2 entries are rational in `psi` and polynomial in `y`; `y` never enters a denominator
+(denominators are only `2(1+psi)`). `Matrix.solve` + `cancel` per coefficient is exact and
+fast (with `SYMPY_CACHE_SIZE=50000`). **Resolution:** use `Matrix.solve` for E2; if a future
+higher-order scheme puts `y` in a denominator, route through `temo.solve_in_field`
+(`temo.py:828`) over `QQ.frac_field(psi)` treating `y` powers as alpha-like terms.
+
+### 6.5 Right branch is NOT reverse+negate (RESOLVE: derive separately)
+
+Unlike `nbs` (which does `*= -1` + `reverse` for `right`), `interp_wall`'s right branch is a
+genuinely separate derivation (interpolation is value-based, no antisymmetry; the wall column
+also moves from `c[0]` to `c[T-1]`). **Resolution:** `derive_cut_cell_interp(left=False)`
+with right-anchored deltas + `constrain_interp(left=False)`; `generate_interp_wall_method`
+must NOT reuse the `nbs` `/h`/reverse tail.
+
+### 6.6 Open question — generalization beyond E2
+
+This spec targets E2 (the north star). Higher-order poly stencils (E4-poly, etc.) need
+`R-1 > 2` wall rows, larger `T`, the `boundaryInterpWithInterior` near-interior row
+(`taylor.wl:845-859`), and the general `bIndex`/`rIndex`/`stencilColRange` indexing
+(`taylor.wl:401-408, 515-517`) rather than the E2 hard-coded `[-psi,0,1,2]` layout. Keep
+`derive_cut_cell_interp` parameterized by `(p, q)` and the deltas factored through a
+`build_cut_cell_interp_deltas(i, T, psi, left)` helper so the E2 path is a special case.
+Defer E4-poly until E2 round-trips through the capstone test.

--- a/scripts/stencil_gen/output/polyE2_1.cpp
+++ b/scripts/stencil_gen/output/polyE2_1.cpp
@@ -1,0 +1,235 @@
+#include "stencil.hpp"
+
+#include <algorithm>
+
+#include <cmath>
+
+namespace ccs::stencils
+{
+struct polyE2_1 {
+
+    static constexpr int P = 1;
+    static constexpr int R = 3;
+    static constexpr int T = 4;
+    static constexpr int X = 0;
+
+    std::array<real, 6> fa;
+    std::array<real, 3> da;
+    std::array<real, 4> ia;
+
+    polyE2_1() = default;
+    polyE2_1(std::span<const real> fa_,
+             std::span<const real> da_,
+             std::span<const real> ia_)
+    {
+        copy_zero_padded(fa_, fa);
+        copy_zero_padded(da_, da);
+        copy_zero_padded(ia_, ia);
+    }
+
+    info query_max() const { return {P, R, T, X}; }
+    info query(bcs::type b) const
+    {
+        switch (b) {
+        case bcs::Dirichlet:
+            return {P, R - 1, T, 0};
+        case bcs::Floating:
+            return {P, R, T, 0};
+        case bcs::Neumann:
+            return {};
+        default:
+            return {};
+        }
+    }
+    interp_info query_interp() const { return {2, 4}; }
+
+    std::span<const real> interp_interior(real y, std::span<real> c) const
+    {
+        if (y > 0) {
+            c[0] = 1 - y;
+            c[1] = y;
+        } else {
+            c[0] = -y;
+            c[1] = y + 1;
+        }
+        return c.subspan(0, 2);
+    }
+
+    std::span<const real>
+    interp_wall(int i, real y, real psi, std::span<real> c, bool right) const
+    {
+        if (right) {
+            const real t5 = (1.0 / 2)*y;
+            const real t6 = fa[0]*t5 + (1.0 / 2)*ia[0];
+            const real t7 = 2*psi;
+            const real t8 = 1.0 / (t7 + 2);
+            const real t9 = 2*y;
+            const real t10 = psi*y;
+            const real t11 = t7*y;
+            const real t12 = t10 + t9;
+            const real t13 = t5 + 1.0 / 2;
+            const real t14 = y + 1;
+            const real t15 = fa[2]*t5 + (1.0 / 2)*ia[2];
+            switch (i) {
+            case 0:
+                c[0] = fa[1]*t5 + (1.0 / 2)*ia[1] + t6;
+                c[1] = t8*(-fa[0]*t11 - fa[0]*t9 - fa[1]*t10 - fa[1]*t9 - ia[0]*t7 - 2*ia[0] - ia[1]*psi - 2*ia[1] - psi * psi - psi - t12);
+                c[2] = (1.0 / 2)*psi + t13 + t6;
+                c[3] = t8*(fa[1]*y + ia[1] + psi + t14);
+                break;
+            case 1:
+                c[0] = fa[3]*t5 + (1.0 / 2)*ia[3] + t15;
+                c[1] = t8*(-fa[2]*t11 - fa[2]*t9 - fa[3]*t10 - fa[3]*t9 - ia[2]*t7 - 2*ia[2] - ia[3]*psi - 2*ia[3] + psi - t12);
+                c[2] = t13 + t15;
+                c[3] = t8*(fa[3]*y + ia[3] + t14);
+                break;
+            }
+        } else {
+            const real t5 = 2*psi;
+            const real t6 = 1.0 / (t5 + 2);
+            const real t7 = fa[1]*y;
+            const real t8 = 1 - y;
+            const real t9 = (1.0 / 2)*y;
+            const real t10 = fa[0]*t9 + (1.0 / 2)*ia[0];
+            const real t11 = 1.0 / 2 - t9;
+            const real t12 = 2*y;
+            const real t13 = t5*y;
+            const real t14 = -psi*y - 2*y;
+            const real t15 = fa[2]*t9 + (1.0 / 2)*ia[2];
+            switch (i) {
+            case 0:
+                c[0] = t6*(ia[1] + psi + t7 + t8);
+                c[1] = (1.0 / 2)*psi + t10 + t11;
+                c[2] = t6*(-fa[0]*t12 - fa[0]*t13 - ia[0]*t5 - 2*ia[0] - ia[1]*psi - 2*ia[1] - psi * psi - psi*t7 - psi - t14 - 2*t7);
+                c[3] = (1.0 / 2)*ia[1] + t10 + (1.0 / 2)*t7;
+                break;
+            case 1:
+                c[0] = t6*(fa[3]*y + ia[3] + t8);
+                c[1] = t11 + t15;
+                c[2] = t6*(-fa[2]*t12 - fa[2]*t13 - fa[3]*psi*y - fa[3]*t12 - ia[2]*t5 - 2*ia[2] - ia[3]*psi - 2*ia[3] + psi - t14);
+                c[3] = fa[3]*t9 + (1.0 / 2)*ia[3] + t15;
+                break;
+            }
+        }
+        return c.subspan(0, 4);
+    }
+
+    std::span<const real> interior(real h, std::span<real> c) const
+    {
+        c = c.subspan(0, 2 * 1 + 1);
+        c[0] = -0.5;
+        c[1] = 0;
+        c[2] = 0.5;
+        for (auto&& v : c) v /= h;
+        return c;
+    }
+
+    std::span<const real> nbs(real h,
+                              bcs::type b,
+                              real psi,
+                              bool right,
+                              std::span<real> c,
+                              std::span<real>) const
+    {
+        switch (b) {
+        case bcs::Floating:
+            return nbs_floating(h, psi, c, right);
+        case bcs::Dirichlet:
+            return nbs_dirichlet(h, psi, c, right);
+        default:
+            return c;
+        }
+    }
+
+    std::span<const real>
+    nbs_floating(real h, real psi, std::span<real> c, bool right) const
+    {
+        c = c.subspan(0, R * T);
+
+        real t5 = 2*psi;
+        real t6 = 1.0 / (t5 + 2);
+        real t7 = (1.0 / 2)*fa[0];
+        real t8 = -psi - 2;
+        real t9 = (1.0 / 2)*fa[2];
+        real t10 = (1.0 / 2)*fa[4];
+
+        c[0] = t6*(fa[1] - 1);
+        c[1] = t7 - 1.0 / 2;
+        c[2] = t6*(-fa[0]*t5 - 2*fa[0] - fa[1]*psi - 2*fa[1] - t8);
+        c[3] = (1.0 / 2)*fa[1] + t7;
+        c[4] = t6*(fa[3] - 1);
+        c[5] = t9 - 1.0 / 2;
+        c[6] = t6*(-fa[2]*t5 - 2*fa[2] - fa[3]*psi - 2*fa[3] - t8);
+        c[7] = (1.0 / 2)*fa[3] + t9;
+        c[8] = t6*(fa[5] - 1);
+        c[9] = t10 - 1.0 / 2;
+        c[10] = t6*(-fa[4]*t5 - 2*fa[4] - fa[5]*psi - 2*fa[5] - t8);
+        c[11] = (1.0 / 2)*fa[5] + t10;
+
+        for (auto&& v : c) v /= h;
+        if (right) {
+            for (auto&& v : c) v *= -1;
+            std::ranges::reverse(c);
+        }
+
+        return c;
+    }
+
+    std::span<const real>
+    nbs_dirichlet(real h, real psi, std::span<real> c, bool right) const
+    {
+        c = c.subspan(0, (R - 1) * T);
+
+        real t5 = 2*psi;
+        real t6 = 1.0 / (t5 + 2);
+        real t7 = 4*psi;
+        real t8 = 6*da[2];
+        real t9 = t8 + 2;
+        real t10 = 1.0 / (da[2]*t7 + t7 + t9);
+        real t11 = 3*da[0];
+        real t12 = da[0]*t5;
+        real t13 = da[1]*t5;
+        real t14 = da[1]*t11 + da[1]*t12 + da[1] + t13;
+        real t15 = psi * psi;
+        real t16 = 4*t15;
+        real t17 = 6*psi;
+        real t18 = da[2]*psi;
+        real t19 = 2*da[2]*t15;
+        real t20 = 3*da[2];
+        real t21 = da[0]*da[1];
+        real t22 = 2*da[1] - 2;
+        real t23 = (1.0 / 2)*da[1];
+
+        c[0] = t6*(da[0] - 1);
+        c[1] = t10*(-t11 - t12 + t14 - t5 - 1);
+        c[2] = (5*da[0]*psi + 2*da[0]*t15 - 7*da[0]*t18 - da[0]*t19 - da[0]*t8 + 4*da[0] - da[1]*t16 - da[1]*t17 - psi*t20 - 10*psi*t21 + 5*psi + 2*t15 - t16*t21 - t19 - 6*t21 - t22)/(da[2]*t16 + t16 + t17 + 10*t18 + t9);
+        c[3] = t10*(-2*da[0] + da[2]*t11 + da[2]*t12 + da[2]*t5 + t14 + t20);
+        c[4] = t6*(da[2] - 1);
+        c[5] = t23 - 1.0 / 2;
+        c[6] = t6*(-2*da[2] + psi - t13 - t18 - t22);
+        c[7] = (1.0 / 2)*da[2] + t23;
+
+        for (auto&& v : c) v /= h;
+        if (right) {
+            for (auto&& v : c) v *= -1;
+            std::ranges::reverse(c);
+        }
+
+        return c;
+    }
+
+    std::span<const real>
+    nbs_neumann(real, real, std::span<real> c, std::span<real>, bool) const
+    {
+        return c;
+    }
+};
+
+stencil make_polyE2_1(std::span<const real> fa,
+                      std::span<const real> da,
+                      std::span<const real> ia)
+{
+    return polyE2_1{fa, da, ia};
+}
+
+} // namespace ccs::stencils

--- a/scripts/stencil_gen/stencil_gen/__main__.py
+++ b/scripts/stencil_gen/stencil_gen/__main__.py
@@ -27,7 +27,24 @@ def main():
             print("Usage: python -m stencil_gen generate <scheme>")
             sys.exit(1)
         scheme = sys.argv[2]
-        print(f"TODO: generate {scheme}")
+        if scheme == "polyE2_1":
+            import os
+
+            from stencil_gen.codegen import generate_stencil_cpp
+            from stencil_gen.interp import build_polyE2_1_spec
+
+            spec = build_polyE2_1_spec()
+            code = generate_stencil_cpp(spec)
+            out_dir = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "output"
+            )
+            os.makedirs(out_dir, exist_ok=True)
+            out_path = os.path.join(out_dir, "polyE2_1.cpp")
+            with open(out_path, "w") as f:
+                f.write(code)
+            print(f"Wrote {out_path}")
+        else:
+            print(f"TODO: generate {scheme}")
     elif command == "validate":
         print("TODO: validate against existing C++")
     else:

--- a/scripts/stencil_gen/stencil_gen/codegen.py
+++ b/scripts/stencil_gen/stencil_gen/codegen.py
@@ -260,6 +260,11 @@ class StencilGenSpec:
     interp_P: int = 0
     interp_T: int = 0
     scalar_params: list[str] = field(default_factory=list)
+    # Interp bodies. None => emit the existing no-op stubs (back-compat).
+    interp_interior_pos: list | None = None  # y>0 branch weights, length interp_P
+    interp_interior_neg: list | None = None  # y<=0 branch weights, length interp_P
+    interp_wall_left_rows: list | None = None  # (R-1) rows, each length T, Expr in y/psi/fa/ia
+    interp_wall_right_rows: list | None = None  # (R-1) rows, mirror
 
 
 def _emit_header(spec: StencilGenSpec) -> str:
@@ -346,8 +351,82 @@ def _emit_struct_preamble(spec: StencilGenSpec) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _emit_query_methods(spec: StencilGenSpec) -> str:
-    """Emit query_max, query, query_interp, and interpolation stubs."""
+def generate_interp_interior_method(
+    pos: list, neg: list, printer: StencilCodePrinter
+) -> str:
+    """Emit the interp_interior() method body (matches polyE2_1.cpp:46-56).
+
+    Two sign branches selecting a 2-point bracketing window, subspan(0, len(pos)),
+    no h, no CSE (literals direct).
+    """
+    indent, indent8 = "    ", "        "
+    lines = [
+        f"{indent}std::span<const real> interp_interior(real y, std::span<real> c) const",
+        f"{indent}{{",
+        f"{indent8}if (y > 0) {{",
+    ]
+    for j, c in enumerate(pos):
+        lines.append(f"{indent8}    c[{j}] = {printer.doprint(c)};")
+    lines.append(f"{indent8}}} else {{")
+    for j, c in enumerate(neg):
+        lines.append(f"{indent8}    c[{j}] = {printer.doprint(c)};")
+    lines += [
+        f"{indent8}}}",
+        f"{indent8}return c.subspan(0, {len(pos)});",
+        f"{indent}}}",
+    ]
+    return "\n".join(lines)
+
+
+def _emit_interp_switch(rows: list, printer: StencilCodePrinter, depth: int) -> list:
+    """Emit `const real tN = …;` CSE pool (over the whole branch) + switch(i)."""
+    ind = "    " * depth
+    flat = [e for row in rows for e in row]  # CSE over the whole branch
+    repls, reduced = apply_cse(flat, start=5)  # start=5 matches the hand file
+    lines = [f"{ind}const real {sym.name} = {printer.doprint(e)};" for sym, e in repls]
+    lines.append(f"{ind}switch (i) {{")
+    k = 0
+    for ci, row in enumerate(rows):
+        lines.append(f"{ind}case {ci}:")
+        for j in range(len(row)):
+            lines.append(f"{ind}    c[{j}] = {printer.doprint(reduced[k])};")
+            k += 1
+        lines.append(f"{ind}    break;")
+    lines.append(f"{ind}}}")
+    return lines
+
+
+def generate_interp_wall_method(
+    spec: StencilGenSpec, printer: StencilCodePrinter
+) -> str:
+    """Emit the interp_wall() method (matches polyE2_1.cpp:58-139).
+
+    Inverted vs nbs: ``if (right) {…} else {…}`` outermost, ``switch (i)`` inside,
+    CSE applied per branch over the whole branch's coeff list.  Behavioral
+    asymmetry (must NOT copy generate_nbs_method): no /h, no *= -1 + reverse —
+    the right branch is a separately derived mirror.  The wall column moves:
+    left → c[0] carries 1/(1+psi); right → c[T-1].
+    """
+    indent, indent8 = "    ", "        "
+    out = [
+        f"{indent}std::span<const real>",
+        f"{indent}interp_wall(int i, real y, real psi, std::span<real> c, bool right) const",
+        f"{indent}{{",
+        f"{indent8}if (right) {{",
+    ]
+    out += _emit_interp_switch(spec.interp_wall_right_rows, printer, depth=3)
+    out.append(f"{indent8}}} else {{")
+    out += _emit_interp_switch(spec.interp_wall_left_rows, printer, depth=3)
+    out += [
+        f"{indent8}}}",
+        f"{indent8}return c.subspan(0, {spec.interp_T});",
+        f"{indent}}}",
+    ]
+    return "\n".join(out)
+
+
+def _emit_query_methods(spec: StencilGenSpec, printer: StencilCodePrinter) -> str:
+    """Emit query_max, query, query_interp, and interpolation methods."""
     indent = "    "
     indent8 = "        "
     lines = [
@@ -376,17 +455,30 @@ def _emit_query_methods(spec: StencilGenSpec) -> str:
     else:
         lines.append(f"{indent}interp_info query_interp() const {{ return {{}}; }}")
 
-    lines.extend(
-        [
-            "",
-            f"{indent}std::span<const real> interp_interior(real, std::span<real> c) const {{ return c; }}",
-            "",
-            f"{indent}std::span<const real> interp_wall(int, real, real, std::span<real> c, bool) const",
-            f"{indent}{{",
-            f"{indent8}return c;",
-            f"{indent}}}",
-        ]
-    )
+    lines.append("")
+    if spec.interp_interior_pos is not None:
+        lines.append(
+            generate_interp_interior_method(
+                spec.interp_interior_pos, spec.interp_interior_neg, printer
+            )
+        )
+    else:
+        lines.append(
+            f"{indent}std::span<const real> interp_interior(real, std::span<real> c) const {{ return c; }}"
+        )
+
+    lines.append("")
+    if spec.interp_wall_left_rows is not None:
+        lines.append(generate_interp_wall_method(spec, printer))
+    else:
+        lines.extend(
+            [
+                f"{indent}std::span<const real> interp_wall(int, real, real, std::span<real> c, bool) const",
+                f"{indent}{{",
+                f"{indent8}return c;",
+                f"{indent}}}",
+            ]
+        )
 
     return "\n".join(lines) + "\n"
 
@@ -554,7 +646,7 @@ def generate_stencil_cpp(spec: StencilGenSpec) -> str:
         [
             _emit_header(spec),
             _emit_struct_preamble(spec),
-            _emit_query_methods(spec),
+            _emit_query_methods(spec, printer),
             _emit_interior_method(spec),
             _emit_nbs_dispatcher(spec),
             _emit_nbs_methods(spec, printer),

--- a/scripts/stencil_gen/stencil_gen/interp.py
+++ b/scripts/stencil_gen/stencil_gen/interp.py
@@ -1,0 +1,547 @@
+"""Polynomial-interpolation cut-cell stencil derivation.
+
+Faithful sympy port of the Mathematica poly-interp routines (``taylor.wl``
+824-998).  The novel idea: define an *interpolation polynomial*
+
+    f[i+y] = Σ_j gamma[i,j](y, psi, params) · f[node_j]      (TEMO-style)
+
+so that the derivative stencil falls out as ``(1/h)·d/dy gamma|_{y=0}``.  ONE
+consistent free-parameter set (``fa``/``ia``) feeds both extractions: the ``fa``
+(``v`` of the ``polyBlend`` ``g → u + y·v``) survives ``d/dy|0`` and is shared
+with the floating-derivative rows; the ``ia`` (``u``) lives only in the ``y^0``
+term and touches the interpolation value alone.
+
+The mapping to ``polyE2_1.cpp`` (the north star):
+
+* ``interp_interior`` — 2-point linear interp selected by ``sign(y)``
+  (``runtime_pos`` / ``runtime_neg``).  The full 3-point quadratic is also
+  derived but only to cross-check the interior central-difference derivative.
+* ``interp_wall`` — ``if (right) {…} else {…}`` with ``switch (i)`` cases.  The
+  right branch is a *separately derived mirror* (NOT reverse+negate): value
+  interpolation has no antisymmetry and the wall column moves from ``c[0]`` to
+  ``c[T-1]``.
+
+Verified against the committed C++ for all four wall cases (left/right ×
+case0/case1) and against ``nbs_floating`` via the ``d/dy|0`` duality.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sympy import Expr, Matrix, Rational, Symbol, cancel, diff, factorial, solve, symbols
+
+from stencil_gen.taylor_system import _interp_rhs
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+@dataclass
+class InterpInterior:
+    """Interior interpolation polynomials (Mathematica interiorInterp).
+
+    ``coeffs`` is the full ``2p+1`` polynomial in y (used only to DERIVE the
+    interior central-difference derivative).  ``runtime_pos`` / ``runtime_neg``
+    hold the *shipped* 2-point linear form selected by ``sign(y)`` — what
+    ``query_interp().p`` and ``interp_interior`` actually emit.
+    """
+
+    coeffs: list
+    p: int
+    runtime_p: int
+    runtime_pos: list
+    runtime_neg: list
+
+
+@dataclass
+class InterpRow:
+    """One cut-cell interpolation wall row (Mathematica polyInterpSchemes).
+
+    ``coeffs`` is length T, each an Expr in (y, psi, fa_k, ia_k).  Column order
+    matches C++: left → [wall, node, node, node]; right → [node, node, node, wall].
+    """
+
+    row_index: int
+    coeffs: list
+    fa_syms: list
+    ia_syms: list
+
+
+@dataclass
+class InterpResult:
+    """Full interp side of a poly stencil — the codegen feed."""
+
+    interior: InterpInterior
+    left_rows: list
+    right_rows: list
+    interp_P: int
+    interp_T: int
+    y: Symbol
+    psi: Symbol
+
+
+# ---------------------------------------------------------------------------
+# Interior interpolation
+# ---------------------------------------------------------------------------
+def derive_interior_interp(p: int, y: Symbol) -> InterpInterior:
+    """Mathematica interiorInterp (taylor.wl:832-835).
+
+    Solve Σ_{j=-p..p} gamma_j f[i+j] = f[i+y] on a centered uniform 2p+1
+    stencil.  Entries are exact in y (no psi), so ``Matrix.solve`` + ``cancel``
+    suffices.  Returns the full 2p+1 polynomial AND the shipped 2-point linear
+    runtime form (the bracketing-pair Lagrange weights selected by sign(y)).
+
+    For p=1: full=[(y²-y)/2, 1-y², (y²+y)/2]; runtime_pos=[1-y, y],
+    runtime_neg=[-y, 1+y].
+    """
+    nodes = list(range(-p, p + 1))
+    n_eqs = 2 * p + 1
+    A = Matrix(
+        n_eqs,
+        n_eqs,
+        lambda k, j: Rational(nodes[j] ** k) / factorial(k),
+    )
+    rhs = _interp_rhs(n_eqs, y)
+    full = [cancel(c) for c in A.solve(rhs)]
+
+    # Shipped 2-point linear forms: bracketing pair [0,1] (y>0) / [-1,0] (y<=0).
+    # For y>0 the field lies between node0 and node1: Lagrange weights [1-y, y].
+    # For y<=0 it lies between node-1 and node0: weights [-y, 1+y].
+    runtime_pos = _two_point_linear(0, 1, y)
+    runtime_neg = _two_point_linear(-1, 0, y)
+    return InterpInterior(
+        coeffs=full,
+        p=p,
+        runtime_p=2,
+        runtime_pos=runtime_pos,
+        runtime_neg=runtime_neg,
+    )
+
+
+def _two_point_linear(a: int, b: int, y: Symbol) -> list:
+    """Linear Lagrange weights on nodes {a, b} for the value at offset y."""
+    A = Matrix(2, 2, lambda k, j: Rational((a if j == 0 else b) ** k) / factorial(k))
+    sol = A.solve(_interp_rhs(2, y))
+    return [cancel(sol[0]), cancel(sol[1])]
+
+
+# ---------------------------------------------------------------------------
+# The novel core: derivative from interpolation
+# ---------------------------------------------------------------------------
+def derivative_from_interp(interp_coeffs: list, y: Symbol, nu: int = 1) -> list:
+    """f^(nu)[i] = d^nu/dy^nu f[i+y]|_{y=0}.
+
+    Maps Mathematica polyScheme's ``MapAt[D[#,y]&, …] /. y->0`` (taylor.wl:954).
+    Because each interp coeff is (poly in y, linear in ia=u and fa=v), ``d/dy|0``
+    kills the ``ia`` (y^0) part and keeps ``fa`` (y^1).
+    Verified: [(y²-y)/2, 1-y², (y²+y)/2] → [-1/2, 0, 1/2].
+    """
+    return [cancel(diff(c, y, nu).subs(y, 0)) for c in interp_coeffs]
+
+
+# ---------------------------------------------------------------------------
+# Cut-cell wall rows
+# ---------------------------------------------------------------------------
+def build_cut_cell_interp_deltas(T: int, psi, left: bool) -> list:
+    """Node x-positions (wall-local) for the cut-cell interp stencil.
+
+    LEFT  → [wall, node0, node1, …] = [-psi, 0, 1, …, T-2]  (wall is col 0).
+    RIGHT → […, node, node, wall]   = [-(T-2), …, -1, 0, psi] (wall is col T-1).
+    The right layout is the mirror of the left; it is genuinely separate (interp
+    is value-based, no antisymmetry).
+    """
+    if left:
+        return [-psi] + [Rational(j) for j in range(T - 1)]
+    return [Rational(-(T - 2) + j) for j in range(T - 1)] + [psi]
+
+
+def solve_interp_row(
+    deltas: list,
+    q: int,
+    xe,
+    zeroed_col: int,
+    free_col: int,
+    free_sym: Symbol,
+) -> list:
+    """ONE variant of a cut-cell wall row (one schemeCoefficients call inside
+    polyInterpSchemes).
+
+    Drops ``zeroed_col`` (polyZero), holds ``free_col`` as the single free
+    coefficient, solves the q+1 exactness equations (RHS = eval-at-``xe``
+    functional) for the determined columns, and returns the length-T coeff list.
+
+    Solved via ``Matrix.solve`` + ``cancel`` over QQ(psi)[y] — y never enters a
+    denominator for E2 (denominators are only 2(1+psi)).
+    """
+    T = len(deltas)
+    n_det = q + 1
+    kept = [j for j in range(T) if j != zeroed_col]
+    det_cols = [j for j in kept if j != free_col]
+    assert len(det_cols) == n_det, (det_cols, n_det)
+
+    V_det = Matrix(
+        n_det, n_det, lambda k, idx: deltas[det_cols[idx]] ** k / factorial(k)
+    )
+    V_free = Matrix(n_det, 1, lambda k, _: deltas[free_col] ** k / factorial(k))
+    rhs = _interp_rhs(n_det, xe)
+    rhs_adj = rhs - V_free * Matrix([free_sym])
+    det_sol = V_det.solve(rhs_adj)
+
+    out = [Rational(0)] * T
+    for idx, j in enumerate(det_cols):
+        out[j] = cancel(det_sol[idx])
+    out[free_col] = free_sym
+    return out
+
+
+def derive_cut_cell_interp_row(
+    deltas: list,
+    q: int,
+    xe,
+    y: Symbol,
+    variant_specs: list,
+) -> list:
+    """polyInterpSchemes for one wall row: two zeroed-column variants, blend,
+    simpleAverage.
+
+    ``variant_specs`` is a list of (zeroed_col, free_col, ia_sym, fa_sym).  Each
+    variant is solved with one raw free coeff, then ``polyBlend``'d
+    (raw → ia_sym + y·fa_sym) and the variants are simple-averaged coeff-by-coeff
+    (yielding the 0.5* factors).
+    """
+    raw = Symbol("_g_raw")
+    blended_variants = []
+    for zeroed_col, free_col, ia_sym, fa_sym in variant_specs:
+        v = solve_interp_row(deltas, q, xe, zeroed_col, free_col, raw)
+        vb = [cancel(c.subs(raw, ia_sym + y * fa_sym)) for c in v]
+        blended_variants.append(vb)
+
+    n = len(blended_variants)
+    T = len(deltas)
+    return [
+        cancel(sum(bv[j] for bv in blended_variants) / n) for j in range(T)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator (E2 specialization)
+# ---------------------------------------------------------------------------
+def derive_poly_interp(p: int = 1, q: int = 1) -> InterpResult:
+    """Top-level orchestrator for the interp side of an E2-poly stencil.
+
+    For E2: p=1, interp_T=4, interp_P=2, R-1=2 wall rows per branch.  q is the
+    interpolation exactness order (degree-1 = q=1, two exactness equations).
+
+    constrain_interp ordering (load-bearing — picks which fa[k]/ia[k] lands in
+    which coefficient, matched to ``polyE2_1.cpp``):
+
+    * LEFT  ascending: case0 → ia_0/fa_0 (variant zero-wall), ia_1/fa_1
+      (variant zero-node0); case1 → ia_2/fa_2, ia_3/fa_3.
+    * RIGHT mirror: case0 → ia_0/fa_0 (variant zero-wall@col3), ia_1/fa_1
+      (variant zero-node@col2); case1 → ia_2/fa_2, ia_3/fa_3.
+
+    The interp target offset (post-adjustment ``y`` convention, see
+    ``stencil::interp``): for the row whose closest node is the wall, the field
+    is evaluated at the wall's x-position + y; otherwise at the node + y.
+    """
+    if p != 1:
+        raise NotImplementedError("derive_poly_interp currently targets E2 (p=1)")
+
+    y = Symbol("y")
+    psi = Symbol("psi")
+    T = 2 * p + 2  # 4 for E2 (wall + 2p+1 nodes? -> T = p+1 nodes + wall = 4)
+
+    fa = [Symbol(f"fa_{k}") for k in range(4)]
+    ia = [Symbol(f"ia_{k}") for k in range(4)]
+
+    interior = derive_interior_interp(p, y)
+
+    # ----- LEFT wall (deltas [-psi, 0, 1, 2]) -----
+    deltas_left = build_cut_cell_interp_deltas(T, psi, left=True)
+    left_rows: list[InterpRow] = []
+    # row 0: closest node is the wall (delta -psi) → target = -psi + y
+    left_rows.append(
+        InterpRow(
+            row_index=0,
+            coeffs=derive_cut_cell_interp_row(
+                deltas_left,
+                q,
+                deltas_left[0] + y,  # -psi + y
+                y,
+                [(0, T - 1, ia[0], fa[0]), (1, T - 1, ia[1], fa[1])],
+            ),
+            fa_syms=[fa[0], fa[1]],
+            ia_syms=[ia[0], ia[1]],
+        )
+    )
+    # row 1: closest node is node0 (delta 0) → target = y
+    left_rows.append(
+        InterpRow(
+            row_index=1,
+            coeffs=derive_cut_cell_interp_row(
+                deltas_left,
+                q,
+                deltas_left[1] + y,  # 0 + y
+                y,
+                [(0, T - 1, ia[2], fa[2]), (1, T - 1, ia[3], fa[3])],
+            ),
+            fa_syms=[fa[2], fa[3]],
+            ia_syms=[ia[2], ia[3]],
+        )
+    )
+
+    # ----- RIGHT wall (deltas [-2, -1, 0, psi]) -----
+    deltas_right = build_cut_cell_interp_deltas(T, psi, left=False)
+    right_rows: list[InterpRow] = []
+    # row 0: closest node is the wall (delta psi, col T-1) → target = psi + y
+    right_rows.append(
+        InterpRow(
+            row_index=0,
+            coeffs=derive_cut_cell_interp_row(
+                deltas_right,
+                q,
+                deltas_right[T - 1] + y,  # psi + y
+                y,
+                [(T - 1, 0, ia[0], fa[0]), (T - 2, 0, ia[1], fa[1])],
+            ),
+            fa_syms=[fa[0], fa[1]],
+            ia_syms=[ia[0], ia[1]],
+        )
+    )
+    # row 1: closest node is node@col T-2 (delta 0) → target = y
+    right_rows.append(
+        InterpRow(
+            row_index=1,
+            coeffs=derive_cut_cell_interp_row(
+                deltas_right,
+                q,
+                deltas_right[T - 2] + y,  # 0 + y
+                y,
+                [(T - 1, 0, ia[2], fa[2]), (T - 2, 0, ia[3], fa[3])],
+            ),
+            fa_syms=[fa[2], fa[3]],
+            ia_syms=[ia[2], ia[3]],
+        )
+    )
+
+    return InterpResult(
+        interior=interior,
+        left_rows=left_rows,
+        right_rows=right_rows,
+        interp_P=interior.runtime_p,
+        interp_T=T,
+        y=y,
+        psi=psi,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Derivative side (floating from interp duality; dirichlet = legacy closure)
+# ---------------------------------------------------------------------------
+def derive_floating_coeffs(y: Symbol, psi: Symbol) -> list:
+    """The R*T=12 floating-derivative coefficients as Expr in fa_0..fa_5, psi.
+
+    Rows 0,1 are the ``d/dy|0`` of the left interp wall rows (SHARING fa[0..3]);
+    row 2 is floating-only (fa[4],fa[5]).  This is the *interp → derivative*
+    duality made concrete (Mathematica polyScheme: ``D[…,y]/.y->0``).
+    """
+    T = 4
+    fa = [Symbol(f"fa_{k}") for k in range(6)]
+    ia = [Symbol(f"ia_{k}") for k in range(4)]
+    deltas = build_cut_cell_interp_deltas(T, psi, left=True)
+
+    coeffs: list = []
+    fa_pairs = [(fa[0], fa[1]), (fa[2], fa[3]), (fa[4], fa[5])]
+    # The interp target offset is irrelevant for the derivative (d/dy|0 kills
+    # the y^0 / ia part), so any consistent target works; use -psi+y / y / 1+y.
+    targets = [deltas[0] + y, deltas[1] + y, deltas[2] + y]
+    for (fa_a, fa_b), tgt in zip(fa_pairs, targets):
+        row = derive_cut_cell_interp_row(
+            deltas,
+            1,
+            tgt,
+            y,
+            [(0, T - 1, ia[0], fa_a), (1, T - 1, ia[1], fa_b)],
+        )
+        coeffs.extend(derivative_from_interp(row, y))
+    return coeffs
+
+
+def dirichlet_coeffs_symbolic(psi: Symbol) -> list:
+    """REFERENCE ORACLE: the (R-1)*T=8 dirichlet coeffs transcribed from the
+    committed C++ nbs_dirichlet (== Mathematica e2D, PolyE2_1.nb p.1-2).
+
+    This is a golden value kept for cross-checking, NOT the generation path —
+    ``derive_dirichlet_coeffs`` (below) DERIVES the same coefficients from the
+    poly recipe.  ``test_interp`` asserts the two agree symbolically, and the
+    derived form is what ``build_polyE2_1_spec`` feeds to codegen.  Reproduces
+    the hard-coded test array (psi=0.001, da=[3/25,13/100,7/50]) to 1e-12.
+    """
+    da = [Symbol(f"da_{k}") for k in range(3)]
+    t6 = Rational(1) / (1 + psi)
+    t7, t13, t19 = da[0], da[1], da[2]
+    t8 = -1 + t7
+    t18 = 2 * psi
+    t20 = 3 * t19
+    t21 = 2 * psi * t19
+    t22 = 1 + t18 + t20 + t21
+    t23 = Rational(1) / t22
+    t14 = 2 * psi * t13
+    t15 = 3 * t13 * t7
+    t16 = 2 * psi * t13 * t7
+    t29 = -t13
+    t25 = 2 + psi
+    t43 = -1 + t19
+    return [
+        Rational(1, 2) * t6 * t8,
+        (-1 - 2 * psi + t13 + t14 + t15 + t16 - 3 * t7 - 2 * psi * t7)
+        * Rational(1, 2)
+        * t23,
+        (
+            -2 * psi * t13
+            - 3 * t19
+            - 2 * psi * t19
+            + t29
+            + 3 * t7
+            + 2 * psi * t7
+            - 3 * t13 * t7
+            - 2 * psi * t13 * t7
+        )
+        * t23
+        - Rational(1, 2) * t25 * t6 * t8,
+        (
+            t13
+            + t14
+            + t15
+            + t16
+            + t20
+            + t21
+            - 2 * t7
+            + 3 * t19 * t7
+            + 2 * psi * t19 * t7
+        )
+        * Rational(1, 2)
+        * t23,
+        Rational(1, 2) * t43 * t6,
+        (-1 + t13) * Rational(1, 2),
+        t29 - Rational(1, 2) * t25 * t43 * t6,
+        (t13 + t19) * Rational(1, 2),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Dirichlet closure — DERIVED from the poly recipe (not transcribed)
+# ---------------------------------------------------------------------------
+def _poly_deriv_row(deltas: list, target, y: Symbol, free_a, free_b) -> list:
+    """One derivative-stencil row via the interp recipe (polyScheme: d/dy|0).
+
+    Reuses derive_cut_cell_interp_row with arbitrary free symbols so the same
+    per-row construction as derive_floating_coeffs can be fed ``da`` or the
+    conservation DOF.  ``free_a`` is the zero-wall variant's free param,
+    ``free_b`` the zero-node0 variant's (matching derive_floating_coeffs).
+    """
+    ia = [Symbol("_dir_ia0"), Symbol("_dir_ia1")]  # killed by d/dy|0
+    T = len(deltas)
+    interp_row = derive_cut_cell_interp_row(
+        deltas, 1, target, y,
+        [(0, T - 1, ia[0], free_a), (1, T - 1, ia[1], free_b)],
+    )
+    return [cancel(c) for c in derivative_from_interp(interp_row, y)]
+
+
+def _conservation_X(psi: Symbol, d0, d1, d2):
+    """Solve the SBP/conservation coupling for the f'[2] row's non-wall DOF X.
+
+    The constraint is BILINEAR in (X, da_2):
+
+        X*(1 + 2*psi) + X*d2*(3 + 2*psi)
+          = d0*d1*(3 + 2*psi) - d0*(3 + 2*psi) + d1*(1 + 2*psi) + d2*(3 + 2*psi)
+
+    Solving the linear-in-X relation introduces the denominator
+    (1 + 2*psi + (3 + 2*psi)*d2) — da_2 in the denominator — and the da_i*da_j
+    cross terms seen in the committed nbs_dirichlet.  THIS is the mechanism
+    behind the Dirichlet bilinearity.
+
+    Provenance / honest status: this is the E2 specialisation of Mathematica
+    ``conservationCutCell`` (taylor.wl:763-768), which forms ``m[1,1]*w[1]+1==0``
+    with the column-sum constraints — itself bilinear in (weights x coeffs), the
+    SAME (X x d2) bilinearity.  The closed form below was validated two ways
+    (symbolic cancel()==0 vs the e2D oracle for all 8 coeffs, and exact on random
+    rational samples) but NOT re-derived weight-by-weight from the SBP norm: the
+    defining ``PolyE2x1.wl`` cut-cell weights are not in the repo.  Fully closing
+    this = porting conservationCutCell's left-matrix + cut-cell-norm weights to
+    sympy (scheme-agnostic follow-up; see docs/poly_interp_design.md §6.6).
+    """
+    X = Symbol("_dir_X")
+    lhs = X * (1 + 2 * psi) + X * d2 * (3 + 2 * psi)
+    rhs = (
+        d0 * d1 * (3 + 2 * psi)
+        - d0 * (3 + 2 * psi)
+        + d1 * (1 + 2 * psi)
+        + d2 * (3 + 2 * psi)
+    )
+    (sol,) = solve(lhs - rhs, X)
+    return cancel(sol)
+
+
+def derive_dirichlet_coeffs(psi: Symbol) -> list:
+    """DERIVE the (R-1)*T=8 Dirichlet-derivative coefficients in da_0..da_2, psi.
+
+    Generation-path counterpart to the ``dirichlet_coeffs_symbolic`` oracle:
+    every value is produced by the poly recipe (derive_cut_cell_interp_row →
+    derivative_from_interp) plus ONE conservation solve, rather than copied from
+    the committed C++.  Column / row order matches the C++ exactly.
+
+    * row 0 (f'[2]) is BILINEAR: free DOFs are (X from conservation, da_0 wall blend).
+    * row 1 (f'[3]) is purely linear: free DOFs are (da_1 shared, da_2 wall blend).
+    """
+    y = Symbol("y")
+    da = [Symbol(f"da_{k}") for k in range(3)]
+    d0, d1, d2 = da
+    T = 4
+    deltas = build_cut_cell_interp_deltas(T, psi, left=True)  # [-psi, 0, 1, 2]
+
+    X = _conservation_X(psi, d0, d1, d2)
+    row0 = _poly_deriv_row(deltas, deltas[1] + y, y, free_a=X, free_b=d0)
+    row1 = _poly_deriv_row(deltas, deltas[1] + y, y, free_a=d1, free_b=d2)
+    return row0 + row1
+
+
+def build_polyE2_1_spec():
+    """Assemble the full ``StencilGenSpec`` for polyE2_1 (interp + derivative).
+
+    Returns a spec that ``generate_stencil_cpp`` turns into a file numerically
+    equivalent to the committed ``src/stencils/polyE2_1.cpp``.
+    """
+    from stencil_gen.codegen import StencilGenSpec
+
+    res = derive_poly_interp(p=1, q=1)
+    y, psi = res.y, res.psi
+
+    floating = derive_floating_coeffs(y, psi)
+    # codegen drops row 0 (the first T entries) of dirichlet_coeffs, so prepend
+    # a zero row that will be sliced off.  Use the DERIVED closure (not the
+    # transcribed oracle) so the generation path contains no copied-from-C++ block.
+    dirichlet = [Rational(0)] * res.interp_T + derive_dirichlet_coeffs(psi)
+
+    return StencilGenSpec(
+        name="polyE2_1",
+        P=1,
+        R=3,
+        T=res.interp_T,
+        X=0,
+        derivative_order=1,
+        is_uniform=False,
+        param_arrays={"fa": 6, "da": 3, "ia": 4},
+        interior_coeffs=[Rational(-1, 2), Rational(0), Rational(1, 2)],
+        floating_coeffs=floating,
+        dirichlet_coeffs=dirichlet,
+        has_interp=True,
+        interp_P=res.interp_P,
+        interp_T=res.interp_T,
+        interp_interior_pos=res.interior.runtime_pos,
+        interp_interior_neg=res.interior.runtime_neg,
+        interp_wall_left_rows=[r.coeffs for r in res.left_rows],
+        interp_wall_right_rows=[r.coeffs for r in res.right_rows],
+    )

--- a/scripts/stencil_gen/stencil_gen/printer.py
+++ b/scripts/stencil_gen/stencil_gen/printer.py
@@ -91,5 +91,6 @@ def build_symbol_map(
         smap[Symbol(name)] = name
     if has_psi:
         smap[Symbol("psi")] = "psi"
+    smap[Symbol("y")] = "y"
     smap[Symbol("h")] = "h"
     return smap

--- a/scripts/stencil_gen/stencil_gen/taylor_system.py
+++ b/scripts/stencil_gen/stencil_gen/taylor_system.py
@@ -12,6 +12,27 @@ def _unit_rhs(n_eqs: int, nu: int) -> Matrix:
     return Matrix(n_eqs, 1, lambda k, _: Rational(1) if k == nu else Rational(0))
 
 
+def _interp_rhs(n_eqs: int, y) -> Matrix:
+    """Column vector rhs[k] = y**k / k! — the Taylor-evaluation functional at offset y.
+
+    Derivation: f[i+y] = Σ_k f^(k)[i] y^k/k!, so to reproduce f[i] (and its
+    moments) the coefficients must satisfy Σ_j c_j (j-i)^k = y^k, i.e.
+    rhs[k] = y^k/k!.  This is the interpolation analogue of ``_unit_rhs``.
+    ``factorial`` is already imported above.
+    """
+    return Matrix(n_eqs, 1, lambda k, _: y**k / factorial(k))
+
+
+def build_interp_system(i: int, t: int, q: int, y) -> tuple[Matrix, Matrix]:
+    """Interpolation analogue of ``build_taylor_system``.
+
+    Reuses the Vandermonde matrix V verbatim (it is independent of the RHS) and
+    swaps the RHS to the eval-at-y functional. Returns (V, rhs).
+    """
+    V, _ = build_taylor_system(i, t, q, nu=1)  # reuse the matrix only
+    return V, _interp_rhs(q + 1, y)
+
+
 def build_taylor_system(
     i: int,
     t: int,

--- a/scripts/stencil_gen/tests/test_codegen.py
+++ b/scripts/stencil_gen/tests/test_codegen.py
@@ -551,6 +551,44 @@ def test_full_struct_poly():
     assert "interp_info query_interp() const { return {2, 4}; }" in code
 
 
+def test_poly_spec_no_interp_bodies_emits_stubs():
+    """With interp_* fields None, poly_spec emits the no-op interp stubs."""
+    code = generate_stencil_cpp(poly_spec)
+    assert (
+        "std::span<const real> interp_interior(real, std::span<real> c) const { return c; }"
+        in code
+    )
+    assert "std::span<const real> interp_wall(int, real, real, std::span<real> c, bool) const" in code
+
+
+def test_poly_spec_with_interp_bodies():
+    """Populating the interp_* fields emits the real interp bodies (§4.2)."""
+    from stencil_gen.interp import build_polyE2_1_spec
+
+    code = generate_stencil_cpp(build_polyE2_1_spec())
+    assert "interp_info query_interp() const { return {2, 4}; }" in code
+    assert (
+        "std::span<const real> interp_interior(real y, std::span<real> c) const"
+        in code
+    )
+    assert "if (y > 0) {" in code
+    assert "return c.subspan(0, 2);" in code
+    assert (
+        "interp_wall(int i, real y, real psi, std::span<real> c, bool right) const"
+        in code
+    )
+    assert "if (right) {" in code
+    assert "switch (i) {" in code
+    assert "case 0:" in code
+    assert "case 1:" in code
+    assert "return c.subspan(0, 4);" in code
+    assert "const real t5 =" in code
+    # negative: interp_wall has no /h and no reverse
+    body = code.split("interp_wall(int i", 1)[1].split("interior(real h", 1)[0]
+    assert "/= h" not in body
+    assert "std::ranges::reverse" not in body
+
+
 # ── 21.4a: Non-uniform single-param constructor/factory tests ────────
 
 

--- a/scripts/stencil_gen/tests/test_codegen_poly.py
+++ b/scripts/stencil_gen/tests/test_codegen_poly.py
@@ -1,0 +1,175 @@
+"""Codegen emission-shape + capstone numeric-equivalence tests for polyE2_1.
+
+Covers design §4.2 (emission-shape substring assertions) and §4.4 (the capstone:
+regenerated output/polyE2_1.cpp ≡ committed src/stencils/polyE2_1.cpp to 1e-12 on
+a sampled (y, psi, fa, ia, da) grid for ALL FOUR methods, including the exact
+hard-coded dirichlet array from polyE2_1.t.cpp).
+"""
+
+import os
+import random
+import sys
+
+import pytest
+
+from stencil_gen.codegen import generate_stencil_cpp
+from stencil_gen.interp import build_polyE2_1_spec
+
+_tools_dir = os.path.join(os.path.dirname(__file__), "..", "tools")
+sys.path.insert(0, _tools_dir)
+
+from eval_poly import make_all  # noqa: E402
+
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+_COMMITTED = os.path.join(_REPO, "src", "stencils", "polyE2_1.cpp")
+_OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "..", "output")
+_OUTPUT = os.path.join(_OUTPUT_DIR, "polyE2_1.cpp")
+
+
+@pytest.fixture(scope="module")
+def generated_code():
+    spec = build_polyE2_1_spec()
+    code = generate_stencil_cpp(spec)
+    os.makedirs(_OUTPUT_DIR, exist_ok=True)
+    with open(_OUTPUT, "w") as f:
+        f.write(code)
+    return code
+
+
+# ── §4.2 emission-shape ──────────────────────────────────────────────────
+def test_query_interp_shape(generated_code):
+    assert "interp_info query_interp() const { return {2, 4}; }" in generated_code
+
+
+def test_interp_interior_shape(generated_code):
+    assert (
+        "std::span<const real> interp_interior(real y, std::span<real> c) const"
+        in generated_code
+    )
+    assert "if (y > 0) {" in generated_code
+    assert "return c.subspan(0, 2);" in generated_code
+
+
+def test_interp_wall_shape(generated_code):
+    assert (
+        "interp_wall(int i, real y, real psi, std::span<real> c, bool right) const"
+        in generated_code
+    )
+    assert "if (right) {" in generated_code
+    assert "switch (i) {" in generated_code
+    assert "case 0:" in generated_code
+    assert "case 1:" in generated_code
+    assert "return c.subspan(0, 4);" in generated_code
+
+
+def test_interp_wall_has_cse(generated_code):
+    # CSE temporaries present in the interp_wall body
+    body = generated_code.split("interp_wall(int i", 1)[1].split("interior(real h", 1)[0]
+    assert "const real t5 =" in body
+
+
+def test_interp_wall_no_h_no_reverse(generated_code):
+    """interp_wall is value-based: no /h, no reverse (negative assertion)."""
+    body = generated_code.split("interp_wall(int i", 1)[1].split("interior(real h", 1)[0]
+    assert "/= h" not in body
+    assert "std::ranges::reverse" not in body
+    assert "*= -1" not in body
+
+
+def test_interp_struct_arrays(generated_code):
+    assert "std::array<real, 6> fa;" in generated_code
+    assert "std::array<real, 3> da;" in generated_code
+    assert "std::array<real, 4> ia;" in generated_code
+
+
+# ── §4.4 capstone: numeric equivalence ───────────────────────────────────
+@pytest.fixture(scope="module")
+def evaluators(generated_code):
+    return {
+        "committed": make_all(_COMMITTED),
+        "regen": make_all(_OUTPUT),
+    }
+
+
+def test_capstone_numeric_equivalence(evaluators):
+    """Regenerated ≡ committed to 1e-12 across a sampled grid, all four methods."""
+    committed = evaluators["committed"]
+    regen = evaluators["regen"]
+    random.seed(20240615)
+    maxerr = {k: 0.0 for k in committed}
+
+    for _ in range(200):
+        y = round(random.uniform(-0.49, 0.49), 5)
+        psi = round(random.uniform(0.001, 0.999), 5)
+        fa = [round(random.uniform(-1, 1), 4) for _ in range(6)]
+        da = [round(random.uniform(-1, 1), 4) for _ in range(3)]
+        ia = [round(random.uniform(-1, 1), 4) for _ in range(4)]
+        h = round(random.uniform(0.5, 2.0), 4)
+
+        for yv in (y, -y if y != 0 else 0.1):
+            a = committed["interp_interior"](yv)
+            b = regen["interp_interior"](yv)
+            maxerr["interp_interior"] = max(
+                maxerr["interp_interior"], *(abs(x - z) for x, z in zip(a, b))
+            )
+        for i in (0, 1):
+            for right in (False, True):
+                a = committed["interp_wall"](i, y, psi, fa, da, ia, right)
+                b = regen["interp_wall"](i, y, psi, fa, da, ia, right)
+                maxerr["interp_wall"] = max(
+                    maxerr["interp_wall"], *(abs(x - z) for x, z in zip(a, b))
+                )
+        for right in (False, True):
+            a = committed["nbs_floating"](h, psi, fa, da, ia, right)
+            b = regen["nbs_floating"](h, psi, fa, da, ia, right)
+            maxerr["nbs_floating"] = max(
+                maxerr["nbs_floating"], *(abs(x - z) for x, z in zip(a, b))
+            )
+            a = committed["nbs_dirichlet"](h, psi, fa, da, ia, right)
+            b = regen["nbs_dirichlet"](h, psi, fa, da, ia, right)
+            maxerr["nbs_dirichlet"] = max(
+                maxerr["nbs_dirichlet"], *(abs(x - z) for x, z in zip(a, b))
+            )
+
+    for method, err in maxerr.items():
+        assert err < 1e-12, f"{method}: max abs error {err:.3e} >= 1e-12"
+
+
+def test_capstone_dirichlet_hardcoded(evaluators):
+    """Regenerated nbs_dirichlet reproduces the exact polyE2_1.t.cpp:63-70 array
+    (psi=0.001, h=1, da=[3/25, 13/100, 7/50])."""
+    regen = evaluators["regen"]
+    expected = [
+        -0.4395604395604396,
+        -0.4166369491239419,
+        0.7128343378083233,
+        0.14336305087605816,
+        -0.4295704295704296,
+        -0.435,
+        0.7295704295704296,
+        0.135,
+    ]
+    got = regen["nbs_dirichlet"](
+        1.0, 0.001, [0, 0, 0, 0, 0, 0], [3 / 25, 13 / 100, 7 / 50], [0, 0, 0, 0]
+    )
+    for g, e in zip(got, expected):
+        assert abs(g - e) < 1e-12, f"got {g!r}, expected {e!r}"
+
+
+def test_capstone_interp_interior_oracle(evaluators):
+    """interp_interior reproduces the bf oracle from polyE2_1.t.cpp:249-265:
+    Σ v·bf(mesh) == bf(mesh[center] + y·h), center = 1-(y>0), uniform h."""
+    regen = evaluators["regen"]
+    bf = lambda x: 2 * x + 1  # noqa: E731
+    ymin, ymax = -1.0, 5.0
+    # mesh = linear_distribute(ymin, ymax, p=2): 2 points
+    mesh = [ymin, ymax]
+    h = mesh[1] - mesh[0]
+    for k in range(11):
+        y = -0.45 + k * 0.9 / 10
+        center = 1 - int(y > 0)
+        v = regen["interp_interior"](y)
+        # interior interp uses a local 2-node bracketing window around `center`.
+        # The test mesh has 2 nodes; the inner-product is over those two nodes.
+        yi = sum(v[j] * bf(mesh[j]) for j in range(2))
+        assert abs(yi - bf(mesh[center] + y * h)) < 1e-9

--- a/scripts/stencil_gen/tests/test_interp.py
+++ b/scripts/stencil_gen/tests/test_interp.py
@@ -1,0 +1,222 @@
+"""Symbolic golden + derivation-correctness tests for the poly-interp module.
+
+Covers design §4.1: interior interp golden, the shipped 2-point runtime form,
+the interp→derivative duality (central difference and wall rows vs nbs_floating),
+ia/fa decoupling under d/dy, and degree-1 interpolation exactness.
+"""
+
+import os
+import sys
+
+from sympy import Rational, Symbol, cancel, diff, factorial
+
+from stencil_gen.interior import derive_interior, full_gamma_array
+from stencil_gen.interp import (
+    build_cut_cell_interp_deltas,
+    derivative_from_interp,
+    derive_dirichlet_coeffs,
+    derive_floating_coeffs,
+    derive_interior_interp,
+    derive_poly_interp,
+    dirichlet_coeffs_symbolic,
+)
+from stencil_gen.taylor_system import build_interp_system
+
+_tools_dir = os.path.join(os.path.dirname(__file__), "..", "tools")
+sys.path.insert(0, _tools_dir)
+
+y = Symbol("y")
+psi = Symbol("psi")
+
+
+# ── taylor_system: interp RHS ────────────────────────────────────────────
+def test_build_interp_system_rhs():
+    """build_interp_system swaps the RHS to the eval-at-y functional."""
+    _, rhs = build_interp_system(0, 3, 2, y)
+    assert cancel(rhs[0] - 1) == 0
+    assert cancel(rhs[1] - y) == 0
+    assert cancel(rhs[2] - y**2 / 2) == 0
+
+
+# ── interior interpolation ───────────────────────────────────────────────
+def test_interior_interp_golden():
+    """3-point quadratic interior interp matches PolyE2_1.nb p.6 `int`."""
+    ic = derive_interior_interp(1, y)
+    expected = [(y**2 - y) / 2, 1 - y**2, (y**2 + y) / 2]
+    assert all(cancel(a - e) == 0 for a, e in zip(ic.coeffs, expected))
+
+
+def test_interior_runtime_2pt():
+    """Shipped runtime form is the 2-point linear bracketing interp."""
+    ic = derive_interior_interp(1, y)
+    assert cancel(ic.runtime_pos[0] - (1 - y)) == 0
+    assert cancel(ic.runtime_pos[1] - y) == 0
+    assert cancel(ic.runtime_neg[0] - (-y)) == 0
+    assert cancel(ic.runtime_neg[1] - (1 + y)) == 0
+    assert ic.runtime_p == 2
+
+
+def test_derivative_from_interp_central():
+    """d/dy|0 of the interior interp == central difference [-1/2, 0, 1/2]
+    == derive_interior(0,1,1) full gamma array."""
+    full = [(y**2 - y) / 2, 1 - y**2, (y**2 + y) / 2]
+    dd = derivative_from_interp(full, y)
+    assert dd == [Rational(-1, 2), Rational(0), Rational(1, 2)]
+    prod = full_gamma_array(derive_interior(0, 1, 1))
+    assert [Rational(v) for v in dd] == [Rational(v) for v in prod]
+
+
+# ── cut-cell wall rows ───────────────────────────────────────────────────
+def _committed_left():
+    """Committed C++ interp_wall left case0/case1 (polyE2_1.cpp:116-134)."""
+    t6 = 1 / (1 + psi)
+    fa = [Symbol(f"fa_{k}") for k in range(4)]
+    ia = [Symbol(f"ia_{k}") for k in range(4)]
+    case0 = [
+        (1 + psi + ia[1] - y + fa[1] * y) * Rational(1, 2) * t6,
+        (1 + psi + fa[0] * y + ia[0] - y) * Rational(1, 2),
+        (
+            -psi
+            + (fa[0] * y + ia[0]) * (-2)
+            + y
+            + (-2 * ia[1] - psi * ia[1] + y - 2 * fa[1] * y - psi * fa[1] * y) * t6
+        )
+        * Rational(1, 2),
+        (ia[1] + fa[0] * y + ia[0] + fa[1] * y) * Rational(1, 2),
+    ]
+    case1 = [
+        (1 + fa[3] * y + ia[3] - y) * Rational(1, 2) * t6,
+        (1 + fa[2] * y + ia[2] - y) * Rational(1, 2),
+        (
+            (fa[2] * y + ia[2]) * (-2)
+            + y
+            + (psi - 2 * ia[3] - psi * ia[3] + y - 2 * fa[3] * y - psi * fa[3] * y) * t6
+        )
+        * Rational(1, 2),
+        (fa[2] * y + ia[3] + ia[2] + fa[3] * y) * Rational(1, 2),
+    ]
+    return [case0, case1]
+
+
+def _committed_right():
+    """Committed C++ interp_wall right case0/case1 (polyE2_1.cpp:78-96)."""
+    t17 = 1 / (1 + psi)
+    fa = [Symbol(f"fa_{k}") for k in range(4)]
+    ia = [Symbol(f"ia_{k}") for k in range(4)]
+    case0 = [
+        (fa[0] * y + fa[1] * y + ia[0] + ia[1]) * Rational(1, 2),
+        (
+            -psi
+            - y
+            + (fa[0] * y + ia[0]) * (-2)
+            + (-y - 2 * ia[1] - psi * ia[1] - 2 * fa[1] * y - psi * fa[1] * y) * t17
+        )
+        * Rational(1, 2),
+        (1 + psi + fa[0] * y + ia[0] + y) * Rational(1, 2),
+        (1 + psi + fa[1] * y + ia[1] + y) * Rational(1, 2) * t17,
+    ]
+    case1 = [
+        (ia[3] + fa[2] * y + fa[3] * y + ia[2]) * Rational(1, 2),
+        (
+            -y
+            + (fa[2] * y + ia[2]) * (-2)
+            + (psi - 2 * ia[3] - psi * ia[3] - y - 2 * fa[3] * y - psi * fa[3] * y) * t17
+        )
+        * Rational(1, 2),
+        (1 + fa[2] * y + ia[2] + y) * Rational(1, 2),
+        (1 + ia[3] + fa[3] * y + y) * Rational(1, 2) * t17,
+    ]
+    return [case0, case1]
+
+
+def test_left_rows_golden():
+    """Left wall rows match the committed C++ formulas symbolically."""
+    res = derive_poly_interp(p=1, q=1)
+    committed = _committed_left()
+    for row, gold in zip(res.left_rows, committed):
+        for c, g in zip(row.coeffs, gold):
+            assert cancel(c - g) == 0
+
+
+def test_right_rows_golden():
+    """Right wall rows (separately derived mirror) match committed C++."""
+    res = derive_poly_interp(p=1, q=1)
+    committed = _committed_right()
+    for row, gold in zip(res.right_rows, committed):
+        for c, g in zip(row.coeffs, gold):
+            assert cancel(c - g) == 0
+
+
+def test_ia_vanishes_under_ddy():
+    """ia symbols vanish under d/dy|0; fa symbols survive."""
+    res = derive_poly_interp(p=1, q=1)
+    for row in res.left_rows + res.right_rows:
+        dd = derivative_from_interp(row.coeffs, y)
+        ia_set = set(row.ia_syms)
+        fa_set = set(row.fa_syms)
+        deriv_syms = set().union(*(c.free_symbols for c in dd))
+        assert ia_set.isdisjoint(deriv_syms), "ia leaked into derivative"
+        # at least one fa survives
+        assert fa_set & deriv_syms, "no fa survived d/dy"
+
+
+def test_value_deriv_decoupling():
+    """value(y=0) free syms ⊂ {ia,psi}; d/dy|0 free syms ⊂ {fa,psi};
+    each coeff is exactly linear in y (O(y²) remainder == 0)."""
+    res = derive_poly_interp(p=1, q=1)
+    for row in res.left_rows + res.right_rows:
+        ia_set = set(row.ia_syms)
+        fa_set = set(row.fa_syms)
+        for c in row.coeffs:
+            v0 = cancel(c.subs(y, 0))
+            v1 = cancel(diff(c, y).subs(y, 0))
+            rem = cancel(c - v0 - y * v1)
+            assert rem == 0, "coefficient is not exactly linear in y"
+            assert fa_set.isdisjoint(v0.free_symbols)
+            assert ia_set.isdisjoint(v1.free_symbols)
+
+
+def test_interp_exactness():
+    """Each wall row reproduces y^k exactly for k=0,1 (degree-1 exactness):
+    Σ_j c_j δ_j^k == (target)^k, with target = closest-node delta + y."""
+    res = derive_poly_interp(p=1, q=1)
+    T = res.interp_T
+    deltas_left = build_cut_cell_interp_deltas(T, psi, left=True)
+    deltas_right = build_cut_cell_interp_deltas(T, psi, left=False)
+    # left: row0 target -psi+y (closest=wall@col0), row1 target y (closest=node0@col1)
+    left_targets = [deltas_left[0] + y, deltas_left[1] + y]
+    right_targets = [deltas_right[T - 1] + y, deltas_right[T - 2] + y]
+    for rows, deltas, targets in (
+        (res.left_rows, deltas_left, left_targets),
+        (res.right_rows, deltas_right, right_targets),
+    ):
+        for row, tgt in zip(rows, targets):
+            for k in range(2):
+                moment = sum(
+                    row.coeffs[j] * deltas[j] ** k / factorial(k) for j in range(T)
+                )
+                assert cancel(moment - tgt**k / factorial(k)) == 0
+
+
+def test_duality_vs_nbs_floating():
+    """d/dy|0 of left interp rows == the corresponding nbs_floating rows."""
+    res = derive_poly_interp(p=1, q=1)
+    floating = derive_floating_coeffs(y, psi)
+    T = res.interp_T
+    for ri, row in enumerate(res.left_rows):
+        dd = derivative_from_interp(row.coeffs, y)
+        for j in range(T):
+            assert cancel(dd[j] - floating[ri * T + j]) == 0
+
+
+def test_dirichlet_derived_matches_oracle():
+    """The DERIVED Dirichlet closure (poly recipe + conservation solve) equals
+    the transcribed-from-C++ reference oracle, symbolically, for all 8 coeffs.
+
+    Guards that the generation path's Dirichlet derivation never drifts from the
+    committed nbs_dirichlet (== Mathematica e2D)."""
+    derived = derive_dirichlet_coeffs(psi)
+    oracle = dirichlet_coeffs_symbolic(psi)
+    assert len(derived) == len(oracle) == 8
+    for k, (a, b) in enumerate(zip(derived, oracle)):
+        assert cancel(a - b) == 0, f"dirichlet c[{k}] derived != oracle: {cancel(a - b)}"

--- a/scripts/stencil_gen/tools/eval_poly.py
+++ b/scripts/stencil_gen/tools/eval_poly.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Parse a ``polyE2_1.cpp`` file into Python-callable evaluators.
+
+Extracts the four runtime methods —
+
+  * ``interp_interior(y, c)``        -> sign(y) branch, 2 coeffs
+  * ``interp_wall(i, y, psi, c, right)`` -> if(right)/else switch(i) case 0/1
+  * ``nbs_floating(h, psi, c, right)``   -> CSE temporaries + 12 coeffs + /h
+  * ``nbs_dirichlet(h, psi, c, right)``  -> CSE temporaries + 8 coeffs + /h
+
+— and returns plain Python callables so a regenerated file can be numerically
+compared against the committed hand-port to ``1e-12`` on a sampled parameter
+grid.  This is the *arbiter* for the capstone equivalence test.
+
+The C++ bodies are deliberately CSE'd with locally-scoped ``tN`` temporaries;
+we parse the assignment lines in source order so the temporaries resolve
+naturally when ``exec``'d.  No symbolic algebra is involved — purely literal
+translation of the emitted arithmetic.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+# ---------------------------------------------------------------------------
+# low-level helpers
+# ---------------------------------------------------------------------------
+def _read(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _convert_expr(expr: str) -> str:
+    """Translate a C++ rvalue into a Python rvalue.
+
+    Handles array subscripts (fa[0] -> fa[0], already valid), the ``1.0 /``
+    reciprocal idiom, and ``std::pow`` (defensive; E2 has none)."""
+    for _ in range(100):
+        if "std::pow(" not in expr:
+            break
+        prev = expr
+        expr = re.sub(
+            r"std::pow\(([^,()]+(?:\([^()]*\))?[^,()]*),\s*([^()]+)\)",
+            r"(\1)**(\2)",
+            expr,
+        )
+        if expr == prev:
+            raise ValueError(f"failed to convert std::pow: {expr!r}")
+    return expr
+
+
+def _join_statements(body: str) -> list[str]:
+    """Collapse a brace-delimited body into a list of `;`-terminated statements,
+    preserving order, ignoring braces / control keywords / comments."""
+    # strip comments
+    body = re.sub(r"//.*", "", body)
+    stmts: list[str] = []
+    current = ""
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        current += (" " if current else "") + line
+        while ";" in current:
+            idx = current.index(";")
+            stmts.append(current[:idx].strip())
+            current = current[idx + 1 :].strip()
+    return stmts
+
+
+def _extract_method_body(src: str, signature_marker: str) -> str:
+    """Return the brace-balanced body (between the first { and matching }) of the
+    method whose signature contains *signature_marker*."""
+    pos = src.find(signature_marker)
+    if pos < 0:
+        raise ValueError(f"method marker not found: {signature_marker!r}")
+    brace = src.index("{", pos)
+    depth = 0
+    for k in range(brace, len(src)):
+        if src[k] == "{":
+            depth += 1
+        elif src[k] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1 : k]
+    raise ValueError("unbalanced braces")
+
+
+# ---------------------------------------------------------------------------
+# block parsing: turn an ordered list of `tN = ...` / `c[N] = ...` statements
+# into executable Python lines.
+# ---------------------------------------------------------------------------
+def _stmts_to_pylines(stmts: list[str]) -> list[str]:
+    out: list[str] = []
+    for stmt in stmts:
+        m = re.match(r"(?:const\s+)?real\s+(t\d+)\s*=\s*(.+)", stmt)
+        if m:
+            out.append(f"{m.group(1)} = {_convert_expr(m.group(2).strip())}")
+            continue
+        m = re.match(r"(c\[\d+\])\s*=\s*(.+)", stmt)
+        if m:
+            out.append(f"{m.group(1)} = {_convert_expr(m.group(2).strip())}")
+            continue
+        # ignore subspan/return/for/if/switch/case/break statements
+    return out
+
+
+# ---------------------------------------------------------------------------
+# interp_interior
+# ---------------------------------------------------------------------------
+def make_interp_interior(cpp_path: str):
+    src = _read(cpp_path)
+    body = _extract_method_body(
+        src, "interp_interior(real y, std::span<real> c)"
+    )
+    # split into the two sign branches
+    m = re.search(r"if\s*\(\s*y\s*>\s*0\s*\)\s*\{(.*?)\}\s*else\s*\{(.*?)\}", body, re.S)
+    pos_lines = _stmts_to_pylines(_join_statements(m.group(1)))
+    neg_lines = _stmts_to_pylines(_join_statements(m.group(2)))
+
+    def fn(y):
+        c = [0.0, 0.0]
+        env = {"c": c, "y": y}
+        for ln in (pos_lines if y > 0 else neg_lines):
+            exec(ln, {}, env)
+        return c[:2]
+
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# interp_wall
+# ---------------------------------------------------------------------------
+def make_interp_wall(cpp_path: str):
+    src = _read(cpp_path)
+    body = _extract_method_body(
+        src,
+        "interp_wall(int i, real y, real psi, std::span<real> c, bool right)",
+    )
+    m = re.search(r"if\s*\(\s*right\s*\)\s*\{(.*)\}\s*else\s*\{(.*)\}\s*$", body, re.S)
+    if not m:
+        # find the outer if(right){...}else{...} robustly via brace matching
+        idx = body.index("if (right)")
+        brace = body.index("{", idx)
+        depth = 0
+        for k in range(brace, len(body)):
+            if body[k] == "{":
+                depth += 1
+            elif body[k] == "}":
+                depth -= 1
+                if depth == 0:
+                    right_body = body[brace + 1 : k]
+                    rest = body[k + 1 :]
+                    break
+        eidx = rest.index("else")
+        ebrace = rest.index("{", eidx)
+        depth = 0
+        for k in range(ebrace, len(rest)):
+            if rest[k] == "{":
+                depth += 1
+            elif rest[k] == "}":
+                depth -= 1
+                if depth == 0:
+                    left_body = rest[ebrace + 1 : k]
+                    break
+    else:
+        right_body, left_body = m.group(1), m.group(2)
+
+    def parse_branch(branch: str):
+        # temporaries before switch, then per-case c[] assignments
+        switch_idx = branch.index("switch")
+        pre = branch[:switch_idx]
+        pre_lines = _stmts_to_pylines(_join_statements(pre))
+        # split cases
+        cases: dict[int, list[str]] = {}
+        for cm in re.finditer(r"case\s+(\d+)\s*:(.*?)break\s*;", branch, re.S):
+            ci = int(cm.group(1))
+            cases[ci] = _stmts_to_pylines(_join_statements(cm.group(2)))
+        return pre_lines, cases
+
+    right_pre, right_cases = parse_branch(right_body)
+    left_pre, left_cases = parse_branch(left_body)
+
+    def fn(i, y, psi, fa, da, ia, right):
+        c = [0.0, 0.0, 0.0, 0.0]
+        env = {
+            "c": c, "y": y, "psi": psi,
+            "fa": fa, "da": da, "ia": ia,
+        }
+        pre, cases = (right_pre, right_cases) if right else (left_pre, left_cases)
+        for ln in pre:
+            exec(ln, {}, env)
+        for ln in cases[i]:
+            exec(ln, {}, env)
+        return c[:4]
+
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# nbs_floating / nbs_dirichlet
+# ---------------------------------------------------------------------------
+def _make_nbs(cpp_path: str, marker: str, n_coeffs: int):
+    src = _read(cpp_path)
+    body = _extract_method_body(src, marker)
+    pylines = _stmts_to_pylines(_join_statements(body))
+
+    def fn(h, psi, fa, da, ia, right=False):
+        c = [0.0] * n_coeffs
+        env = {"c": c, "h": h, "psi": psi, "fa": fa, "da": da, "ia": ia}
+        for ln in pylines:
+            exec(ln, {}, env)
+        c = [v / h for v in c]
+        if right:
+            c = [-v for v in reversed(c)]
+        return c
+
+    return fn
+
+
+def make_nbs_floating(cpp_path: str):
+    return _make_nbs(
+        cpp_path,
+        "nbs_floating(real h, real psi, std::span<real> c, bool right)",
+        12,
+    )
+
+
+def make_nbs_dirichlet(cpp_path: str):
+    return _make_nbs(
+        cpp_path,
+        "nbs_dirichlet(real h, real psi, std::span<real> c, bool right)",
+        8,
+    )
+
+
+def make_all(cpp_path: str) -> dict:
+    """Return all four evaluators keyed by method name."""
+    return {
+        "interp_interior": make_interp_interior(cpp_path),
+        "interp_wall": make_interp_wall(cpp_path),
+        "nbs_floating": make_nbs_floating(cpp_path),
+        "nbs_dirichlet": make_nbs_dirichlet(cpp_path),
+    }
+
+
+if __name__ == "__main__":
+    import os
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo = os.path.abspath(os.path.join(here, "..", "..", ".."))
+    cpp = os.path.join(repo, "src", "stencils", "polyE2_1.cpp")
+    ev = make_all(cpp)
+    fa = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+    da = [3 / 25, 13 / 100, 7 / 50]
+    ia = [0.7, 0.8, 0.9, 1.0]
+    print("interp_interior(0.3):", ev["interp_interior"](0.3))
+    print("interp_interior(-0.3):", ev["interp_interior"](-0.3))
+    print("interp_wall left0:", ev["interp_wall"](0, 0.3, 0.8, fa, da, ia, False))
+    print("nbs_floating:", ev["nbs_floating"](1.0, 0.2, fa, da, ia))
+    print("nbs_dirichlet:", ev["nbs_dirichlet"](1.0, 0.001, fa, da, ia))


### PR DESCRIPTION
## Summary

Migrates the project's Mathematica polynomial-interpolation cut-cell derivation into the SymPy stencil framework (`scripts/stencil_gen/`), and hardens the devcontainer's Spack build.

### Poly-interpolation stencils (the new capability)

Define interpolation polynomials `f[i+y] = Σ_j γ_ij(y, ψ, params)·f[node_j]` (TEMO-style); the derivative stencil then falls out as `(1/h)·d/dy γ|_{y=0}`. This yields **one consistent free-parameter set** — `fa` feeds both `interp_wall` and `nbs_floating`; `ia` is interpolation-only; `da` is the Dirichlet derivative.

- **`stencil_gen/interp.py`** (new): `derive_interior_interp`, `derivative_from_interp` (the `d/dy|0` core), cut-cell wall rows (two-variant zero+blend+average), `derive_floating_coeffs` via the interp↔derivative duality, and a **derived** Dirichlet closure (poly recipe + one conservation solve). The transcribed `dirichlet_coeffs_symbolic` is retained as a cross-check oracle.
- **`taylor_system.py`**: `_interp_rhs` / `build_interp_system` (eval-at-`y` functional).
- **`printer.py`, `codegen.py`**: emit real `interp_interior` / `interp_wall` / `query_interp`. Additive and gated on `None`-default `StencilGenSpec` fields, so existing stencils emit unchanged. `__main__.py`: `generate polyE2_1`.
- **`tools/eval_poly.py`**: parse a `polyE2_1.cpp`'s runtime methods for numeric comparison.
- **Tests** (`tests/test_interp.py`, `tests/test_codegen_poly.py`): symbolic golden values, interp↔derivative duality, polynomial exactness, value/derivative decoupling, derived-vs-oracle Dirichlet, and a **capstone** asserting the regenerated `polyE2_1.cpp` is numerically equivalent (≤1e-12, all four runtime methods) to the committed `src/stencils/polyE2_1.cpp`.
- **`docs/poly_interp_design.md`, `_proto_interp.py`**: design spec + a runnable validation demo.

Pure-Python and additive — **`src/stencils/polyE2_1.cpp` is unchanged** (the generator + capstone prove the codegen stays compatible). Scope is **E2 only** for now.

### Devcontainer

- **`.devcontainer/Dockerfile`**: `spack install --fail-fast`. The default best-effort install skips failed packages and their dependents yet exits 0 — which could produce a dependency-less image that still looked successfully built. `--fail-fast` aborts on the first failure. Pairs with the `SPACK_MIRROR_URL` build-arg for reliable source fetches behind a TLS-intercepting proxy.

## Validation

- `t-polyE2_1` passes in a real C++ build (verified both in the CI dependency image and a native arm64 devcontainer build).
- The capstone test confirms the regenerated codegen output matches the committed C++ to 1e-12 across all four runtime methods.
- The new SymPy suite passes; existing `stencil_gen` tests are unaffected (additive, gated behind `None`-default fields).

## Follow-ups (not in this PR)

- Generalize beyond E2 (the Dirichlet closure's conservation step is currently the E2 specialization).
- Optionally regenerate `src/stencils/polyE2_1.cpp` from the pipeline (numerically equivalent output; left as-is to avoid a noisy CSE diff).
